### PR TITLE
Optimize & Speed Up Pub Params usage/read

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rustc_tools_util = "0.2"
 tower = "0.3"
 rand = "0.7.0"
 bincode = "1.3.1"
+lazy_static = "1.4"
 
 [build-dependencies]
 tonic-build = "0.3"

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -4,15 +4,38 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use tracing::info;
+
 pub(crate) mod circuit_helpers;
 pub mod encoding;
 pub mod services;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Rusk {}
+
+impl Default for Rusk {
+    fn default() -> Rusk {
+        // Initialize the PUB_PARAMS since they're lazily
+        // evaluated. On that way we prevent the first usage
+        // of the PUB_PARAMS to take a lot of time.
+        info!("Loading CRS...");
+        lazy_static::initialize(&PUB_PARAMS);
+        info!("CRS was successfully loaded...");
+        Rusk {}
+    }
+}
 
 pub mod proto_types {
     pub use super::services::rusk_proto::{
         BlsScalar, JubJubCompressed, JubJubScalar, Proof,
+    };
+}
+
+use dusk_plonk::prelude::PublicParameters;
+use lazy_static::lazy_static;
+lazy_static! {
+    static ref PUB_PARAMS: PublicParameters = {
+        circuit_helpers::read_pub_params()
+            .expect("Error reading Public Params.")
     };
 }

--- a/src/lib/services/blindbid/score_gen_handler.rs
+++ b/src/lib/services/blindbid/score_gen_handler.rs
@@ -14,7 +14,7 @@ use dusk_blindbid::BlindBidCircuit;
 use dusk_plonk::jubjub::AffinePoint as JubJubAffine;
 use dusk_plonk::prelude::*;
 use tonic::{Code, Request, Response, Status};
-use tracing::info;
+
 /// Implementation of the ScoreGeneration Handler.
 pub struct ScoreGenHandler<'a> {
     request: &'a Request<GenerateScoreRequest>,
@@ -80,10 +80,8 @@ where
             size: 0,
             pi_constructor: None,
         };
-        info!("Starting to compute a proof");
         let proof = gen_blindbid_proof(&mut circuit)
             .map_err(|e| Status::new(Code::Unknown, format!("{}", e)))?;
-        info!("Finished with computing the proof");
         Ok(Response::new(GenerateScoreResponse {
             blindbid_proof: encode_request_param(&proof),
             score: encode_request_param(score.score),
@@ -109,10 +107,8 @@ fn parse_score_gen_params(
 // Generate a blindbid proof given a circuit instance loaded with the
 // desired inputs.verifier_key
 fn gen_blindbid_proof(circuit: &mut BlindBidCircuit) -> Result<Proof> {
-    // Read PublicParameters
-    let pub_params = read_pub_params()?;
     // Read ProverKey of the circuit.
     let prover_key = read_blindcid_circuit_pk()?;
     // Generate a proof using the circuit
-    circuit.gen_proof(&pub_params, &prover_key, b"BlindBid")
+    circuit.gen_proof(&crate::PUB_PARAMS, &prover_key, b"BlindBid")
 }

--- a/src/lib/services/blindbid/verify_score_handler.rs
+++ b/src/lib/services/blindbid/verify_score_handler.rs
@@ -15,7 +15,7 @@ use dusk_blindbid::BlindBidCircuit;
 use dusk_plonk::jubjub::AffinePoint as JubJubAffine;
 use dusk_plonk::prelude::*;
 use tonic::{Request, Response, Status};
-use tracing::warn;
+
 /// Implementation of the VerifyScore Handler.
 pub struct VerifyScoreHandler<'a> {
     request: &'a Request<VerifyScoreRequest>,
@@ -72,10 +72,7 @@ where
                 score,
             ) {
                 Ok(_) => true,
-                Err(e) => {
-                    warn!("{:?}", e);
-                    false
-                }
+                Err(_) => false,
             },
         }))
     }
@@ -105,8 +102,6 @@ fn verify_blindbid_proof(
     prover_id: BlsScalar,
     score: BlsScalar,
 ) -> Result<()> {
-    // Read PublicParameters
-    let pub_params = read_pub_params()?;
     // Read VerifierKey of the circuit.
     let verifier_key = read_blindcid_circuit_vk()?;
     // Build PI array (safe to unwrap since we just created the circuit
@@ -133,5 +128,11 @@ fn verify_blindbid_proof(
         PublicInput::BlsScalar(-score, 0),
     ];
     // Verify the proof.
-    circuit.verify_proof(&pub_params, &verifier_key, b"BlindBid", proof, &pi)
+    circuit.verify_proof(
+        &crate::PUB_PARAMS,
+        &verifier_key,
+        b"BlindBid",
+        proof,
+        &pi,
+    )
 }


### PR DESCRIPTION
We were previously reading the public parameters from disk
on every call that arrived requiering a proff generation/verification.
It was unoptimal to work on that way since due to the ammount
of checks that are needed to guarantee that the Public Parameters
are correct is massive, it takes like 2min to obtain an instance
of the Public Parameters.

So we've moved the Pub Params read to a lazy_static block which is
executed in the `default` fn call to the Rusk instance that you execute.
This forces to read the pub params just at the time where you
instanciate the Rusk server and therefore no RPC method gets delayed
by this fact.

Closes #112