### PR TITLE
Update CRS generation and rusk-profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ phoenix-core = {git="https://github.com/dusk-network/phoenix-core", tag = "v0.7.
 anyhow = "1.0"
 rand = "0.7"
 bid-circuits = {path ="./contracts/bid/circuits"}
-transfer-circuits = {path ="./contracts/transfer/circuits", features=["builder"]}
+transfer-circuits = {path ="./contracts/transfer/circuits", features=["builder", "builder-no-rusk-profile-keys"]}
 rusk-profile = { path = "./profile" }
 lazy_static = "1.4"
 canonical = "0.5"

--- a/contracts/transfer/circuits/src/builder.rs
+++ b/contracts/transfer/circuits/src/builder.rs
@@ -222,9 +222,11 @@ where
         })?;
 
         let keys = rusk_profile::keys_for(env!("CARGO_PKG_NAME"));
-        let (pk, vk) = keys
-            .get(id)
-            .ok_or(anyhow!("Failed to get keys from Rusk profile"))?;
+        let (pk, vk) = keys.get(id).ok_or(anyhow!(
+            "Failed to get '{}' keys for '{}' from Rusk profile",
+            id,
+            env!("CARGO_PKG_NAME")
+        ))?;
 
         let pk = ProverKey::from_bytes(pk.as_slice())?;
         let vk = VerifierKey::from_bytes(vk.as_slice())?;


### PR DESCRIPTION
- Change `set_common_reference_string` to accept a buffer instead a path
- Change `get_common_reference_string` to fail if the cached file's hash
  does not match with the expected one
- Change CRS generation in build script to use a seedable rng
- Change `build.rs` to re-run even if only the script itself is updated
- Change `build.rs` to enforce `PUB_PARAMS` initialization despite the
  keys generation