### PR TITLE
Define modular structure for rusk contracts.

### DIFF
--- a/contracts/bid/Cargo.toml
+++ b/contracts/bid/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "bid"
+version = "0.1.0"
+authors = ["CPerezz <c.perezbaro@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/contracts/bid/circuits/Cargo.toml
+++ b/contracts/bid/circuits/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "bid-circuits"
+version = "0.1.0"
+authors = ["CPerezz <c.perezbaro@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/contracts/bid/circuits/rustfmt.toml
+++ b/contracts/bid/circuits/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/contracts/bid/circuits/src/lib.rs
+++ b/contracts/bid/circuits/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/contracts/bid/rustfmt.toml
+++ b/contracts/bid/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/contracts/bid/src/lib.rs
+++ b/contracts/bid/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/contracts/transfer/circuits/Cargo.toml
+++ b/contracts/transfer/circuits/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "transfer-circuits"
+version = "0.1.0"
+authors = ["CPerezz <c.perezbaro@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/contracts/transfer/circuits/rustfmt.toml
+++ b/contracts/transfer/circuits/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/contracts/transfer/circuits/src/lib.rs
+++ b/contracts/transfer/circuits/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
As stated in #73 it would be nice to define better the structure
of the contracts in respect to services.

On this way we have sub-crates for both, circuits and contracts
for each service that rusk contains/works with.

All of this sub-crates derive from a root folder located in the
root of the git repo which is called `contracts/`.

Closes #73