### PR TITLE
Add `.rusk` profile folder with local / CI caching

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -21,38 +21,36 @@ jobs:
         with:
           command: dusk-analyzer
 
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-
-  test_stable:
-    name: Stable tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup target add wasm32-unknown-unknown
-      - run: make test
-
   test_nightly:
     name: Nightly tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Cache .rusk profile
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-rusk-profile
+        with:
+          path: ~/.rusk
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Cache deps
+        uses: actions/cache@v2
+        with:
+          path: |-
+            .cargo_home
+            target/*/.*
+            target/*/build
+            target/*/deps
+          key: ${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "rusk"
 version = "0.1.0"
-authors = ["CPerezz <carlos@dusk.network>", "zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network>", "Jules de Smit <jules@dusk.network>"]
+authors = [
+  "CPerezz <carlos@dusk.network>", 
+  "zer0 <matteo@dusk.network>", 
+  "Victor Lopez <victor@dusk.network>",
+  "Jules de Smit <jules@dusk.network>"
+]
 edition = "2018"
 autobins = false
 
@@ -34,6 +39,7 @@ tower = "0.3"
 rand = "0.7.0"
 bincode = "1.3.1"
 lazy_static = "1.4"
+rusk-profile = { path = "./profile" }
 
 [build-dependencies]
 tonic-build = "0.3"
@@ -47,4 +53,6 @@ kelvin = "0.19.0"
 nstack = "0.5.0"
 rand = "0.7"
 bincode = "1.3.1"
-bid-circuits = {path ="contracts/bid/circuits"}
+bid-circuits = {path ="./contracts/bid/circuits"}
+rusk-profile = { path = "./profile" }
+lazy_static = "1.4"

--- a/contracts/bid/circuits/Cargo.toml
+++ b/contracts/bid/circuits/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2018"
 anyhow = "^1.0.0"
 dusk-plonk = {version = "0.2.11"}
 plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.3.0"}
-dusk-blindbid = { git = "https://github.com/dusk-network/dusk-blindbid", tag = "v0.1.0" }
+dusk-blindbid = { git = "https://github.com/dusk-network/dusk-blindbid", tag = "v0.2.4" }
 rand = "0.7"

--- a/contracts/bid/circuits/src/correctness.rs
+++ b/contracts/bid/circuits/src/correctness.rs
@@ -12,10 +12,7 @@ use dusk_plonk::jubjub::{
     AffinePoint, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
 };
 use dusk_plonk::prelude::*;
-use plonk_gadgets::{
-    AllocatedScalar, RangeGadgets::range_check,
-    ScalarGadgets::conditionally_select_one,
-};
+use plonk_gadgets::{AllocatedScalar, RangeGadgets::range_check};
 
 /// Circuit which proves the correctness of a blind bid.
 #[derive(Debug, Clone, Default)]
@@ -39,20 +36,13 @@ impl Circuit<'_> for CorrectnessCircuit {
     ) -> Result<Vec<PublicInput>, Error> {
         let mut pi = vec![];
 
-        // Generate constant witness values for 0.
-        let zero =
-            composer.add_witness_to_circuit_description(BlsScalar::zero());
-
         // Make sure we have all of the circuit inputs before proceeding.
         let commitment = self
             .commitment
-            .ok_or_else(|| CircuitErrors::CircuitInputsNotFound)?;
-        let value = self
-            .value
-            .ok_or_else(|| CircuitErrors::CircuitInputsNotFound)?;
-        let blinder = self
-            .blinder
-            .ok_or_else(|| CircuitErrors::CircuitInputsNotFound)?;
+            .ok_or(CircuitErrors::CircuitInputsNotFound)?;
+        let value = self.value.ok_or(CircuitErrors::CircuitInputsNotFound)?;
+        let blinder =
+            self.blinder.ok_or(CircuitErrors::CircuitInputsNotFound)?;
 
         // Allocate all private inputs to the circuit.
         let value = AllocatedScalar::allocate(composer, value);
@@ -117,8 +107,7 @@ impl Circuit<'_> for CorrectnessCircuit {
         Ok((
             prover
                 .prover_key
-                .expect("Unexpected error. Missing VerifierKey in compilation")
-                .clone(),
+                .expect("Unexpected error. Missing VerifierKey in compilation"),
             verifier
                 .verifier_key
                 .expect("Unexpected error. Missing VerifierKey in compilation"),

--- a/profile/Cargo.toml
+++ b/profile/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rusk-profile"
+version = "0.1.0"
+authors = ["zer0 <matteo@dusk.network>"]
+edition = "2018"
+autobins = false
+
+[dependencies]
+dirs = "3.0"
+cargo-lock = "6.0.0"
+sha2 = "0.9.1"

--- a/profile/src/lib.rs
+++ b/profile/src/lib.rs
@@ -1,0 +1,180 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dirs::home_dir;
+use sha2::{Digest, Sha256};
+use std::fs::{self, read, write, File};
+use std::io;
+use std::io::prelude::*;
+use std::path::{Path, PathBuf};
+
+pub struct Keys {
+    crate_name: String,
+    version: String,
+}
+
+impl Keys {
+    pub fn get_dir(&self) -> Option<PathBuf> {
+        if let Ok(mut dir) = get_rusk_keys_dir() {
+            dir.push(&self.crate_name);
+            dir.push(&self.version);
+            Some(dir)
+        } else {
+            None
+        }
+    }
+
+    pub fn are_outdated(&self) -> bool {
+        self.get_dir().map_or(true, |dir| !dir.exists())
+    }
+
+    pub fn get(&self, handle: &str) -> Option<(Vec<u8>, Vec<u8>)> {
+        let dir = self.get_dir();
+
+        dir.filter(|dir| dir.exists()).and_then(|dir| {
+            let mut hasher = Sha256::new();
+            hasher.update(handle.as_bytes());
+            let hash = format!("{:x}", hasher.finalize());
+
+            let mut pk_file = dir.clone();
+            pk_file.push(format!("{}.pk", hash));
+            let mut vk_file = dir;
+            vk_file.push(format!("{}.vk", hash));
+
+            let pk = read(pk_file);
+            let vk = read(vk_file);
+
+            match (pk, vk) {
+                (Ok(pk), Ok(vk)) => Some((pk, vk)),
+                (_, _) => None,
+            }
+        })
+    }
+
+    pub fn get_prover(&self, handle: &str) -> Option<Vec<u8>> {
+        let dir = self.get_dir();
+
+        dir.filter(|dir| dir.exists()).and_then(|mut dir| {
+            let mut hasher = Sha256::new();
+            hasher.update(handle.as_bytes());
+            let hash = format!("{:x}", hasher.finalize());
+
+            dir.push(format!("{}.pk", hash));
+
+            read(dir).ok()
+        })
+    }
+
+    pub fn get_verifier(&self, handle: &str) -> Option<Vec<u8>> {
+        let dir = self.get_dir();
+
+        dir.filter(|dir| dir.exists()).and_then(|mut dir| {
+            let mut hasher = Sha256::new();
+            hasher.update(handle.as_bytes());
+            let hash = format!("{:x}", hasher.finalize());
+
+            dir.push(format!("{}.vk", hash));
+
+            read(dir).ok()
+        })
+    }
+
+    pub fn update(
+        &self,
+        handle: &str,
+        keys: (Vec<u8>, Vec<u8>),
+    ) -> Result<(), io::Error> {
+        let mut dir = get_rusk_keys_dir()?;
+
+        dir.push(&self.crate_name);
+        if dir.exists() {
+            fs::remove_dir_all(dir.clone())?;
+        }
+        dir.push(&self.version);
+        fs::create_dir_all(dir.clone())?;
+
+        let mut hasher = Sha256::new();
+        hasher.update(handle.as_bytes());
+
+        let hash = format!("{:x}", hasher.finalize());
+
+        let mut pk_file = dir.clone();
+        pk_file.push(format!("{}.pk", hash));
+
+        let mut vk_file = dir;
+        vk_file.push(format!("{}.vk", hash));
+
+        File::create(pk_file)?.write_all(&keys.0)?;
+        File::create(vk_file)?.write_all(&keys.1)?;
+
+        Ok(())
+    }
+}
+
+pub fn get_rusk_profile_dir() -> Result<PathBuf, io::Error> {
+    if let Some(mut dir) = home_dir() {
+        dir.push(".rusk");
+        // PathBuf::from(BLINDBID_CIRCUIT_PK_PATH).exists(),
+        fs::create_dir_all(dir.clone())?;
+        Ok(dir)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "User Profile Dir not found",
+        ))
+    }
+}
+
+pub fn get_rusk_keys_dir() -> Result<PathBuf, io::Error> {
+    let mut profile = get_rusk_profile_dir()?;
+    profile.push("keys");
+    fs::create_dir_all(profile.clone())?;
+    Ok(profile)
+}
+
+/// TODO: change name
+pub fn get_common_reference_string() -> Result<Vec<u8>, io::Error> {
+    let mut profile = get_rusk_profile_dir()?;
+    profile.push("dev.crs");
+
+    Ok(read(profile)?)
+}
+
+/// TODO: change name
+pub fn set_common_reference_string<P: AsRef<Path>>(
+    path: P,
+) -> Result<Vec<u8>, io::Error> {
+    let mut profile = get_rusk_profile_dir()?;
+    profile.push("dev.crs");
+
+    let buff = read(&path)?;
+    write(&profile, &buff)?;
+    Ok(buff)
+}
+
+pub fn keys_for(crate_name: &str) -> Keys {
+    use cargo_lock::{Lockfile, Package};
+    let lockfile = Lockfile::load("./Cargo.lock").unwrap();
+
+    let packages = lockfile
+        .packages
+        .iter()
+        .filter(|package| crate_name == package.name.as_str())
+        .collect::<Vec<&Package>>();
+
+    // TODO: returns an error
+    if packages.len() > 1 {
+        panic!("Found {} version of {}", packages.len(), crate_name);
+    }
+    let package = packages[0];
+
+    let version = format!("{}", package.version);
+
+    Keys {
+        crate_name: crate_name.to_string(),
+        version,
+    }
+}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 max_width = 80
+wrap_comments = true

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -21,12 +21,12 @@ use tonic::transport::Server;
 use version::show_version;
 
 /// Default UDS path that Rusk GRPC-server will connect to.
-pub const SOCKET_PATH: &'static str = "/tmp/rusk_listener";
+pub const SOCKET_PATH: &str = "/tmp/rusk_listener";
 
 /// Default port that Rusk GRPC-server will listen to.
-pub(crate) const PORT: &'static str = "8585";
+pub(crate) const PORT: &str = "8585";
 /// Default host_address that Rusk GRPC-server will listen to.
-pub(crate) const HOST_ADDRESS: &'static str = "127.0.0.1";
+pub(crate) const HOST_ADDRESS: &str = "127.0.0.1";
 
 #[tokio::main]
 async fn main() {
@@ -96,19 +96,20 @@ async fn main() {
         .with_max_level(log)
         .finish();
     // Set the subscriber as global.
-    // so this subscriber will be used as the default in all threads for the remainder
-    // of the duration of the program, similar to how `loggers` work in the `log` crate.
+    // so this subscriber will be used as the default in all threads for the
+    // remainder of the duration of the program, similar to how `loggers`
+    // work in the `log` crate.
     tracing::subscriber::set_global_default(subscriber)
         .expect("Failed on subscribe tracing");
 
-    // Match the desired IPC method. Or set the default one depending on the OS used.
-    // Then startup rusk with the final values.
+    // Match the desired IPC method. Or set the default one depending on the OS
+    // used. Then startup rusk with the final values.
     let res = match matches.value_of("ipc_method") {
         Some(method) => match (cfg!(windows), method) {
             (_, "tcp_ip") => {
                 startup_with_tcp_ip(
-                    matches.value_of("host").unwrap_or_else(|| HOST_ADDRESS),
-                    matches.value_of("port").unwrap_or_else(|| PORT),
+                    matches.value_of("host").unwrap_or(HOST_ADDRESS),
+                    matches.value_of("port").unwrap_or(PORT),
                 )
                 .await
             }
@@ -117,7 +118,7 @@ async fn main() {
             }
             (false, "uds") => {
                 startup_with_uds(
-                    matches.value_of("socket").unwrap_or_else(|| SOCKET_PATH),
+                    matches.value_of("socket").unwrap_or(SOCKET_PATH),
                 )
                 .await
             }
@@ -126,13 +127,13 @@ async fn main() {
         None => {
             if cfg!(windows) {
                 startup_with_tcp_ip(
-                    matches.value_of("host").unwrap_or_else(|| HOST_ADDRESS),
-                    matches.value_of("port").unwrap_or_else(|| PORT),
+                    matches.value_of("host").unwrap_or(HOST_ADDRESS),
+                    matches.value_of("port").unwrap_or(PORT),
                 )
                 .await
             } else {
                 startup_with_uds(
-                    matches.value_of("socket").unwrap_or_else(|| SOCKET_PATH),
+                    matches.value_of("socket").unwrap_or(SOCKET_PATH),
                 )
                 .await
             }
@@ -172,8 +173,8 @@ async fn startup_with_tcp_ip(
     port: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut full_address = host.to_string();
-    full_address.extend(":".chars());
-    full_address.extend(port.to_string().chars());
+    full_address.push(':');
+    full_address.push_str(&port.to_string());
     let addr: std::net::SocketAddr = full_address.parse()?;
     let rusk = Rusk::default();
 

--- a/src/bin/version.rs
+++ b/src/bin/version.rs
@@ -17,11 +17,9 @@ pub(crate) fn show_version(info: VersionInfo) -> String {
         info.commit_date.unwrap_or_default()
     );
 
-    let version_build = if build.len() > 1 {
+    if build.len() > 1 {
         format!("{} ({})", version, build)
     } else {
         version
-    };
-
-    version_build
+    }
 }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -5,8 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use tracing::info;
-
-pub(crate) mod circuit_helpers;
 pub mod encoding;
 pub mod services;
 
@@ -29,7 +27,10 @@ use dusk_plonk::prelude::PublicParameters;
 use lazy_static::lazy_static;
 lazy_static! {
     static ref PUB_PARAMS: PublicParameters = {
-        circuit_helpers::read_pub_params()
-            .expect("Error reading Public Params.")
+        let buff =
+            rusk_profile::get_common_reference_string().expect("CRS not found");
+        let result: PublicParameters =
+            bincode::deserialize(&buff).expect("CRS not decoded");
+        result
     };
 }

--- a/src/lib/services/blindbid/score_gen_handler.rs
+++ b/src/lib/services/blindbid/score_gen_handler.rs
@@ -7,7 +7,6 @@
 use super::super::ServiceRequestHandler;
 use super::get_bid_storage_fields;
 use super::{GenerateScoreRequest, GenerateScoreResponse};
-use crate::circuit_helpers::*;
 use crate::encoding::{decode_affine, decode_bls_scalar};
 use anyhow::Result;
 use dusk_blindbid::BlindBidCircuit;
@@ -37,8 +36,9 @@ where
         // any of them is missing since all are required to compute
         // the score and the blindbid proof.
         let (k, seed, secret) = parse_score_gen_params(self.request)?;
-        // XXX: We need to mock the storage for now, so we push to a PoseidonTree the Bid that we
-        // should only need to retrieve. To do so, we need all of the parameters, not just the index.
+        // XXX: We need to mock the storage for now, so we push to a
+        // PoseidonTree the Bid that we should only need to retrieve. To
+        // do so, we need all of the parameters, not just the index.
         let (bid, branch) = get_bid_storage_fields(
             self.request.get_ref().index_stored_bid as usize,
             Some(secret),
@@ -67,7 +67,8 @@ where
             latest_consensus_round,
             latest_consensus_step,
         );
-        // Generate Blindbid proof proving that the generated `Score` is correct.
+        // Generate Blindbid proof proving that the generated `Score` is
+        // correct.
         let mut circuit = BlindBidCircuit {
             bid: Some(bid),
             score: Some(score),
@@ -105,7 +106,12 @@ fn parse_score_gen_params(
 // desired inputs.verifier_key
 fn gen_blindbid_proof(circuit: &mut BlindBidCircuit) -> Result<Proof> {
     // Read ProverKey of the circuit.
-    let prover_key = read_blindcid_circuit_pk()?;
+    // TODO: remove unwrap
+    let prover_key = rusk_profile::keys_for("dusk-blindbid")
+        .get_prover("blindbid")
+        .unwrap();
+
+    let prover_key = ProverKey::from_bytes(&prover_key[..])?;
     // Generate a proof using the circuit
     circuit.gen_proof(&crate::PUB_PARAMS, &prover_key, b"BlindBid")
 }

--- a/src/lib/services/echoer.rs
+++ b/src/lib/services/echoer.rs
@@ -26,8 +26,9 @@ impl Echoer for Rusk {
         info!("Got an ECHO request: {:?}", request);
 
         let reply = EchoResponse {
-            // We must use .into_inner() as the fields of gRPC requests and responses are private
-            message: format!("{}", request.into_inner().message).into(),
+            // We must use .into_inner() as the fields of gRPC requests and
+            // responses are private
+            message: request.into_inner().message,
         };
 
         Ok(Response::new(reply))

--- a/tests/blindbid_service.rs
+++ b/tests/blindbid_service.rs
@@ -39,8 +39,9 @@ mod blindbid_service_tests {
         let subscriber =
             Subscriber::builder().with_max_level(Level::INFO).finish();
         // Set the subscriber as global.
-        // so this subscriber will be used as the default in all threads for the remainder
-        // of the duration of the program, similar to how `loggers` work in the `log` crate.
+        // so this subscriber will be used as the default in all threads for the
+        // remainder of the duration of the program, similar to how
+        // `loggers` work in the `log` crate.
         subscriber::set_global_default(subscriber)
             .expect("Failed on subscribe tracing");
 
@@ -50,9 +51,9 @@ mod blindbid_service_tests {
 
         let mut uds = UnixListener::bind(SOCKET_PATH)?;
         let rusk = Rusk::default();
-        // We can't avoid the unwrap here until the async closure (#62290) lands.
-        // And therefore we can force the closure to return a Result.
-        // See: https://github.com/rust-lang/rust/issues/62290
+        // We can't avoid the unwrap here until the async closure (#62290)
+        // lands. And therefore we can force the closure to return a
+        // Result. See: https://github.com/rust-lang/rust/issues/62290
         tokio::spawn(async move {
             Server::builder()
                 .add_service(BlindBidServiceServer::new(rusk))

--- a/tests/echo_service_tests.rs
+++ b/tests/echo_service_tests.rs
@@ -34,8 +34,9 @@ mod echo_service_tests {
         let subscriber =
             Subscriber::builder().with_max_level(Level::INFO).finish();
         // Set the subscriber as global.
-        // so this subscriber will be used as the default in all threads for the remainder
-        // of the duration of the program, similar to how `loggers` work in the `log` crate.
+        // so this subscriber will be used as the default in all threads for the
+        // remainder of the duration of the program, similar to how
+        // `loggers` work in the `log` crate.
         subscriber::set_global_default(subscriber)
             .expect("Failed on subscribe tracing");
 
@@ -45,9 +46,9 @@ mod echo_service_tests {
 
         let mut uds = UnixListener::bind(SOCKET_PATH)?;
         let rusk = Rusk::default();
-        // We can't avoid the unwrap here until the async closure (#62290) lands.
-        // And therefore we can force the closure to return a Result.
-        // See: https://github.com/rust-lang/rust/issues/62290
+        // We can't avoid the unwrap here until the async closure (#62290)
+        // lands. And therefore we can force the closure to return a
+        // Result. See: https://github.com/rust-lang/rust/issues/62290
         tokio::spawn(async move {
             Server::builder()
                 .add_service(EchoerServer::new(rusk))

--- a/tests/pki_service.rs
+++ b/tests/pki_service.rs
@@ -41,8 +41,9 @@ mod pki_service_tests {
         let subscriber =
             Subscriber::builder().with_max_level(Level::INFO).finish();
         // Set the subscriber as global.
-        // so this subscriber will be used as the default in all threads for the remainder
-        // of the duration of the program, similar to how `loggers` work in the `log` crate.
+        // so this subscriber will be used as the default in all threads for the
+        // remainder of the duration of the program, similar to how
+        // `loggers` work in the `log` crate.
         subscriber::set_global_default(subscriber)
             .expect("Failed on subscribe tracing");
 
@@ -52,9 +53,9 @@ mod pki_service_tests {
 
         let mut uds = UnixListener::bind(SOCKET_PATH)?;
         let rusk = Rusk::default();
-        // We can't avoid the unwrap here until the async closure (#62290) lands.
-        // And therefore we can force the closure to return a Result.
-        // See: https://github.com/rust-lang/rust/issues/62290
+        // We can't avoid the unwrap here until the async closure (#62290)
+        // lands. And therefore we can force the closure to return a
+        // Result. See: https://github.com/rust-lang/rust/issues/62290
         tokio::spawn(async move {
             Server::builder()
                 .add_service(KeysServer::new(rusk))


### PR DESCRIPTION
- Remove `cargo check` from CI
- Remove tests for stable from CI
- Add CI caching for `.rusk` profile
- Add CI caching for rust dependencies
- Create a sub crate `profile` to handle rusk's profile settings
- Add key's caching mechanism in `rusk_profile`
- Update Rusk to use both at runtime and at compile time `rusk_profile`
- Add `wrap_comments` to `rustfmt.toml`
- Run `cargo fmt`
- Fix all Rusk warnings

Resolves: #123