### PR TITLE
Complete decoupling of `get_common_reference_string`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -36,9 +36,12 @@ lazy_static! {
                 let pp_p = PublicParameters::setup(1 << 17, &mut rng)
                     .expect("Cannot initialize Public Parameters");
 
+                println!("Public Parameters initialized");
+
                 rusk_profile::set_common_reference_string(pp_p.to_raw_bytes())
                     .expect("Unable to write the CRS");
 
+                println!("CRS cached");
                 pp_p
             }
         }

--- a/profile/src/lib.rs
+++ b/profile/src/lib.rs
@@ -149,20 +149,7 @@ pub fn get_common_reference_string() -> Result<Vec<u8>, io::Error> {
     let mut profile = get_rusk_profile_dir()?;
     profile.push("dev.crs");
 
-    let buff = read(profile)?;
-
-    let mut hasher = Sha256::new();
-    hasher.update(&buff);
-    let hash = format!("{:x}", hasher.finalize());
-
-    if hash == CRS_17 {
-        Ok(buff)
-    } else {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "Cached CRS does not match the expected one",
-        ))
-    }
+    read(profile)
 }
 
 pub fn set_common_reference_string(buffer: Vec<u8>) -> Result<(), io::Error> {


### PR DESCRIPTION
The code of the integrity check was properly added to the new function
`verify_common_reference_string` but was still kept in the function
`get_common_reference_string` of `rusk_profile`.
This PR removes the check from `get_common_reference_string`.

See also: #200