### PR TITLE
Transfer Circuits - From public inputs

### DIFF
--- a/circuits/transfer/Cargo.toml
+++ b/circuits/transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-circuits"
-version = "0.1.2"
+version = "0.1.1"
 authors = ["Bounce23 <luke@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2018"
 

--- a/circuits/transfer/Cargo.toml
+++ b/circuits/transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-circuits"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Bounce23 <luke@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2018"
 

--- a/circuits/transfer/src/execute.rs
+++ b/circuits/transfer/src/execute.rs
@@ -47,6 +47,24 @@ pub struct ExecuteCircuit<const DEPTH: usize, const CAPACITY: usize> {
     pub tx_hash: BlsScalar,
 }
 
+impl<const DEPTH: usize, const CAPACITY: usize> From<&[PublicInput]>
+    for ExecuteCircuit<DEPTH, CAPACITY>
+{
+    // TODO
+    // This should be removed after the `Circuit` trait of PLONK is refactored.
+    //
+    // Also, this implementation should be `TryFrom` - this is only a temporary
+    // workaround to allow host verification. The invalid public points will
+    // just be ignored.
+    //
+    // This implementation intentionally don't benefit from `Default` because
+    // both need to be removed in the short term and its better if they are
+    // completely decoupled
+    fn from(_pi: &[PublicInput]) -> Self {
+        todo!()
+    }
+}
+
 impl<const DEPTH: usize, const CAPACITY: usize>
     ExecuteCircuit<DEPTH, CAPACITY>
 {


### PR DESCRIPTION
Closes #225

Currently, the PLONK circuit API relies on a valid instance to
set the correct public inputs positions so it can run proofs.

The host must be agnostic of the circuit instance because the
public inputs exists only on the contract scope. But, it still
need the circuit instance to call the verify methods of the
plonk traits.