### PR TITLE
ABI `verify_proof` with Plonk VerifierData

### DIFF
--- a/rusk-abi/CHANGELOG.md
+++ b/rusk-abi/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Change `verify_proof` to accept verifier data [#247]
+
 ## [0.2.0] - 2021-03-12
 
 ### Added

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -24,7 +24,7 @@ dusk-pki = { version = "0.6", default-features = false, features = ["canon"] }
 dusk-jubjub = { version = "0.8", default-features = false, features = ["canon"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-dusk-plonk = { version = "0.6", default-features = false, features = ["canon"] }
+dusk-plonk = { version = "0.7.0-pre", default-features = false, features = ["canon"] }
 rusk-profile = { path = "../rusk-profile", version = "0.3" }
 dusk-bytes = "0.1"
 

--- a/rusk-abi/src/hosted.rs
+++ b/rusk-abi/src/hosted.rs
@@ -26,13 +26,12 @@ pub fn poseidon_hash(scalars: Vec<BlsScalar>) -> BlsScalar {
 
 pub fn verify_proof(
     proof: Vec<u8>,
-    vk: Vec<u8>,
-    pi_values: Vec<PublicInput>,
-    pi_positions: Vec<u32>,
+    verifier_data: Vec<u8>,
+    pi: Vec<PublicInput>,
 ) -> bool {
     dusk_abi::query(
         &RuskModule::id(),
-        &(RuskModule::VERIFY_PROOF, proof, vk, pi_values, pi_positions),
+        &(RuskModule::VERIFY_PROOF, proof, verifier_data, pi),
     )
     .expect("query RuskModule for verify a proof should not fail")
 }

--- a/rusk-abi/src/lib.rs
+++ b/rusk-abi/src/lib.rs
@@ -16,13 +16,16 @@
 #![no_std]
 #![deny(clippy::all)]
 
-use canonical::Canon;
-use canonical_derive::Canon;
 use dusk_abi::{ContractId, Module};
-use dusk_bls12_381::BlsScalar;
-use dusk_jubjub::{JubJubAffine, JubJubScalar};
+
+mod public_input;
+
+pub use public_input::PublicInput;
 
 /// Module that exports the ABI for Rusk's Contracts
+///
+/// Any proof to be verified with this module should use `b"dusk-network` as
+/// transcript initialization
 #[allow(dead_code)]
 pub struct RuskModule<S> {
     store: S,
@@ -44,17 +47,6 @@ impl<S> Module for RuskModule<S> {
     fn id() -> ContractId {
         ContractId::reserved(77)
     }
-}
-
-/// Enum that represents all possible types of public inputs
-#[derive(Canon, Clone)]
-pub enum PublicInput {
-    /// A Public Input Point
-    Point(JubJubAffine),
-    /// A Public Input BLS Scalar
-    BlsScalar(BlsScalar),
-    /// A Public Input JubJub Scalar
-    JubJubScalar(JubJubScalar),
 }
 
 cfg_if::cfg_if! {

--- a/rusk-abi/src/public_input.rs
+++ b/rusk-abi/src/public_input.rs
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use canonical::Canon;
+use canonical_derive::Canon;
+use dusk_bls12_381::BlsScalar;
+use dusk_jubjub::{JubJubAffine, JubJubScalar};
+
+/// Enum that represents all possible types of public inputs
+#[derive(Canon, Clone)]
+pub enum PublicInput {
+    /// A Public Input Point
+    Point(JubJubAffine),
+    /// A Public Input BLS Scalar
+    BlsScalar(BlsScalar),
+    /// A Public Input JubJub Scalar
+    JubJubScalar(JubJubScalar),
+}
+
+impl From<BlsScalar> for PublicInput {
+    fn from(s: BlsScalar) -> PublicInput {
+        Self::BlsScalar(s)
+    }
+}
+
+impl From<JubJubScalar> for PublicInput {
+    fn from(s: JubJubScalar) -> PublicInput {
+        Self::JubJubScalar(s)
+    }
+}
+
+impl From<JubJubAffine> for PublicInput {
+    fn from(p: JubJubAffine) -> PublicInput {
+        Self::Point(p)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod host {
+    use super::PublicInput;
+    use dusk_plonk::prelude::*;
+
+    impl Into<PublicInputValue> for PublicInput {
+        fn into(self) -> PublicInputValue {
+            match self {
+                PublicInput::BlsScalar(v) => PublicInputValue::from(v),
+                PublicInput::JubJubScalar(v) => PublicInputValue::from(v),
+                PublicInput::Point(v) => PublicInputValue::from(v),
+            }
+        }
+    }
+}

--- a/rusk-abi/tests/contracts/host_fn/src/lib.rs
+++ b/rusk-abi/tests/contracts/host_fn/src/lib.rs
@@ -56,11 +56,10 @@ mod hosted {
         pub fn verify(
             &self,
             proof: Vec<u8>,
-            vk: Vec<u8>,
+            verifier_data: Vec<u8>,
             pi_values: Vec<PublicInput>,
-            pi_positions: Vec<u32>,
         ) -> bool {
-            rusk_abi::verify_proof(proof, vk, pi_values, pi_positions)
+            rusk_abi::verify_proof(proof, verifier_data, pi_values)
         }
 
         pub fn schnorr_signature(
@@ -103,12 +102,11 @@ mod hosted {
 
             VERIFY => {
                 let proof: Vec<u8> = Canon::<BS>::read(&mut source)?;
-                let vk: Vec<u8> = Canon::<BS>::read(&mut source)?;
+                let verifier_data: Vec<u8> = Canon::<BS>::read(&mut source)?;
                 let pi_values: Vec<rusk_abi::PublicInput> =
                     Canon::<BS>::read(&mut source)?;
-                let pi_positions: Vec<u32> = Canon::<BS>::read(&mut source)?;
 
-                let ret = slf.verify(proof, vk, pi_values, pi_positions);
+                let ret = slf.verify(proof, verifier_data, pi_values);
 
                 let r = {
                     // return value


### PR DESCRIPTION
Resolves #247

The verifier key was upgraded to contain also the public input positions
to avoid unnecessary complexity while building the static data of the
used circuits.

This change is transparent to the users of plonk library, so we needed
to remove the public inputs positions as a parameter of the ABI and
treat the verifier agnostically as a vec of u8.