### PR TITLE
Compile bid correctness proof circuit in build time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ kelvin = "0.19.0"
 nstack = "0.5.0"
 rand = "0.7"
 bincode = "1.3.1"
+bid-circuits = {path ="contracts/bid/circuits"}

--- a/contracts/bid/circuits/Cargo.toml
+++ b/contracts/bid/circuits/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bid-circuits"
 version = "0.1.0"
-authors = ["CPerezz <c.perezbaro@gmail.com>"]
+authors = ["Jules de Smit <jules@dusk.network>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
We need to pre-compile the bid correctness_circuit in order to have quick access to preprocessed `ProverKey` and
`VerifierKey`.

That will allow us to elaborate proofs and verify them without preprocessing.

Closes #103