### PR TITLE
Update dependencies to allow rusk to compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,31 +11,11 @@ tracing = "0.1"
 tracing-subscriber = "0.1"
 clap = "2.33"
 prost = "0.6"
-rusk-vm = { git = "https://github.com/dusk-network/rusk-vm" }
-phoenix-abi = { git = "https://github.com/dusk-network/phoenix-abi" }
+rusk-vm = { git = "https://github.com/dusk-network/rusk-vm", rev ="9c318e"}
 kelvin = "0.12"
 kelvin-radix = "0.8"
-
 hex = "^0.4"
-
-dataview = { git = "https://github.com/dusk-network/dataview.git" }
-
-[dependencies.phoenix]
-git = "https://github.com/dusk-network/phoenix"
-
+# phoenix_core needs to be added
 [build-dependencies]
 tonic-build = { version = "0.1", default-features = false, features = ["transport"] }
 
-# This is a temporary fix until we stop to use zexe; it's needed to replace
-# in the dependency graph the library below with the revision specified.
-# Unfortunately `patch` works matching just the URL - doesn't take in account
-# revision or branches, see:  https://github.com/rust-lang/cargo/issues/5478
-#
-# A quick workaround is changing the URL with double slashes
-[patch.'https://github.com/scipr-lab/zexe/']
-algebra = { git = 'https://github.com/scipr-lab//zexe', rev="2c22b77" }
-ff-fft = { git = "https://github.com/scipr-lab//zexe", rev="2c22b77" }
-bench-utils = { git = "https://github.com/scipr-lab//zexe", rev="2c22b77" }
-
-[patch.'https://github.com/scipr-lab/poly-commit']
-poly-commit = { git = "https://github.com/scipr-lab//poly-commit", rev="77676213"}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use phoenix::{
+/*use phoenix::{
     rpc::{self, rusk_client::RuskClient, PublicKey},
     SecretKey,
 };
@@ -42,4 +42,4 @@ pub async fn validate_state_transition(
 
 pub async fn client() -> Result<RuskClient<Channel>, Error> {
     Ok(RuskClient::connect("http://127.0.0.1:8080").await?)
-}
+}*/

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod server;
 
 use tonic::transport::Server;
 
-use phoenix::{rpc::rusk_server::RuskServer, utils, zk};
+//use phoenix::{rpc::rusk_server::RuskServer, utils, zk};
 use server::Rusk;
 
 #[tokio::main]
@@ -14,16 +14,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     db_path.push("phoenix-db");
     std::env::set_var("PHOENIX_DB", db_path.into_os_string());
 
-    // Mandatory Phoenix setup
-    utils::init();
-    zk::init();
-
-    let addr = "127.0.0.1:8080".parse().unwrap();
-    println!("listening on {}...", addr);
-    Server::builder()
-        .add_service(RuskServer::new(Rusk::default()))
-        .serve(addr)
-        .await?;
-
+    //let addr = "127.0.0.1:8080".parse().unwrap();
+    //println!("listening on {}...", addr);
+    /* Server::builder()
+            .add_service(RuskServer::new(Rusk::default()))
+            .serve(addr)
+            .await?;
+    */
     Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,26 +1,26 @@
-use dataview::Pod;
+//use dataview::Pod;
 use kelvin::{Blake2b, Root};
-use phoenix::{
+/*use phoenix::{
     db, db::DbNotesIterator, rpc, utils, Error, Note, NoteGenerator,
     NoteVariant, ObfuscatedNote, PublicKey, SecretKey, Transaction,
     TransactionInput, TransactionItem, TransparentNote, ViewKey,
-};
-use phoenix_abi::{Input as ABIInput, Note as ABINote, Proof as ABIProof};
+};*/
+//use phoenix_abi::{Input as ABIInput, Note as ABINote, Proof as ABIProof};
 use rusk_vm::dusk_abi::H256;
 use rusk_vm::{Contract, GasMeter, NetworkState, Schedule, StandardABI};
 use std::convert::{TryFrom, TryInto};
 use std::fs;
 use std::path::Path;
 use tracing::trace;
-
+/*
 fn error_to_tonic(e: Error) -> tonic::Status {
     e.into()
 }
-
+*/
 pub struct Rusk {
     transfer_id: H256,
 }
-
+/*
 // Transfer Contract's `transfer` method
 //
 // For genesis contracts atm we will have this signature
@@ -404,7 +404,6 @@ impl rpc::rusk_server::Rusk for Rusk {
         _request: tonic::Request<rpc::BidTransactionRequest>,
     ) -> Result<tonic::Response<rpc::BidTransaction>, tonic::Status> {
         trace!("Incoming new bid request");
-        unimplemented!()
     }
 
     // TODO: implement
@@ -500,3 +499,4 @@ impl rpc::rusk_server::Rusk for Rusk {
 #[cfg(test)]
 #[path = "./test_contract_transfer.rs"]
 mod test_contract_transfer;
+*/

--- a/src/test_contract_transfer.rs
+++ b/src/test_contract_transfer.rs
@@ -1,4 +1,4 @@
-use super::*;
+/*use super::*;
 use crate::client;
 use phoenix::{
   db, rpc::rusk_server::RuskServer, utils, zk, PublicKey, SecretKey,
@@ -67,3 +67,4 @@ async fn test_transfer() {
   ))
   .unwrap();
 }
+*/


### PR DESCRIPTION
We need a way to allow rusk to compile in order to be able to start working on the top of it in respect of the blindbid + phoenix-core circuit-related functions that need to be defined there.

The solution might not be the most elegant one, but there's no other way to allow the compilation than basically coment out almost everything since all was depending on phoenix and it is going to be replaced.

As soon as @ZER0 is avaliable, we should start refactoring the commented code to make it work.