### PR TITLE
Replace `Default` for to/from of TxPayload and Tx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   "CPerezz <carlos@dusk.network>", 
   "zer0 <matteo@dusk.network>", 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk"
-version = "0.1.1"
+version = "0.1.0"
 authors = [
   "CPerezz <carlos@dusk.network>", 
   "zer0 <matteo@dusk.network>", 

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,6 @@
 #![allow(non_snake_case)]
 use anyhow::Result;
 use bid_circuits::CorrectnessCircuit;
-use canonical_host::MemStore;
 use dusk_blindbid::{bid::Bid, BlindBidCircuit};
 use dusk_pki::{Ownable, PublicSpendKey, SecretSpendKey};
 use dusk_plonk::circuit_builder::Circuit;

--- a/src/lib/encoding.rs
+++ b/src/lib/encoding.rs
@@ -95,7 +95,7 @@ impl From<&StealthAddress> for rusk_proto::StealthAddress {
 
 impl From<&Transaction> for rusk_proto::Transaction {
     fn from(value: &Transaction) -> Self {
-        let buf = value.payload.into_bytes();
+        let buf = value.payload.to_bytes();
 
         rusk_proto::Transaction {
             version: value.version.into(),

--- a/src/lib/encoding.rs
+++ b/src/lib/encoding.rs
@@ -95,7 +95,7 @@ impl From<&StealthAddress> for rusk_proto::StealthAddress {
 
 impl From<&Transaction> for rusk_proto::Transaction {
     fn from(value: &Transaction) -> Self {
-        let buf = value.payload.to_bytes();
+        let buf = value.payload.into_bytes();
 
         rusk_proto::Transaction {
             version: value.version.into(),

--- a/src/lib/encoding.rs
+++ b/src/lib/encoding.rs
@@ -14,8 +14,7 @@ use dusk_pki::{
 use dusk_plonk::jubjub::JubJubAffine;
 use dusk_plonk::prelude::*;
 use std::convert::TryInto;
-use std::io::{Read, Write};
-use tonic::Status;
+use tonic::{Code, Status};
 
 /// Wrapper over `jubjub_decode` fn
 pub(crate) fn decode_affine(bytes: &[u8]) -> Result<JubJubAffine, Status> {
@@ -94,19 +93,23 @@ impl From<&StealthAddress> for rusk_proto::StealthAddress {
     }
 }
 
+impl From<&Transaction> for rusk_proto::Transaction {
+    fn from(value: &Transaction) -> Self {
+        let buf = value.payload.to_bytes();
+
+        rusk_proto::Transaction {
+            version: value.version.into(),
+            r#type: value.tx_type.into(),
+            payload: buf,
+        }
+    }
+}
+
 impl TryFrom<&mut Transaction> for rusk_proto::Transaction {
     type Error = Status;
 
     fn try_from(value: &mut Transaction) -> Result<Self, Status> {
-        let mut buf = vec![0u8; 4096];
-        let n = value.payload.read(&mut buf)?;
-        buf.truncate(n);
-
-        Ok(rusk_proto::Transaction {
-            version: value.version.into(),
-            r#type: value.tx_type.into(),
-            payload: buf,
-        })
+        Ok(rusk_proto::Transaction::from(&*value))
     }
 }
 
@@ -169,8 +172,10 @@ impl TryFrom<&mut rusk_proto::Transaction> for Transaction {
     fn try_from(
         value: &mut rusk_proto::Transaction,
     ) -> Result<Transaction, Status> {
-        let mut payload = TransactionPayload::default();
-        let _ = payload.write(&value.payload)?;
+        let payload = TransactionPayload::from_bytes(value.payload.as_slice())
+            .map_err(|e| {
+                Status::new(Code::InvalidArgument, format!("{}", e))
+            })?;
 
         Ok(Transaction {
             version: value

--- a/src/lib/transaction.rs
+++ b/src/lib/transaction.rs
@@ -30,10 +30,10 @@ impl Transaction {
         }
     }
 
-    pub fn into_bytes(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = vec![self.version, self.tx_type];
 
-        bytes.extend_from_slice(&self.payload.into_bytes());
+        bytes.extend_from_slice(&self.payload.to_bytes());
 
         bytes
     }
@@ -84,7 +84,7 @@ impl TransactionPayload {
         }
     }
 
-    pub fn into_bytes(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = vec![];
 
         bytes.extend_from_slice(&self.anchor.to_bytes());
@@ -293,7 +293,7 @@ impl Write for Transaction {
 
 impl Read for TransactionPayload {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let bytes = self.into_bytes();
+        let bytes = self.to_bytes();
         let l = bytes.len();
 
         if buf.len() < l {
@@ -317,7 +317,7 @@ impl Write for TransactionPayload {
 
         mem::swap(&mut tx, self);
 
-        let l = self.into_bytes().len();
+        let l = self.to_bytes().len();
 
         Ok(l)
     }
@@ -429,7 +429,7 @@ mod tests {
     fn transaction_read_write() -> Result<()> {
         let mut tx = deterministic_tx();
 
-        let buf = tx.into_bytes();
+        let buf = tx.to_bytes();
         let decoded_tx = Transaction::from_bytes(&buf)?;
 
         assert_eq!(tx, decoded_tx);


### PR DESCRIPTION
No implementation of `Default` is possible for a transaction due to the internal keys that must derive from a provided random number generator.

These default implementations are currently used only for serialization purposes. An implementation of to/from bytes will fix that.