### PR TITLE
    Decouple the CRS integrity check from `get_common_reference_string`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,13 +19,13 @@ use lazy_static::lazy_static;
 lazy_static! {
     static ref PUB_PARAMS: PublicParameters = {
         match rusk_profile::get_common_reference_string() {
-            Ok(buff) => unsafe {
+            Ok(buff) if rusk_profile::verify_common_reference_string(&buff) => unsafe {
                 println!("Got the CRS from cache");
 
                 PublicParameters::from_slice_unchecked(&buff[..])
                     .expect("Cannot deserialize the CRS")
             },
-            Err(_) => {
+            Ok(_) | Err(_) => {
                 println!("New CRS needs to be generated and cached");
 
                 use rand::rngs::StdRng;

--- a/profile/Cargo.toml
+++ b/profile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-profile"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["zer0 <matteo@dusk.network>"]
 edition = "2018"
 autobins = false

--- a/profile/src/lib.rs
+++ b/profile/src/lib.rs
@@ -181,6 +181,14 @@ pub fn delete_common_reference_string() -> Result<(), io::Error> {
     Ok(())
 }
 
+pub fn verify_common_reference_string(buff: &[u8]) -> bool {
+    let mut hasher = Sha256::new();
+    hasher.update(&buff);
+    let hash = format!("{:x}", hasher.finalize());
+
+    hash == CRS_17
+}
+
 pub fn keys_for(crate_name: &str) -> Keys {
     use cargo_lock::{Lockfile, Package};
     let lockfile = Lockfile::load("./Cargo.lock").unwrap();


### PR DESCRIPTION
- Remove the integrity check from `get_common_reference_string`
- Add `verify_common_reference_string` to perform the integrity check
- Change `build.rs`

Resolves: #200