### PR TITLE
Update bid_circuits & blindbid circuits aligned to the new Circuit trait

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -80,6 +80,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         true => (),
         _ => default_proof::write_default_proof()?,
     };
+
     Ok(())
 }
 
@@ -105,14 +106,14 @@ mod bid {
         );
 
         let mut circuit = CorrectnessCircuit {
-            commitment: Some(c),
-            value: Some(value.into()),
-            blinder: Some(blinder.into()),
-            size: 0,
-            pi_constructor: None,
+            commitment: c,
+            value: value.into(),
+            blinder: blinder.into(),
+            trim_size: 1 << 10,
+            pi_positions: vec![],
         };
 
-        let (pk, vk, _) = circuit.compile(&pub_params)?;
+        let (pk, vk) = circuit.compile(&pub_params)?;
         let mut pk_file = File::create(BID_CORRECTNESS_CIRCUIT_PK_PATH)?;
         pk_file.write(&pk.to_bytes())?;
 
@@ -152,25 +153,25 @@ mod blindbid {
         let score = bid.compute_score(
             &secret,
             secret_k,
-            branch.root,
+            branch.root(),
             consensus_round_seed,
             latest_consensus_round,
             latest_consensus_step,
         )?;
 
         let mut circuit = BlindBidCircuit {
-            bid: Some(bid),
-            score: Some(score),
-            secret_k: Some(secret_k),
-            secret: Some(secret),
-            seed: Some(consensus_round_seed),
-            latest_consensus_round: Some(latest_consensus_round),
-            latest_consensus_step: Some(latest_consensus_step),
-            branch: Some(&branch),
-            size: 0,
-            pi_constructor: None,
+            bid: bid,
+            score: score,
+            secret_k: secret_k,
+            secret: secret,
+            seed: consensus_round_seed,
+            latest_consensus_round: latest_consensus_round,
+            latest_consensus_step: latest_consensus_step,
+            branch: &branch,
+            trim_size: 1 << 15,
+            pi_positions: vec![],
         };
-        let (pk, vk, _) = circuit.compile(&pub_params)?;
+        let (pk, vk) = circuit.compile(&pub_params)?;
         let mut pk_file = File::create(BLINDBID_CIRCUIT_PK_PATH)?;
         pk_file.write(&pk.to_bytes())?;
 

--- a/contracts/bid/circuits/Cargo.toml
+++ b/contracts/bid/circuits/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "^1.0.0"
-dusk-plonk = {version = "0.2.11"}
-plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.3.0"}
-dusk-blindbid = { git = "https://github.com/dusk-network/dusk-blindbid", tag = "v0.1.0" }
+dusk-plonk = "0.3.1"
+plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.4.0"}
+dusk-blindbid = { git = "https://github.com/dusk-network/dusk-blindbid", tag = "v0.3.0" }
 rand = "0.7"

--- a/src/lib/services/blindbid/score_gen_handler.rs
+++ b/src/lib/services/blindbid/score_gen_handler.rs
@@ -54,7 +54,7 @@ where
             .compute_score(
                 &secret,
                 k,
-                branch.root,
+                branch.root(),
                 seed,
                 latest_consensus_round,
                 latest_consensus_step,
@@ -69,16 +69,16 @@ where
         );
         // Generate Blindbid proof proving that the generated `Score` is correct.
         let mut circuit = BlindBidCircuit {
-            bid: Some(bid),
-            score: Some(score),
-            secret_k: Some(k),
-            secret: Some(secret),
-            seed: Some(seed),
-            latest_consensus_round: Some(latest_consensus_round),
-            latest_consensus_step: Some(latest_consensus_step),
-            branch: Some(&branch),
-            size: 0,
-            pi_constructor: None,
+            bid: bid,
+            score: score,
+            secret_k: k,
+            secret: secret,
+            seed: seed,
+            latest_consensus_round: latest_consensus_round,
+            latest_consensus_step: latest_consensus_step,
+            branch: &branch,
+            trim_size: 1 << 15,
+            pi_positions: vec![],
         };
         let proof = gen_blindbid_proof(&mut circuit)
             .map_err(|e| Status::new(Code::Unknown, format!("{}", e)))?;

--- a/src/lib/services/blindbid/verify_score_handler.rs
+++ b/src/lib/services/blindbid/verify_score_handler.rs
@@ -52,16 +52,16 @@ where
 
         // Create a BlindBidCircuit instance
         let mut circuit = BlindBidCircuit {
-            bid: Some(bid),
-            score: Some(Score::default()),
-            secret_k: Some(BlsScalar::default()),
-            secret: Some(JubJubAffine::default()),
-            seed: Some(seed),
-            latest_consensus_round: Some(latest_consensus_round),
-            latest_consensus_step: Some(latest_consensus_step),
-            branch: Some(&branch),
-            size: 0,
-            pi_constructor: None,
+            bid: bid,
+            score: Score::default(),
+            secret_k: BlsScalar::default(),
+            secret: JubJubAffine::default(),
+            seed: seed,
+            latest_consensus_round: latest_consensus_round,
+            latest_consensus_step: latest_consensus_step,
+            branch: &branch,
+            trim_size: 1 << 15,
+            pi_positions: vec![],
         };
 
         Ok(Response::new(VerifyScoreResponse {
@@ -104,25 +104,12 @@ fn verify_blindbid_proof(
     // Build PI array (safe to unwrap since we just created the circuit
     // with everything initialized).
     let pi = vec![
-        PublicInput::BlsScalar(
-            -circuit.branch.expect("Unexpected Error").root,
-            0,
-        ),
-        PublicInput::BlsScalar(
-            -circuit.bid.expect("Unexpected Error").hash(),
-            0,
-        ),
-        PublicInput::AffinePoint(
-            circuit.bid.expect("Unexpected Error").c,
-            0,
-            0,
-        ),
-        PublicInput::BlsScalar(
-            -circuit.bid.expect("Unexpected Error").hashed_secret,
-            0,
-        ),
-        PublicInput::BlsScalar(-prover_id, 0),
-        PublicInput::BlsScalar(-score, 0),
+        PublicInput::BlsScalar(circuit.branch.root(), 0),
+        PublicInput::BlsScalar(circuit.bid.hash(), 0),
+        PublicInput::AffinePoint(circuit.bid.c, 0, 0),
+        PublicInput::BlsScalar(circuit.bid.hashed_secret, 0),
+        PublicInput::BlsScalar(prover_id, 0),
+        PublicInput::BlsScalar(score, 0),
     ];
     // Verify the proof.
     circuit.verify_proof(


### PR DESCRIPTION
After updating the following deps to the latests
releases:
 ## Updated deps
- `dusk-plonk v0.3.1`
- `plonk_gadgets v0.4.0`
- `dusk-blindbid v0.3.0`

We needed to refactor the circuits and it's implementations
acording to the new `Circuit` trait API.

- Refactored `BlindBidCircuit` usage & field renaming.
- Refactored `BidCorrectnessCircuit` usage & field renaming.
- Update build.rs with the new `Circuit` API.