### PR TITLE
Change `verify_proof` to accept verifier data

### DIFF
--- a/rusk-abi/CHANGELOG.md
+++ b/rusk-abi/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Change `verify_proof` to accept verifier data [#247]
+
 ## [0.2.0] - 2021-03-12
 
 ### Added

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -24,7 +24,7 @@ dusk-pki = { version = "0.6", default-features = false, features = ["canon"] }
 dusk-jubjub = { version = "0.8", default-features = false, features = ["canon"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-dusk-plonk = { version = "0.6", default-features = false, features = ["canon"] }
+dusk-plonk = { version = "0.7.0-pre", default-features = false, features = ["canon"] }
 rusk-profile = { path = "../rusk-profile", version = "0.3" }
 dusk-bytes = "0.1"
 

--- a/rusk-abi/src/host.rs
+++ b/rusk-abi/src/host.rs
@@ -7,17 +7,26 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use canonical::{ByteSource, Canon, Store};
+use canonical::{ByteSource, Canon, InvalidEncoding, Store};
 use dusk_abi::{HostModule, Query, ReturnValue};
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::DeserializableSlice;
 use dusk_pki::PublicKey;
-use dusk_plonk::circuit;
+use dusk_plonk::circuit::{self, VerifierData};
 use dusk_plonk::prelude::*;
 use schnorr::Signature;
 
-use crate::PublicInput;
-use crate::RuskModule;
+use crate::{PublicInput, RuskModule};
+
+impl Into<PublicInputValue> for PublicInput {
+    fn into(self) -> PublicInputValue {
+        match self {
+            PublicInput::BlsScalar(v) => PublicInputValue::from(v),
+            PublicInput::JubJubScalar(v) => PublicInputValue::from(v),
+            PublicInput::Point(v) => PublicInputValue::from(v),
+        }
+    }
+}
 
 impl<S> RuskModule<S>
 where
@@ -47,35 +56,25 @@ where
 
             Self::VERIFY_PROOF => {
                 let proof: Vec<u8> = Canon::<S>::read(&mut source)?;
-                let vk: Vec<u8> = Canon::<S>::read(&mut source)?;
-                let pi_values: Vec<PublicInput> =
-                    Canon::<S>::read(&mut source)?;
-                let pi_positions: Vec<u32> = Canon::<S>::read(&mut source)?;
+                let verifier_data: Vec<u8> = Canon::<S>::read(&mut source)?;
+                let pi: Vec<PublicInput> = Canon::<S>::read(&mut source)?;
 
-                let pi_positions: Vec<_> =
-                    pi_positions.iter().map(|i| *i as usize).collect();
+                let proof = Proof::from_slice(&proof)
+                    .map_err(|_| InvalidEncoding.into())?;
 
-                let vk = VerifierKey::from_slice(&vk[..]).expect("a Key");
+                let verifier_data =
+                    VerifierData::from_slice(verifier_data.as_slice())
+                        .map_err(|_| InvalidEncoding.into())?;
 
-                let proof = Proof::from_slice(&proof).expect("a Proof");
-
-                let pi_values: Vec<PublicInputValue> = pi_values
-                    .iter()
-                    .map(|pi| match *pi {
-                        PublicInput::BlsScalar(v) => PublicInputValue::from(v),
-                        PublicInput::JubJubScalar(v) => {
-                            PublicInputValue::from(v)
-                        }
-                        PublicInput::Point(v) => PublicInputValue::from(v),
-                    })
-                    .collect();
+                let pi: Vec<PublicInputValue> =
+                    pi.into_iter().map(|pi| pi.into()).collect();
 
                 let ret = circuit::verify_proof(
                     &self.pp,
-                    &vk,
+                    verifier_data.key(),
                     &proof,
-                    &pi_values[..],
-                    &pi_positions[..],
+                    pi.as_slice(),
+                    verifier_data.pi_pos().as_slice(),
                     b"dusk-network",
                 )
                 .is_ok();

--- a/rusk-abi/src/hosted.rs
+++ b/rusk-abi/src/hosted.rs
@@ -26,13 +26,12 @@ pub fn poseidon_hash(scalars: Vec<BlsScalar>) -> BlsScalar {
 
 pub fn verify_proof(
     proof: Vec<u8>,
-    vk: Vec<u8>,
-    pi_values: Vec<PublicInput>,
-    pi_positions: Vec<u32>,
+    verifier_data: Vec<u8>,
+    pi: Vec<PublicInput>,
 ) -> bool {
     dusk_abi::query(
         &RuskModule::id(),
-        &(RuskModule::VERIFY_PROOF, proof, vk, pi_values, pi_positions),
+        &(RuskModule::VERIFY_PROOF, proof, verifier_data, pi),
     )
     .expect("query RuskModule for verify a proof should not fail")
 }

--- a/rusk-abi/src/lib.rs
+++ b/rusk-abi/src/lib.rs
@@ -23,6 +23,9 @@ use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{JubJubAffine, JubJubScalar};
 
 /// Module that exports the ABI for Rusk's Contracts
+///
+/// Any proof to be verified with this module should use `b"dusk-network` as
+/// transcript initialization
 #[allow(dead_code)]
 pub struct RuskModule<S> {
     store: S,
@@ -55,6 +58,24 @@ pub enum PublicInput {
     BlsScalar(BlsScalar),
     /// A Public Input JubJub Scalar
     JubJubScalar(JubJubScalar),
+}
+
+impl From<BlsScalar> for PublicInput {
+    fn from(s: BlsScalar) -> PublicInput {
+        Self::BlsScalar(s)
+    }
+}
+
+impl From<JubJubScalar> for PublicInput {
+    fn from(s: JubJubScalar) -> PublicInput {
+        Self::JubJubScalar(s)
+    }
+}
+
+impl From<JubJubAffine> for PublicInput {
+    fn from(p: JubJubAffine) -> PublicInput {
+        Self::Point(p)
+    }
 }
 
 cfg_if::cfg_if! {

--- a/rusk-abi/tests/contracts/host_fn/src/lib.rs
+++ b/rusk-abi/tests/contracts/host_fn/src/lib.rs
@@ -56,11 +56,10 @@ mod hosted {
         pub fn verify(
             &self,
             proof: Vec<u8>,
-            vk: Vec<u8>,
+            verifier_data: Vec<u8>,
             pi_values: Vec<PublicInput>,
-            pi_positions: Vec<u32>,
         ) -> bool {
-            rusk_abi::verify_proof(proof, vk, pi_values, pi_positions)
+            rusk_abi::verify_proof(proof, verifier_data, pi_values)
         }
 
         pub fn schnorr_signature(
@@ -103,12 +102,11 @@ mod hosted {
 
             VERIFY => {
                 let proof: Vec<u8> = Canon::<BS>::read(&mut source)?;
-                let vk: Vec<u8> = Canon::<BS>::read(&mut source)?;
+                let verifier_data: Vec<u8> = Canon::<BS>::read(&mut source)?;
                 let pi_values: Vec<rusk_abi::PublicInput> =
                     Canon::<BS>::read(&mut source)?;
-                let pi_positions: Vec<u32> = Canon::<BS>::read(&mut source)?;
 
-                let ret = slf.verify(proof, vk, pi_values, pi_positions);
+                let ret = slf.verify(proof, verifier_data, pi_values);
 
                 let r = {
                     // return value


### PR DESCRIPTION
Resolves #247

To improve the build process of the static data of circuits by avoiding
code complexity, the verifier key was upgraded to contain both the
verifier key and the public inputs positions into a new structure called
verifier data.

This change is transparent to the users of plonk library, so we needed
to remove the public inputs positions as a parameter of the ABI and
treat the verifier data agnostically as a `Vec<u8>`.