### PR TITLE
Fix copyright headers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,7 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
 
 /// Buildfile for the rusk crate.

--- a/contracts/bid/circuits/src/lib.rs
+++ b/contracts/bid/circuits/src/lib.rs
@@ -1,4 +1,7 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
 
 #[cfg(test)]

--- a/contracts/bid/src/lib.rs
+++ b/contracts/bid/src/lib.rs
@@ -1,4 +1,7 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
 
 #[cfg(test)]

--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -1,4 +1,7 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
 
 #![no_std]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,9 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
+
 #[cfg(not(target_os = "windows"))]
 mod unix;
 mod version;

--- a/src/bin/unix.rs
+++ b/src/bin/unix.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
+
 #![cfg(not(target_os = "windows"))]
 use std::{
     pin::Pin,

--- a/src/bin/version.rs
+++ b/src/bin/version.rs
@@ -1,4 +1,7 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
 
 //! Helper functions to get the proper version of the crate to be

--- a/src/lib/encoding.rs
+++ b/src/lib/encoding.rs
@@ -1,4 +1,7 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
 
 use super::services::rusk_proto;

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,4 +1,7 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
 
 pub mod encoding;

--- a/src/lib/services.rs
+++ b/src/lib/services.rs
@@ -1,4 +1,7 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
 
 pub mod echoer;

--- a/src/lib/services/echoer.rs
+++ b/src/lib/services/echoer.rs
@@ -1,4 +1,7 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
 
 //! Echo service implementation for the Rusk server.

--- a/src/lib/services/pki.rs
+++ b/src/lib/services/pki.rs
@@ -1,4 +1,7 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
 //! Public Key infrastructure service implementation for the Rusk server.
 

--- a/src/lib/services/pki/keygen.rs
+++ b/src/lib/services/pki/keygen.rs
@@ -1,4 +1,7 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
 
 //! Public Key Infrastructure service implementation for the Rusk server.

--- a/src/lib/services/pki/stealth_gen.rs
+++ b/src/lib/services/pki/stealth_gen.rs
@@ -1,4 +1,7 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
 
 //! Public Key Infrastructure service implementation for the Rusk server.

--- a/tests/echo_service_tests.rs
+++ b/tests/echo_service_tests.rs
@@ -1,5 +1,9 @@
-// Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
+
 #[cfg(not(target_os = "windows"))]
 mod unix;
 use futures::stream::TryStreamExt;

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
+
 #![cfg(not(target_os = "windows"))]
 use std::{
     pin::Pin,


### PR DESCRIPTION
They were of the wrong format, and have been
changed to the format used by cargo-dusk-analyzer.

Fixes #97