### PR TITLE
Remove for loops for sub-make calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-CONTRACTS := $(wildcard ./contracts/*/.)
-CIRCUITS := $(wildcard ./circuits/*/.)
-
 help: ## Display this help screen
-	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@grep -h \
+		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 abi: ## Build the ABI and test it
 	$(MAKE) -C ./rusk-abi test
@@ -11,21 +10,15 @@ keys: ## Create the keys for the circuits
 	$(MAKE) -C ./rusk keys
 
 wasm: ## Generate the WASM for all the contracts
-	for dir in $(CONTRACTS); do \
-        $(MAKE) -C $$dir $@ ; \
-    done
+	$(MAKE) -C ./contracts wasm
 
 circuits: ## Build and test circuit crates
-	for dir in $(CIRCUITS); do \
-        $(MAKE) -C $$dir test ; \
-    done
+	$(MAKE) -C ./circuits test
 
-contracts: wasm ## Execute the test for all contracts
-	for dir in $(CONTRACTS); do \
-        $(MAKE) -C $$dir test ; \
-    done
+contracts: ## Execute the test for all contracts
+	$(MAKE) -C ./contracts test
 
-test: abi wasm circuits contracts ## Run the tests
+test: abi circuits contracts ## Run the tests
 	$(MAKE) -C ./rusk/ $@
 	
 run: wasm ## Run the server

--- a/circuits/Makefile
+++ b/circuits/Makefile
@@ -1,0 +1,13 @@
+SUBDIRS := $(wildcard ./*/.)
+
+help: ## Display this help screen
+	@grep -h \
+		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+test: $(SUBDIRS) ## Run all the tests in the subfolder
+
+$(SUBDIRS):
+	$(MAKE) -C $@ $(MAKECMDGOALS)
+
+.PHONY: test help $(SUBDIRS)

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -1,0 +1,15 @@
+SUBDIRS := $(wildcard ./*/.)
+
+help: ## Display this help screen
+	@grep -h \
+		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+test: $(SUBDIRS) ## Run all the tests in the subfolder
+
+wasm: $(SUBDIRS) ## Generate the WASM for all the contracts
+
+$(SUBDIRS):
+	$(MAKE) -C $@ $(MAKECMDGOALS)
+
+.PHONY: test help $(SUBDIRS)


### PR DESCRIPTION
There are various potential problem with doing the sub-make inside a for
loop for a single recipe (e.g. might not exit on failure or not properly
supporting `--keep-going`, as well as parallel builds acresso multiple
directories; etc.)