### PR TITLE
Fix key_generation workflow for rusk build

### DIFF
--- a/.github/workflows/profile_ci.yml
+++ b/.github/workflows/profile_ci.yml
@@ -21,7 +21,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-01-31
+          toolchain: nightly-2021-03-24
           override: true
+      # This should not be required. But the workflow fails if we don't include it
       - run: rustup component add rustfmt
       - run: make keys


### PR DESCRIPTION
In order to be able to generate the keys and keep them on
the cache, it was needed a fix in the workflow to stop requesting
an old rustc nightly version as well as the need to use rustfmt as a
component of the workflow.

Resolves: #258