### PR TITLE
Lock nightly toolchain version in CI

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2020-10-25
           override: true
       - run: rustup component add rustfmt
       - run: rustup target add wasm32-unknown-unknown
@@ -68,7 +68,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2020-10-25
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ tonic = "0.3"
 tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.10.0"}
 dusk-plonk = "0.3.1"
-dusk-blindbid = {git = "https://github.com/dusk-network/dusk-blindbid", tag = "v0.3.0"}
-dusk-pki = {git = "https://github.com/dusk-network/dusk-pki/", tag = "v0.2.0"}
-phoenix-core = { git = "https://github.com/dusk-network/phoenix-core", tag = "v0.3.0" }
+dusk-blindbid = {git = "https://github.com/dusk-network/dusk-blindbid", branch = "lukes_update"}
+dusk-pki = {git = "https://github.com/dusk-network/dusk-pki/", tag = "v0.3.0"}
+phoenix-core = { git = "https://github.com/dusk-network/phoenix-core", branch = "lukes_update" }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 clap = "2.33.3"
@@ -46,11 +46,11 @@ rusk-profile = { path = "./profile" }
 tonic-build = "0.3"
 rustc_tools_util = "0.2"
 dusk-plonk = "0.3.1"
-dusk-blindbid = {git = "https://github.com/dusk-network/dusk-blindbid", tag = "v0.3.0"}
+dusk-blindbid = {git = "https://github.com/dusk-network/dusk-blindbid", branch = "lukes_update"}
 anyhow = "1.0"
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.10.0"}
-dusk-pki = {git = "https://github.com/dusk-network/dusk-pki/", tag = "v0.2.0"}
-phoenix-core = { git = "https://github.com/dusk-network/phoenix-core", tag = "v0.3.0" }
+dusk-pki = {git = "https://github.com/dusk-network/dusk-pki/", tag = "v0.3.0"}
+phoenix-core = { git = "https://github.com/dusk-network/phoenix-core", branch = "lukes_update" }
 kelvin = "0.19.0"
 nstack = "0.5.0"
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ tonic = "0.3"
 tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.10.0"}
 dusk-plonk = "0.3.1"
-dusk-blindbid = {git = "https://github.com/dusk-network/dusk-blindbid", branch = "lukes_update"}
+dusk-blindbid = {git = "https://github.com/dusk-network/dusk-blindbid", tag = "v0.4.0-alpha"}
 dusk-pki = {git = "https://github.com/dusk-network/dusk-pki/", tag = "v0.3.0"}
-phoenix-core = { git = "https://github.com/dusk-network/phoenix-core", branch = "lukes_update" }
+phoenix-core = { git = "https://github.com/dusk-network/phoenix-core", tag = "v0.4.0-alpha" }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 clap = "2.33.3"
@@ -46,11 +46,11 @@ rusk-profile = { path = "./profile" }
 tonic-build = "0.3"
 rustc_tools_util = "0.2"
 dusk-plonk = "0.3.1"
-dusk-blindbid = {git = "https://github.com/dusk-network/dusk-blindbid", branch = "lukes_update"}
+dusk-blindbid = {git = "https://github.com/dusk-network/dusk-blindbid", tag = "v0.4.0-alpha"}
 anyhow = "1.0"
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.10.0"}
 dusk-pki = {git = "https://github.com/dusk-network/dusk-pki/", tag = "v0.3.0"}
-phoenix-core = { git = "https://github.com/dusk-network/phoenix-core", branch = "lukes_update" }
+phoenix-core = { git = "https://github.com/dusk-network/phoenix-core", tag = "v0.4.0-alpha" }
 kelvin = "0.19.0"
 nstack = "0.5.0"
 rand = "0.7"

--- a/contracts/bid/circuits/Cargo.toml
+++ b/contracts/bid/circuits/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2018"
 anyhow = "^1.0.0"
 dusk-plonk = "0.3.1"
 plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.4.0"}
-dusk-blindbid = { git = "https://github.com/dusk-network/dusk-blindbid", tag = "v0.3.0" }
+dusk-blindbid = { git = "https://github.com/dusk-network/dusk-blindbid", branch = "lukes_update" }
 rand = "0.7"

--- a/contracts/bid/circuits/Cargo.toml
+++ b/contracts/bid/circuits/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2018"
 anyhow = "^1.0.0"
 dusk-plonk = "0.3.1"
 plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.4.0"}
-dusk-blindbid = { git = "https://github.com/dusk-network/dusk-blindbid", branch = "lukes_update" }
+dusk-blindbid = { git = "https://github.com/dusk-network/dusk-blindbid", tag = "v0.4.0-alpha" }
 rand = "0.7"

--- a/contracts/transfer/circuits/Cargo.toml
+++ b/contracts/transfer/circuits/Cargo.toml
@@ -12,6 +12,6 @@ poseidon252 = { git = "https://github.com/dusk-network/Poseidon252" , tag = "v0.
 rand = "0.7"
 kelvin = "0.19"
 plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.4.0"}
-dusk-pki = { git = "https://github.com/dusk-network/dusk-pki", tag = "v0.2.0" }
+dusk-pki = { git = "https://github.com/dusk-network/dusk-pki", tag = "v0.3.0" }
 anyhow = "1.0"
 dusk-plonk = {version = "0.3.1", features = ["trace-print"]}


### PR DESCRIPTION
This avoids errors when attempting to download and install rustfmt.