### PR TITLE
Add BlindBidCircuit compilation to build.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,16 @@ path = "src/bin/main.rs"
 [dependencies]
 tonic = "0.3"
 tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
-poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.6.4"}
-dusk-plonk = "0.2.9"
+poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.8.0"}
+dusk-plonk = "0.2.11"
+dusk-blindbid = {git = "https://github.com/dusk-network/dusk-blindbid", tag = "v0.1.0"}
 dusk-pki = {git = "https://github.com/dusk-network/dusk-pki/", tag = "v0.1.1"}
 tracing = "0.1"
 tracing-subscriber = "0.2"
 clap = "2.33.3"
 prost = "0.6"
-kelvin = "0.18"
-kelvin-radix = "0.10"
+kelvin = "0.19.0"
+kelvin-radix = "0.11.0"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 thiserror = "1.0"
 anyhow = "1.0"
@@ -35,5 +36,12 @@ rand = "0.7.0"
 [build-dependencies]
 tonic-build = "0.3"
 rustc_tools_util = "0.2"
-
-
+dusk-plonk = "0.2.11"
+dusk-blindbid = {git = "https://github.com/dusk-network/dusk-blindbid", tag = "v0.1.0"}
+anyhow = "1.0"
+poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.8.0"}
+dusk-pki = {git = "https://github.com/dusk-network/dusk-pki/", tag = "v0.1.1"}
+kelvin = "0.19.0"
+nstack = "0.5.0"
+rand = "0.7"
+bincode = "1.3.1"

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,24 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
+// Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
+use anyhow::Result;
+use dusk_blindbid::{bid::Bid, BlindBidCircuit};
+use dusk_pki::{PublicSpendKey, SecretSpendKey};
+use dusk_plonk::jubjub::{AffinePoint, GENERATOR_EXTENDED};
+use dusk_plonk::prelude::*;
+use kelvin::Blake2b;
+use poseidon252::PoseidonTree;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::PathBuf;
+
+/// CRS path.
+const PUB_PARAMS_FILE: &'static str = "pub_params_dev.bin";
+/// BlindBid Circuit ProverKey path.
+const BLINDBID_CIRCUIT_PK_PATH: &'static str = "blindbid_circ.pk";
+/// BlindBid Circuit VerifierKey path.
+const BLINDBID_CIRCUIT_VK_PATH: &'static str = "blindbid_circ.vk";
 
 /// Buildfile for the rusk crate.
 ///
@@ -10,7 +28,7 @@
 /// 1. Compile the `.proto` files for tonic.
 /// 2. Get the version of the crate and some extra info to
 /// support the `-v` argument properly.
-
+/// 3. Compile the blindbid circuit.
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Compile protos for tonic.
     tonic_build::compile_protos("schema/rusk.proto")?;
@@ -27,5 +45,104 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "cargo:rustc-env=RUSTC_RELEASE_CHANNEL={}",
         rustc_tools_util::get_channel().unwrap_or_default()
     );
+
+    // Compile BlindBid Circuit if it hasn't been already.
+    match (
+        PathBuf::from(BLINDBID_CIRCUIT_PK_PATH).exists(),
+        PathBuf::from(BLINDBID_CIRCUIT_VK_PATH).exists(),
+    ) {
+        (true, true) => (),
+        (_, _) => blindbid::compile_blindbid_circuit()?,
+    };
     Ok(())
+}
+
+/// Read PublicParameters from the binary file they're stored on.
+fn read_pub_params() -> Result<PublicParameters> {
+    let mut pub_params_file = File::open(PUB_PARAMS_FILE)?;
+    let mut buff = vec![];
+    pub_params_file.read_to_end(&mut buff)?;
+    let result: PublicParameters = bincode::deserialize(&buff)?;
+    Ok(result)
+}
+
+mod blindbid {
+    use super::*;
+
+    pub fn compile_blindbid_circuit() -> Result<()> {
+        let pub_params = read_pub_params()?;
+        // Generate a PoseidonTree and append the Bid.
+        let mut tree: PoseidonTree<Bid, Blake2b> = PoseidonTree::new(17usize);
+        // Generate a correct Bid
+        let secret = JubJubScalar::random(&mut rand::thread_rng());
+        let secret_k = BlsScalar::random(&mut rand::thread_rng());
+        let bid = random_bid(&secret, secret_k)?;
+        let secret: AffinePoint = (GENERATOR_EXTENDED * &secret).into();
+        // Generate fields for the Bid & required by the compute_score
+        let consensus_round_seed = BlsScalar::from(50u64);
+        let latest_consensus_round = BlsScalar::from(50u64);
+        let latest_consensus_step = BlsScalar::from(50u64);
+
+        // Append the StorageBid as an StorageScalar to the tree.
+        tree.push(bid)?;
+
+        // Extract the branch
+        let branch = tree
+            .poseidon_branch(0u64)?
+            .expect("Poseidon Branch Extraction");
+
+        // Generate a `Score` for our Bid with the consensus parameters
+        let score = bid.compute_score(
+            &secret,
+            secret_k,
+            branch.root,
+            consensus_round_seed,
+            latest_consensus_round,
+            latest_consensus_step,
+        )?;
+
+        let mut circuit = BlindBidCircuit {
+            bid: Some(bid),
+            score: Some(score),
+            secret_k: Some(secret_k),
+            secret: Some(secret),
+            seed: Some(consensus_round_seed),
+            latest_consensus_round: Some(latest_consensus_round),
+            latest_consensus_step: Some(latest_consensus_step),
+            branch: Some(&branch),
+            size: 0,
+            pi_constructor: None,
+        };
+        let (pk, vk, _) = circuit.compile(&pub_params)?;
+        let mut pk_file = File::create(BLINDBID_CIRCUIT_PK_PATH)?;
+        pk_file.write(&pk.to_bytes())?;
+
+        let mut vk_file = File::create(BLINDBID_CIRCUIT_VK_PATH)?;
+        vk_file.write(&vk.to_bytes())?;
+
+        Ok(())
+    }
+
+    fn random_bid(secret: &JubJubScalar, secret_k: BlsScalar) -> Result<Bid> {
+        let mut rng = rand::thread_rng();
+        let pk_r = PublicSpendKey::from(SecretSpendKey::default());
+        let stealth_addr = pk_r.gen_stealth_address(&secret);
+        let secret = GENERATOR_EXTENDED * secret;
+        let value = 60_000u64;
+        let value = JubJubScalar::from(value);
+        // Set the timestamps as the max values so the proofs do not fail for them
+        // (never expired or non-elegible).
+        let elegibility_ts = -BlsScalar::from(90u64);
+        let expiration_ts = -BlsScalar::from(90u64);
+
+        Bid::new(
+            &mut rng,
+            &stealth_addr,
+            &value,
+            &secret.into(),
+            secret_k,
+            elegibility_ts,
+            expiration_ts,
+        )
+    }
 }

--- a/contracts/bid/circuits/src/correctness.rs
+++ b/contracts/bid/circuits/src/correctness.rs
@@ -105,13 +105,13 @@ impl Circuit<'_> for CorrectnessCircuit {
         // Setup PublicParams
         let (ck, _) = pub_params.trim(1 << 10)?;
         // Generate & save `ProverKey` with some random values.
-        let mut prover = Prover::new(b"TestCircuit");
+        let mut prover = Prover::new(b"BidCorrectness");
         // Set size & PI builder
         self.pi_constructor = Some(self.gadget(prover.mut_cs())?);
         prover.preprocess(&ck)?;
 
         // Generate & save `VerifierKey` with some random values.
-        let mut verifier = Verifier::new(b"TestCircuit");
+        let mut verifier = Verifier::new(b"BidCorrectness");
         self.gadget(verifier.mut_cs())?;
         verifier.preprocess(&ck)?;
         Ok((


### PR DESCRIPTION
We need to pre-compile the blindbid_circuit in order
to have quick access to preprocessed `ProverKey` and
`VerifierKey`.

That will allow us to elaborate proofs and verify them
without preprocessing.

Closes #94

## NOTE
It took 19min to compile `build.rs` and run the Circuit compilation in `release` mode. Idk why TBH because it should take arround a minute aprox considering that it uses the same code that is used inside of the `dusk-blindbid` lib. I'm not sure why this happens since passing `--release` to the `cargo build` command should run that in less than 2 mins aprox in a normal machine.
Do you know which can be the issue guys?