### PR TITLE
Refactor the gagdets folder 

### DIFF
--- a/contracts/transfer/circuits/Cargo.toml
+++ b/contracts/transfer/circuits/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-phoenix-core = { git = "https://github.com/dusk-network/phoenix-core" , tag = "v0.3.0" }
+phoenix-core = { git = "https://github.com/dusk-network/phoenix-core" , tag = "v0.3.1" }
 poseidon252 = { git = "https://github.com/dusk-network/Poseidon252" , tag = "v0.10.0"}
 rand = "0.7"
 kelvin = "0.19"
 plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.4.0"}
 dusk-pki = { git = "https://github.com/dusk-network/dusk-pki", tag = "v0.2.0" }
 anyhow = "1.0"
-dusk-plonk = {version = "0.3.1", features = ["trace-print"]}
+dusk-plonk = {version = "0.3.1", features = ["trace-print", "trace"]}

--- a/contracts/transfer/circuits/src/dusk_contract/execute.rs
+++ b/contracts/transfer/circuits/src/dusk_contract/execute.rs
@@ -1298,7 +1298,8 @@ mod tests {
             ],
             vec![], //input_commitment_one, input_commitment_two],
             vec![input_note_value_one.into(), input_note_value_two.into()],
-            vec![], ///input_note_blinder_one.into(), input_note_blinder_two.into()],
+            vec![],
+            ///input_note_blinder_one.into(), input_note_blinder_two.into()],
             crossover_commitment,
             crossover_commitment_value.into(),
             crossover_commitment_blinder.into(),
@@ -1313,7 +1314,6 @@ mod tests {
             ],
             fee,
         );
-
 
         // Generate Composer & Public Parameters
         let pub_params =
@@ -1356,7 +1356,12 @@ mod tests {
         );
         verifier_circuit.compile(&pub_params);
         let mut pi = vec![];
-        add_circuit_public_inputs(&verifier_circuit, crossover_commitment, fee, &mut pi);
+        add_circuit_public_inputs(
+            &verifier_circuit,
+            crossover_commitment,
+            fee,
+            &mut pi,
+        );
 
         // Assert the proof will fail
         assert!(verifier_circuit

--- a/contracts/transfer/circuits/src/gadgets.rs
+++ b/contracts/transfer/circuits/src/gadgets.rs
@@ -10,4 +10,5 @@ pub mod merkle;
 pub mod nullifier;
 pub mod preimage;
 pub mod range;
+pub mod schnorr;
 pub mod secret_key;

--- a/contracts/transfer/circuits/src/gadgets/balance.rs
+++ b/contracts/transfer/circuits/src/gadgets/balance.rs
@@ -45,7 +45,7 @@ pub fn balance(
 }
 
 #[cfg(test)]
-mod tests {
+mod balance_tests {
     use super::*;
     use anyhow::{Error, Result};
     use dusk_plonk::commitment_scheme::kzg10::PublicParameters;

--- a/contracts/transfer/circuits/src/gadgets/merkle.rs
+++ b/contracts/transfer/circuits/src/gadgets/merkle.rs
@@ -21,7 +21,7 @@ pub fn merkle(
 }
 
 #[cfg(test)]
-mod commitment_tests {
+mod merkle_tests {
     use super::*;
     use anyhow::{Error, Result};
     use dusk_pki::PublicSpendKey;

--- a/contracts/transfer/circuits/src/gadgets/nullifier.rs
+++ b/contracts/transfer/circuits/src/gadgets/nullifier.rs
@@ -18,7 +18,7 @@ pub fn nullifier_gadget(
 }
 
 #[cfg(test)]
-mod commitment_tests {
+mod nullifier_tests {
     use super::*;
     use anyhow::{Error, Result};
     use dusk_pki::{Ownable, PublicSpendKey, SecretSpendKey};

--- a/contracts/transfer/circuits/src/gadgets/preimage.rs
+++ b/contracts/transfer/circuits/src/gadgets/preimage.rs
@@ -13,7 +13,6 @@ use poseidon252::sponge::sponge::{sponge_hash, sponge_hash_gadget};
 
 /// Prove knowledge of the preimage of a note,
 /// used as input for a transaction.
-#[allow(non_snake_case)]
 pub fn input_preimage(
     composer: &mut StandardComposer,
     note_type: AllocatedScalar,

--- a/contracts/transfer/circuits/src/gadgets/preimage.rs
+++ b/contracts/transfer/circuits/src/gadgets/preimage.rs
@@ -13,11 +13,13 @@ use poseidon252::sponge::sponge::sponge_hash_gadget;
 #[allow(non_snake_case)]
 pub fn input_preimage(
     composer: &mut StandardComposer,
+    type: AllocatedScalar,
     value_commitment_x: AllocatedScalar,
     value_commitment_y: AllocatedScalar,
     pos: AllocatedScalar,
     pk_r_x: AllocatedScalar,
     pk_r_y: AllocatedScalar,
+    encrypted_data: AllocatedScalar,
 ) -> Variable {
     let output = sponge_hash_gadget(
         composer,

--- a/contracts/transfer/circuits/src/gadgets/preimage.rs
+++ b/contracts/transfer/circuits/src/gadgets/preimage.rs
@@ -4,13 +4,13 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use dusk_plonk::bls12_381::Scalar as BlsScalar;
 use dusk_plonk::constraint_system::ecc::Point as PlonkPoint;
 use dusk_plonk::jubjub::AffinePoint;
 use dusk_plonk::prelude::*;
 use plonk_gadgets::AllocatedScalar;
 use poseidon252::sponge::sponge::{sponge_hash, sponge_hash_gadget};
 use std::convert::TryInto;
-use dusk_plonk::bls12_381::Scalar as BlsScalar;
 
 /// Prove knowledge of the preimage of a note,
 /// used as input for a transaction.
@@ -49,7 +49,7 @@ pub fn input_preimage(
 }
 
 #[cfg(test)]
-mod commitment_tests {
+mod preimage_tests {
     use super::*;
     use anyhow::{Error, Result};
     use dusk_pki::{Ownable, PublicSpendKey};
@@ -87,18 +87,6 @@ mod commitment_tests {
         let cipher3 = BlsScalar::from_bytes(&arr3).unwrap();
 
         let note_hash = note.hash();
-            //sponge_hash(&[
-
-        //     BlsScalar::from(note.note() as u64)]);
-        //     note.value_commitment().to_hash_inputs()[0],
-        //     note.value_commitment().to_hash_inputs()[1],
-        //     BlsScalar::from(*note.nonce()),
-        //     note.stealth_address().pk_r().to_hash_inputs()[0],
-        //     note.stealth_address().pk_r().to_hash_inputs()[1],
-        //     note.stealth_address().R().to_hash_inputs()[0],
-        //     note.stealth_address().R().to_hash_inputs()[1],
-        //     BlsScalar::from(note.pos()),]
-        // );
 
         // Generate Composer & Public Parameters
         let pub_params =
@@ -130,9 +118,12 @@ mod commitment_tests {
             prover.mut_cs(),
             BlsScalar::from(note.pos()),
         );
-        let cipher_1 = AllocatedScalar::allocate(prover.mut_cs(), cipher1);
-        let cipher_2 = AllocatedScalar::allocate(prover.mut_cs(), cipher2);
-        let cipher_3 = AllocatedScalar::allocate(prover.mut_cs(), cipher3);
+        let cipher_1 =
+            AllocatedScalar::allocate(prover.mut_cs(), note.cipher()[0]);
+        let cipher_2 =
+            AllocatedScalar::allocate(prover.mut_cs(), note.cipher()[1]);
+        let cipher_3 =
+            AllocatedScalar::allocate(prover.mut_cs(), note.cipher()[2]);
 
         let a = input_preimage(
             prover.mut_cs(),
@@ -178,9 +169,12 @@ mod commitment_tests {
             verifier.mut_cs(),
             BlsScalar::from(note.pos()),
         );
-        let cipher_1 = AllocatedScalar::allocate(verifier.mut_cs(), cipher1);
-        let cipher_2 = AllocatedScalar::allocate(verifier.mut_cs(), cipher2);
-        let cipher_3 = AllocatedScalar::allocate(verifier.mut_cs(), cipher3);
+        let cipher_1 =
+            AllocatedScalar::allocate(verifier.mut_cs(), note.cipher()[0]);
+        let cipher_2 =
+            AllocatedScalar::allocate(verifier.mut_cs(), note.cipher()[1]);
+        let cipher_3 =
+            AllocatedScalar::allocate(verifier.mut_cs(), note.cipher()[2]);
 
         let a = input_preimage(
             verifier.mut_cs(),

--- a/contracts/transfer/circuits/src/gadgets/preimage.rs
+++ b/contracts/transfer/circuits/src/gadgets/preimage.rs
@@ -7,28 +7,39 @@
 use dusk_plonk::prelude::*;
 use plonk_gadgets::AllocatedScalar;
 use poseidon252::sponge::sponge::sponge_hash_gadget;
+use std::convert::TryInto;
 
 /// Prove knowledge of the preimage of a note,
 /// used as input for a transaction.
 #[allow(non_snake_case)]
 pub fn input_preimage(
     composer: &mut StandardComposer,
-    type: AllocatedScalar,
+    note_type: AllocatedScalar,
     value_commitment_x: AllocatedScalar,
     value_commitment_y: AllocatedScalar,
-    pos: AllocatedScalar,
     pk_r_x: AllocatedScalar,
     pk_r_y: AllocatedScalar,
-    encrypted_data: AllocatedScalar,
+    randomness_x: AllocatedScalar,
+    randomness_y: AllocatedScalar,
+    position: AllocatedScalar,
+    cipher_one: AllocatedScalar,
+    cipher_two: AllocatedScalar,
+    cipher_three: AllocatedScalar,
 ) -> Variable {
     let output = sponge_hash_gadget(
         composer,
         &[
+            note_type.var,
             value_commitment_x.var,
             value_commitment_y.var,
-            pos.var,
             pk_r_x.var,
             pk_r_y.var,
+            randomness_x.var,
+            randomness_y.var,
+            position.var,
+            cipher_one.var,
+            cipher_two.var,
+            cipher_three.var,
         ],
     );
 
@@ -47,21 +58,44 @@ mod commitment_tests {
 
     #[test]
     fn preimage_gadget() -> Result<(), Error> {
-        let secret1 = JubJubScalar::from(100u64);
-        let secret2 = JubJubScalar::from(200u64);
+        let value = 7 as u64;
+        let blinder = JubJubScalar::from(1123 as u64);
+        let secret1 = JubJubScalar::from(100 as u64);
+        let secret2 = JubJubScalar::from(200 as u64);
         let pk1 = GENERATOR_EXTENDED * secret1;
         let pk2 = GENERATOR_EXTENDED * secret2;
         let psk = PublicSpendKey::new(pk1, pk2);
-        let value = 25u64;
-        let note = Note::new(NoteType::Transparent, &psk, value);
+        let r = JubJubScalar::from(112 as u64);
+        let nonce = JubJubScalar::from(345 as u64);
+        let note = Note::deterministic(
+            NoteType::Obfuscated,
+            &r,
+            nonce,
+            &psk,
+            value,
+            blinder,
+        );
+        let note_bytes = note.to_bytes();
+        let cipher = &note_bytes[note_bytes.len() - 96..];
+        let arr1: [u8; 32] = cipher[..32].try_into().expect("Invalid length");
+        let cipher1 = BlsScalar::from_bytes(&arr1).unwrap();
+        let arr2: [u8; 32] = cipher[32..64].try_into().expect("Invalid length");
+        let cipher2 = BlsScalar::from_bytes(&arr2).unwrap();
+        let arr3: [u8; 32] = cipher[64..].try_into().expect("Invalid length");
+        let cipher3 = BlsScalar::from_bytes(&arr3).unwrap();
+
         let note_hash = note.hash();
 
         // Generate Composer & Public Parameters
         let pub_params =
-            PublicParameters::setup(1 << 15, &mut rand::thread_rng())?;
-        let (ck, vk) = pub_params.trim(1 << 14)?;
+            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 16)?;
         let mut prover = Prover::new(b"test");
 
+        let note_type = AllocatedScalar::allocate(
+            prover.mut_cs(),
+            BlsScalar::from(note.note() as u64),
+        );
         let comm_x = AllocatedScalar::allocate(
             prover.mut_cs(),
             note.value_commitment().to_hash_inputs()[0],
@@ -69,10 +103,6 @@ mod commitment_tests {
         let comm_y = AllocatedScalar::allocate(
             prover.mut_cs(),
             note.value_commitment().to_hash_inputs()[1],
-        );
-        let pos = AllocatedScalar::allocate(
-            prover.mut_cs(),
-            BlsScalar::from(note.pos()),
         );
         let pkr_x = AllocatedScalar::allocate(
             prover.mut_cs(),
@@ -82,17 +112,49 @@ mod commitment_tests {
             prover.mut_cs(),
             note.stealth_address().pk_r().to_hash_inputs()[1],
         );
+        let r_x = AllocatedScalar::allocate(
+            prover.mut_cs(),
+            note.stealth_address().R().to_hash_inputs()[0],
+        );
+        let r_y = AllocatedScalar::allocate(
+            prover.mut_cs(),
+            note.stealth_address().R().to_hash_inputs()[1],
+        );
+        let pos = AllocatedScalar::allocate(
+            prover.mut_cs(),
+            BlsScalar::from(note.pos()),
+        );
+        let cipher_1 = AllocatedScalar::allocate(prover.mut_cs(), cipher1);
+        let cipher_2 = AllocatedScalar::allocate(prover.mut_cs(), cipher2);
+        let cipher_3 = AllocatedScalar::allocate(prover.mut_cs(), cipher3);
 
-        let a =
-            input_preimage(prover.mut_cs(), comm_x, comm_y, pos, pkr_x, pkr_y);
+        let a = input_preimage(
+            prover.mut_cs(),
+            note_type,
+            comm_x,
+            comm_y,
+            pkr_x,
+            pkr_y,
+            r_x,
+            r_y,
+            pos,
+            cipher_1,
+            cipher_2,
+            cipher_3,
+        );
         prover
             .mut_cs()
             .constrain_to_constant(a, BlsScalar::zero(), -note_hash);
         let prover_pi = prover.mut_cs().public_inputs.clone();
         prover.preprocess(&ck)?;
         let proof = prover.prove(&ck)?;
+        prover.mut_cs().check_circuit_satisfied();
 
         let mut verifier = Verifier::new(b"test");
+        let note_type = AllocatedScalar::allocate(
+            verifier.mut_cs(),
+            BlsScalar::from(note.note() as u64),
+        );
         let comm_x = AllocatedScalar::allocate(
             verifier.mut_cs(),
             note.value_commitment().to_hash_inputs()[0],
@@ -100,10 +162,6 @@ mod commitment_tests {
         let comm_y = AllocatedScalar::allocate(
             verifier.mut_cs(),
             note.value_commitment().to_hash_inputs()[1],
-        );
-        let pos = AllocatedScalar::allocate(
-            verifier.mut_cs(),
-            BlsScalar::from(note.pos()),
         );
         let pkr_x = AllocatedScalar::allocate(
             verifier.mut_cs(),
@@ -113,14 +171,35 @@ mod commitment_tests {
             verifier.mut_cs(),
             note.stealth_address().pk_r().to_hash_inputs()[1],
         );
+        let r_x = AllocatedScalar::allocate(
+            verifier.mut_cs(),
+            note.stealth_address().R().to_hash_inputs()[0],
+        );
+        let r_y = AllocatedScalar::allocate(
+            verifier.mut_cs(),
+            note.stealth_address().R().to_hash_inputs()[1],
+        );
+        let pos = AllocatedScalar::allocate(
+            verifier.mut_cs(),
+            BlsScalar::from(note.pos()),
+        );
+        let cipher_1 = AllocatedScalar::allocate(verifier.mut_cs(), cipher1);
+        let cipher_2 = AllocatedScalar::allocate(verifier.mut_cs(), cipher2);
+        let cipher_3 = AllocatedScalar::allocate(verifier.mut_cs(), cipher3);
 
         let a = input_preimage(
             verifier.mut_cs(),
+            note_type,
             comm_x,
             comm_y,
-            pos,
             pkr_x,
             pkr_y,
+            r_x,
+            r_y,
+            pos,
+            cipher_1,
+            cipher_2,
+            cipher_3,
         );
         verifier.mut_cs().constrain_to_constant(
             a,

--- a/contracts/transfer/circuits/src/gadgets/preimage.rs
+++ b/contracts/transfer/circuits/src/gadgets/preimage.rs
@@ -11,7 +11,6 @@ use dusk_plonk::prelude::*;
 use plonk_gadgets::AllocatedScalar;
 use poseidon252::sponge::sponge::{sponge_hash, sponge_hash_gadget};
 
-
 /// Prove knowledge of the preimage of a note,
 /// used as input for a transaction.
 #[allow(non_snake_case)]
@@ -44,7 +43,6 @@ pub fn input_preimage(
             cipher_three.var,
         ],
     )
-
 }
 
 #[cfg(test)]

--- a/contracts/transfer/circuits/src/gadgets/preimage.rs
+++ b/contracts/transfer/circuits/src/gadgets/preimage.rs
@@ -10,7 +10,7 @@ use dusk_plonk::jubjub::AffinePoint;
 use dusk_plonk::prelude::*;
 use plonk_gadgets::AllocatedScalar;
 use poseidon252::sponge::sponge::{sponge_hash, sponge_hash_gadget};
-use std::convert::TryInto;
+
 
 /// Prove knowledge of the preimage of a note,
 /// used as input for a transaction.
@@ -27,7 +27,7 @@ pub fn input_preimage(
     cipher_two: AllocatedScalar,
     cipher_three: AllocatedScalar,
 ) -> Variable {
-    let output = sponge_hash_gadget(
+    sponge_hash_gadget(
         composer,
         &[
             note_type.var,
@@ -43,9 +43,8 @@ pub fn input_preimage(
             cipher_two.var,
             cipher_three.var,
         ],
-    );
+    )
 
-    output
 }
 
 #[cfg(test)]
@@ -77,21 +76,13 @@ mod preimage_tests {
             value,
             blinder,
         );
-        let note_bytes = note.to_bytes();
-        let cipher = &note_bytes[note_bytes.len() - 96..];
-        let arr1: [u8; 32] = cipher[..32].try_into().expect("Invalid length");
-        let cipher1 = BlsScalar::from_bytes(&arr1).unwrap();
-        let arr2: [u8; 32] = cipher[32..64].try_into().expect("Invalid length");
-        let cipher2 = BlsScalar::from_bytes(&arr2).unwrap();
-        let arr3: [u8; 32] = cipher[64..].try_into().expect("Invalid length");
-        let cipher3 = BlsScalar::from_bytes(&arr3).unwrap();
 
         let note_hash = note.hash();
 
         // Generate Composer & Public Parameters
         let pub_params =
-            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
-        let (ck, vk) = pub_params.trim(1 << 16)?;
+            PublicParameters::setup(1 << 14, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 13)?;
         let mut prover = Prover::new(b"test");
 
         let note_type = AllocatedScalar::allocate(

--- a/contracts/transfer/circuits/src/gadgets/range.rs
+++ b/contracts/transfer/circuits/src/gadgets/range.rs
@@ -19,7 +19,7 @@ pub fn range(
 }
 
 #[cfg(test)]
-mod commitment_tests {
+mod range_tests {
     use super::*;
     use anyhow::{Error, Result};
     use dusk_plonk::commitment_scheme::kzg10::PublicParameters;

--- a/contracts/transfer/circuits/src/gadgets/schnorr.rs
+++ b/contracts/transfer/circuits/src/gadgets/schnorr.rs
@@ -1,42 +1,39 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// // This Source Code Form is subject to the terms of the Mozilla Public
+// // License, v. 2.0. If a copy of the MPL was not distributed with this
+// // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// //
+// // Copyright (c) DUSK NETWORK. All rights reserved.
 //
-// Copyright (c) DUSK NETWORK. All rights reserved.
-
-use dusk_plonk::constraint_system::ecc::scalar_mul::fixed_base::scalar_mul;
-use dusk_plonk::constraint_system::ecc::Point as PlonkPoint;
-use dusk_plonk::jubjub::{
-    AffinePoint, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED, ExtendedPoint
-};
-use dusk_plonk::prelude::*;
-use plonk_gadgets::AllocatedScalar;
-use poseidon252::sponge::sponge::sponge_hash_gadget;
-use std::convert::TryInto;
-
-/// Verifies that schnorr signature outputs
-/// share the same Discrete log
-pub fn schnorr(
-    composer: &mut StandardComposer,
-    signature: AllocatedScalar,
-    R: PlonkPoint,
-    R_prime: PlonkPoint,
-    pk: PlonkPoint,
-    pk_prime: PlonkPoint,
-    message: AllocatedScalar,
-) {
-    let h = sponge_hash_gadget(composer, &[message.var]);
-    let challenge = sponge_hash_gadget(
-        composer,
-        &[*R.x(), *R.y(), *R_prime.x(), *R_prime.y(), h],
-    );
-
-    let sig_1 = scalar_mul(composer, signature.var, GENERATOR_EXTENDED);
-    let sig_2 = scalar_mul(composer, signature.var, GENERATOR_NUMS_EXTENDED);
-
-    let pub_1 = scalar_mul(composer, challenge, ExtendedPoint::from(pk));
-    let pub_2 = scalar_mul(composer, challenge, ExtendedPoint::from(pk_prime));
-
-
-
-}
+// use dusk_plonk::constraint_system::ecc::scalar_mul::fixed_base::scalar_mul;
+// use dusk_plonk::constraint_system::ecc::Point as PlonkPoint;
+// use dusk_plonk::jubjub::{
+//     AffinePoint, ExtendedPoint, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
+// };
+// use dusk_plonk::prelude::*;
+// use plonk_gadgets::AllocatedScalar;
+// use poseidon252::sponge::sponge::sponge_hash_gadget;
+// use std::convert::TryInto;
+//
+// /// Verifies that schnorr signature outputs
+// /// share the same Discrete log
+// pub fn schnorr(
+//     composer: &mut StandardComposer,
+//     signature: AllocatedScalar,
+//     R: PlonkPoint,
+//     R_prime: PlonkPoint,
+//     pk: PlonkPoint,
+//     pk_prime: PlonkPoint,
+//     message: AllocatedScalar,
+// ) {
+//     let h = sponge_hash_gadget(composer, &[message.var]);
+//     let challenge = sponge_hash_gadget(
+//         composer,
+//         &[*R.x(), *R.y(), *R_prime.x(), *R_prime.y(), h],
+//     );
+//
+//     let sig_1 = scalar_mul(composer, signature.var, GENERATOR_EXTENDED);
+//     let sig_2 = scalar_mul(composer, signature.var, GENERATOR_NUMS_EXTENDED);
+//
+//     let pub_1 = scalar_mul(composer, challenge, ExtendedPoint::from(pk));
+//     let pub_2 = scalar_mul(composer, challenge, ExtendedPoint::from(pk_prime));
+// }

--- a/contracts/transfer/circuits/src/gadgets/schnorr.rs
+++ b/contracts/transfer/circuits/src/gadgets/schnorr.rs
@@ -31,9 +31,10 @@ pub fn schnorr_one_key(
     let b = BlsScalar::zero();
     let b = composer.add_witness_to_circuit_description(b);
 
-    let challenge = composer.xor_gate(c,b,252);
+    let challenge = composer.xor_gate(c, b, 252);
 
-    let sig = fixed_base_scalar_mul(composer, signature.var, GENERATOR_EXTENDED);
+    let sig =
+        fixed_base_scalar_mul(composer, signature.var, GENERATOR_EXTENDED);
     let p = variable_base_scalar_mul(composer, challenge, pk);
 
     let add = sig.point().add(composer, *p.point());
@@ -63,9 +64,11 @@ pub fn schnorr_two_keys(
     let b = BlsScalar::zero();
     let b = composer.add_witness_to_circuit_description(b);
 
-    let challenge = composer.xor_gate(c,b,252);
-    let sig_1 = fixed_base_scalar_mul(composer, signature.var, GENERATOR_EXTENDED);
-    let sig_2 = fixed_base_scalar_mul(composer, signature.var, GENERATOR_NUMS_EXTENDED);
+    let challenge = composer.xor_gate(c, b, 252);
+    let sig_1 =
+        fixed_base_scalar_mul(composer, signature.var, GENERATOR_EXTENDED);
+    let sig_2 =
+        fixed_base_scalar_mul(composer, signature.var, GENERATOR_NUMS_EXTENDED);
     let pub_1 = variable_base_scalar_mul(composer, challenge, pk);
     let pub_2 = variable_base_scalar_mul(composer, challenge, pk_prime);
 
@@ -114,9 +117,11 @@ mod schnorr_tests {
 
         let sig_a = AllocatedScalar::allocate(prover.mut_cs(), U.into());
         let R_p = PlonkPoint::from_private_affine(prover.mut_cs(), R);
-        let R_prime_p = PlonkPoint::from_private_affine(prover.mut_cs(), R_prime);
+        let R_prime_p =
+            PlonkPoint::from_private_affine(prover.mut_cs(), R_prime);
         let pk_p = PlonkPoint::from_private_affine(prover.mut_cs(), pk);
-        let pk_prime_p = PlonkPoint::from_private_affine(prover.mut_cs(), pk_prime);
+        let pk_prime_p =
+            PlonkPoint::from_private_affine(prover.mut_cs(), pk_prime);
         let message_a = AllocatedScalar::allocate(prover.mut_cs(), message);
 
         schnorr_two_keys(
@@ -135,9 +140,11 @@ mod schnorr_tests {
         let mut verifier = Verifier::new(b"test");
         let sig = AllocatedScalar::allocate(verifier.mut_cs(), U.into());
         let R = PlonkPoint::from_private_affine(verifier.mut_cs(), R);
-        let R_prime = PlonkPoint::from_private_affine(verifier.mut_cs(), R_prime);
+        let R_prime =
+            PlonkPoint::from_private_affine(verifier.mut_cs(), R_prime);
         let pk = PlonkPoint::from_private_affine(verifier.mut_cs(), pk);
-        let pk_prime = PlonkPoint::from_private_affine(verifier.mut_cs(), pk_prime);
+        let pk_prime =
+            PlonkPoint::from_private_affine(verifier.mut_cs(), pk_prime);
         let message = AllocatedScalar::allocate(verifier.mut_cs(), message);
 
         schnorr_two_keys(
@@ -164,11 +171,7 @@ mod schnorr_tests {
         let r = JubJubScalar::random(&mut rand::thread_rng());
         let R = AffinePoint::from(GENERATOR_EXTENDED * r);
         let h = sponge_hash(&[message]);
-        let c_hash = sponge_hash(&[
-            R.get_x(),
-            R.get_y(),
-            h,
-        ]);
+        let c_hash = sponge_hash(&[R.get_x(), R.get_y(), h]);
         let c = c_hash & BlsScalar::pow_of_2(252).sub(&BlsScalar::one());
         let c = JubJubScalar::from_bytes(&c.to_bytes()).unwrap();
         let U = r - (c * sk);
@@ -184,13 +187,7 @@ mod schnorr_tests {
         let pk_p = PlonkPoint::from_private_affine(prover.mut_cs(), pk);
         let message_a = AllocatedScalar::allocate(prover.mut_cs(), message);
 
-        schnorr_one_key(
-            prover.mut_cs(),
-            sig_a,
-            R_p,
-            pk_p,
-            message_a,
-        );
+        schnorr_one_key(prover.mut_cs(), sig_a, R_p, pk_p, message_a);
         let prover_pi = prover.mut_cs().public_inputs.clone();
         prover.preprocess(&ck)?;
         let proof = prover.prove(&ck)?;
@@ -201,13 +198,7 @@ mod schnorr_tests {
         let pk = PlonkPoint::from_private_affine(verifier.mut_cs(), pk);
         let message = AllocatedScalar::allocate(verifier.mut_cs(), message);
 
-        schnorr_one_key(
-            verifier.mut_cs(),
-            sig,
-            R,
-            pk,
-            message,
-        );
+        schnorr_one_key(verifier.mut_cs(), sig, R, pk, message);
         verifier.preprocess(&ck)?;
         verifier.verify(&proof, &vk, &prover_pi)
     }

--- a/contracts/transfer/circuits/src/gadgets/schnorr.rs
+++ b/contracts/transfer/circuits/src/gadgets/schnorr.rs
@@ -1,39 +1,200 @@
-// // This Source Code Form is subject to the terms of the Mozilla Public
-// // License, v. 2.0. If a copy of the MPL was not distributed with this
-// // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-// //
-// // Copyright (c) DUSK NETWORK. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// use dusk_plonk::constraint_system::ecc::scalar_mul::fixed_base::scalar_mul;
-// use dusk_plonk::constraint_system::ecc::Point as PlonkPoint;
-// use dusk_plonk::jubjub::{
-//     AffinePoint, ExtendedPoint, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
-// };
-// use dusk_plonk::prelude::*;
-// use plonk_gadgets::AllocatedScalar;
-// use poseidon252::sponge::sponge::sponge_hash_gadget;
-// use std::convert::TryInto;
-//
-// /// Verifies that schnorr signature outputs
-// /// share the same Discrete log
-// pub fn schnorr(
-//     composer: &mut StandardComposer,
-//     signature: AllocatedScalar,
-//     R: PlonkPoint,
-//     R_prime: PlonkPoint,
-//     pk: PlonkPoint,
-//     pk_prime: PlonkPoint,
-//     message: AllocatedScalar,
-// ) {
-//     let h = sponge_hash_gadget(composer, &[message.var]);
-//     let challenge = sponge_hash_gadget(
-//         composer,
-//         &[*R.x(), *R.y(), *R_prime.x(), *R_prime.y(), h],
-//     );
-//
-//     let sig_1 = scalar_mul(composer, signature.var, GENERATOR_EXTENDED);
-//     let sig_2 = scalar_mul(composer, signature.var, GENERATOR_NUMS_EXTENDED);
-//
-//     let pub_1 = scalar_mul(composer, challenge, ExtendedPoint::from(pk));
-//     let pub_2 = scalar_mul(composer, challenge, ExtendedPoint::from(pk_prime));
-// }
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_plonk::constraint_system::ecc::scalar_mul::fixed_base::scalar_mul as fixed_base_scalar_mul;
+use dusk_plonk::constraint_system::ecc::scalar_mul::variable_base::variable_base_scalar_mul;
+use dusk_plonk::constraint_system::ecc::Point as PlonkPoint;
+use dusk_plonk::jubjub::{
+    AffinePoint, ExtendedPoint, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
+};
+use dusk_plonk::prelude::*;
+use plonk_gadgets::AllocatedScalar;
+use poseidon252::sponge::sponge::sponge_hash_gadget;
+use std::convert::TryInto;
+
+/// verifies stuff
+pub fn schnorr_one_key(
+    composer: &mut StandardComposer,
+    signature: AllocatedScalar,
+    R: PlonkPoint,
+    pk: PlonkPoint,
+    message: AllocatedScalar,
+) {
+    let h = sponge_hash_gadget(composer, &[message.var]);
+    let challenge = sponge_hash_gadget(composer, &[*R.x(), *R.y(), h]);
+
+    let sig = fixed_base_scalar_mul(composer, signature.var, GENERATOR_EXTENDED);
+    let p = variable_base_scalar_mul(composer, challenge, pk);
+
+    let add = sig.point().add(composer, *p.point());
+    composer.assert_equal_point(add, R);
+}
+
+/// Verifies that schnorr signature outputs
+/// share the same Discrete log
+pub fn schnorr_two_keys(
+    composer: &mut StandardComposer,
+    signature: AllocatedScalar,
+    R: PlonkPoint,
+    R_prime: PlonkPoint,
+    pk: PlonkPoint,
+    pk_prime: PlonkPoint,
+    message: AllocatedScalar,
+) {
+    let h = sponge_hash_gadget(composer, &[message.var]);
+    let challenge = sponge_hash_gadget(
+        composer,
+        &[*R.x(), *R.y(), *R_prime.x(), *R_prime.y(), h],
+    );
+
+    let sig_1 = fixed_base_scalar_mul(composer, signature.var, GENERATOR_EXTENDED);
+    let sig_2 = fixed_base_scalar_mul(composer, signature.var, GENERATOR_NUMS_EXTENDED);
+    let pub_1 = variable_base_scalar_mul(composer, challenge, pk);
+    let pub_2 = variable_base_scalar_mul(composer, challenge, pk_prime);
+
+    let add_1 = sig_1.point().add(composer, *pub_1.point());
+    composer.assert_equal_point(add_1, R);
+    let add_2 = sig_2.point().add(composer, *pub_2.point());
+    composer.assert_equal_point(add_2, R_prime);
+}
+
+#[cfg(test)]
+mod schnorr_tests {
+    use super::*;
+    use anyhow::{Error, Result};
+    use poseidon252::sponge::sponge::sponge_hash;
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn schnorr_gadget() -> Result<(), Error> {
+        // Setup
+        let sk = JubJubScalar::random(&mut rand::thread_rng());
+        let message = BlsScalar::random(&mut rand::thread_rng());
+        let pk = AffinePoint::from(GENERATOR_EXTENDED * sk);
+        let pk_prime = AffinePoint::from(GENERATOR_NUMS_EXTENDED * sk);
+
+        // Signing
+        let r = JubJubScalar::random(&mut rand::thread_rng());
+        let R = AffinePoint::from(GENERATOR_EXTENDED * r);
+        let R_prime = AffinePoint::from(GENERATOR_NUMS_EXTENDED * r);
+        let h = sponge_hash(&[message]);
+        let c_hash = sponge_hash(&[
+            R.get_x(),
+            R.get_y(),
+            R_prime.get_x(),
+            R_prime.get_y(),
+            h,
+        ]);
+        let c = JubJubScalar::from_raw(*c_hash.reduce().internal_repr());
+        let U = r - (c * sk);
+
+        // Generate Composer & Public Parameters
+        let pub_params =
+            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 16)?;
+        let mut prover = Prover::new(b"test");
+
+        let sig_a = AllocatedScalar::allocate(prover.mut_cs(), U.into());
+        let R_p = PlonkPoint::from_private_affine(prover.mut_cs(), R);
+        let R_prime_p = PlonkPoint::from_private_affine(prover.mut_cs(), R_prime);
+        let pk_p = PlonkPoint::from_private_affine(prover.mut_cs(), pk);
+        let pk_prime_p = PlonkPoint::from_private_affine(prover.mut_cs(), pk_prime);
+        let message_a = AllocatedScalar::allocate(prover.mut_cs(), message);
+
+        schnorr_two_keys(
+            prover.mut_cs(),
+            sig_a,
+            R_p,
+            R_prime_p,
+            pk_p,
+            pk_prime_p,
+            message_a,
+        );
+        let prover_pi = prover.mut_cs().public_inputs.clone();
+        prover.preprocess(&ck)?;
+        // prover.mut_cs().check_circuit_satisfied();
+        let proof = prover.prove(&ck)?;
+
+        let mut verifier = Verifier::new(b"test");
+        let sig = AllocatedScalar::allocate(verifier.mut_cs(), U.into());
+        let R = PlonkPoint::from_private_affine(verifier.mut_cs(), R);
+        let R_prime = PlonkPoint::from_private_affine(verifier.mut_cs(), R_prime);
+        let pk = PlonkPoint::from_private_affine(prover.mut_cs(), pk);
+        let pk_prime = PlonkPoint::from_private_affine(prover.mut_cs(), pk_prime);
+        let message = AllocatedScalar::allocate(verifier.mut_cs(), message);
+
+        schnorr_two_keys(
+            verifier.mut_cs(),
+            sig,
+            R,
+            R_prime,
+            pk,
+            pk_prime,
+            message,
+        );
+        verifier.preprocess(&ck)?;
+        verifier.verify(&proof, &vk, &prover_pi)
+    }
+
+    #[test]
+    fn schnorr_gadget_one_key() -> Result<(), Error> {
+        // Setup
+        let sk = JubJubScalar::random(&mut rand::thread_rng());
+        let message = BlsScalar::random(&mut rand::thread_rng());
+        let pk = AffinePoint::from(GENERATOR_EXTENDED * sk);
+
+        // Signing
+        let r = JubJubScalar::random(&mut rand::thread_rng());
+        let R = AffinePoint::from(GENERATOR_EXTENDED * r);
+        let h = sponge_hash(&[message]);
+        let c_hash = sponge_hash(&[
+            R.get_x(),
+            R.get_y(),
+            h,
+        ]);
+        let c = JubJubScalar::from_raw(*c_hash.reduce().internal_repr());
+        let U = r - (c * sk);
+
+        // Generate Composer & Public Parameters
+        let pub_params =
+            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 16)?;
+        let mut prover = Prover::new(b"test");
+
+        let sig_a = AllocatedScalar::allocate(prover.mut_cs(), U.into());
+        let R_p = PlonkPoint::from_private_affine(prover.mut_cs(), R);
+        let pk_p = PlonkPoint::from_private_affine(prover.mut_cs(), pk);
+        let message_a = AllocatedScalar::allocate(prover.mut_cs(), message);
+
+        schnorr_one_key(
+            prover.mut_cs(),
+            sig_a,
+            R_p,
+            pk_p,
+            message_a,
+        );
+        let prover_pi = prover.mut_cs().public_inputs.clone();
+        prover.preprocess(&ck)?;
+        // prover.mut_cs().check_circuit_satisfied();
+        let proof = prover.prove(&ck)?;
+
+        let mut verifier = Verifier::new(b"test");
+        let sig = AllocatedScalar::allocate(verifier.mut_cs(), U.into());
+        let R = PlonkPoint::from_private_affine(verifier.mut_cs(), R);
+        let pk = PlonkPoint::from_private_affine(prover.mut_cs(), pk);
+        let message = AllocatedScalar::allocate(verifier.mut_cs(), message);
+
+        schnorr_one_key(
+            verifier.mut_cs(),
+            sig,
+            R,
+            pk,
+            message,
+        );
+        verifier.preprocess(&ck)?;
+        verifier.verify(&proof, &vk, &prover_pi)
+    }
+}

--- a/contracts/transfer/circuits/src/gadgets/schnorr.rs
+++ b/contracts/transfer/circuits/src/gadgets/schnorr.rs
@@ -31,7 +31,7 @@ pub fn schnorr_one_key(
     let b = BlsScalar::zero();
     let b = composer.add_witness_to_circuit_description(b);
 
-    let challenge = composer.xor_gate(c, b, 252);
+    let challenge = composer.xor_gate(c, b, 250);
 
     let sig =
         fixed_base_scalar_mul(composer, signature.var, GENERATOR_EXTENDED);
@@ -44,7 +44,7 @@ pub fn schnorr_one_key(
 /// Utilises a Schnorr signature scheme,
 /// to prove the knowledge of the discrete
 /// log for given keys in a public key pair.
-/// ALso verifying that both keys share the
+/// Also verifying that both keys share the
 /// same discrete log.
 #[allow(non_snake_case)]
 pub fn schnorr_two_keys(
@@ -64,7 +64,7 @@ pub fn schnorr_two_keys(
     let b = BlsScalar::zero();
     let b = composer.add_witness_to_circuit_description(b);
 
-    let challenge = composer.xor_gate(c, b, 252);
+    let challenge = composer.xor_gate(c, b, 250);
     let sig_1 =
         fixed_base_scalar_mul(composer, signature.var, GENERATOR_EXTENDED);
     let sig_2 =
@@ -105,8 +105,8 @@ mod schnorr_tests {
             R_prime.get_y(),
             h,
         ]);
-        let c = c_hash & BlsScalar::pow_of_2(252).sub(&BlsScalar::one());
-        let c = JubJubScalar::from_bytes(&c.to_bytes()).unwrap();
+        let c_hash = c_hash & BlsScalar::pow_of_2(250).sub(&BlsScalar::one());
+        let c = JubJubScalar::from_bytes(&c_hash.to_bytes()).unwrap();
         let U = r - (c * sk);
 
         // Generate Composer & Public Parameters
@@ -161,6 +161,7 @@ mod schnorr_tests {
     }
 
     #[test]
+    #[allow(non_snake_case)]
     fn schnorr_gadget_one_key() -> Result<(), Error> {
         // Setup
         let sk = JubJubScalar::random(&mut rand::thread_rng());
@@ -172,8 +173,8 @@ mod schnorr_tests {
         let R = AffinePoint::from(GENERATOR_EXTENDED * r);
         let h = sponge_hash(&[message]);
         let c_hash = sponge_hash(&[R.get_x(), R.get_y(), h]);
-        let c = c_hash & BlsScalar::pow_of_2(252).sub(&BlsScalar::one());
-        let c = JubJubScalar::from_bytes(&c.to_bytes()).unwrap();
+        let c_hash = c_hash & BlsScalar::pow_of_2(250).sub(&BlsScalar::one());
+        let c = JubJubScalar::from_bytes(&c_hash.to_bytes()).unwrap();
         let U = r - (c * sk);
 
         // Generate Composer & Public Parameters

--- a/contracts/transfer/circuits/src/gadgets/schnorr.rs
+++ b/contracts/transfer/circuits/src/gadgets/schnorr.rs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_plonk::constraint_system::ecc::scalar_mul::fixed_base::scalar_mul;
+use dusk_plonk::constraint_system::ecc::Point as PlonkPoint;
+use dusk_plonk::jubjub::{
+    AffinePoint, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED, ExtendedPoint
+};
+use dusk_plonk::prelude::*;
+use plonk_gadgets::AllocatedScalar;
+use poseidon252::sponge::sponge::sponge_hash_gadget;
+use std::convert::TryInto;
+
+/// Verifies that schnorr signature outputs
+/// share the same Discrete log
+pub fn schnorr(
+    composer: &mut StandardComposer,
+    signature: AllocatedScalar,
+    R: PlonkPoint,
+    R_prime: PlonkPoint,
+    pk: PlonkPoint,
+    pk_prime: PlonkPoint,
+    message: AllocatedScalar,
+) {
+    let h = sponge_hash_gadget(composer, &[message.var]);
+    let challenge = sponge_hash_gadget(
+        composer,
+        &[*R.x(), *R.y(), *R_prime.x(), *R_prime.y(), h],
+    );
+
+    let sig_1 = scalar_mul(composer, signature.var, GENERATOR_EXTENDED);
+    let sig_2 = scalar_mul(composer, signature.var, GENERATOR_NUMS_EXTENDED);
+
+    let pub_1 = scalar_mul(composer, challenge, ExtendedPoint::from(pk));
+    let pub_2 = scalar_mul(composer, challenge, ExtendedPoint::from(pk_prime));
+
+
+
+}

--- a/contracts/transfer/circuits/src/gadgets/secret_key.rs
+++ b/contracts/transfer/circuits/src/gadgets/secret_key.rs
@@ -23,7 +23,7 @@ pub fn sk_knowledge(
 }
 
 #[cfg(test)]
-mod commitment_tests {
+mod secret_key_tests {
     use super::*;
     use anyhow::{Error, Result};
     use dusk_plonk::commitment_scheme::kzg10::PublicParameters;


### PR DESCRIPTION
As per the refactor required in the dusk contract, this PR will address the gadgets which permeate the circuits.

The first of these is the inner workings of the preimage gadget, which cannot be tied to the note in the current specs. This PR will refactor the the preimage gadget and its uses within rust.
The second is a schnorr signature gadget, which allows us to prove the knowledge of DLP given a signature.

This closes #124. 
