### PR TITLE
transfer-circuits: Split ExecuteCircuit into separated instances

### DIFF
--- a/circuits/transfer/Cargo.toml
+++ b/circuits/transfer/Cargo.toml
@@ -6,21 +6,19 @@ edition = "2018"
 
 [dependencies]
 rand_core = "0.6"
-anyhow = "1.0"
 dusk-bytes = "0.1"
 dusk-plonk = "0.8"
 canonical = "0.6"
-canonical_derive = {version="0.6", optional=true}
-dusk-poseidon = {version="0.21.0-rc", features=["canon"]}
-phoenix-core = {git="https://github.com/dusk-network/phoenix-core", tag="v0.11.0-rc.0", features=["canon"]}
+dusk-poseidon = { version = "0.21.0-rc", features = ["canon"] }
 dusk-pki = "0.7.0-rc"
+phoenix-core = { version = "0.11.0-rc", features = ["canon"] }
 dusk-schnorr = "0.7.0-rc"
-rusk-profile = {path="../../rusk-profile", optional=true}
+code-hasher = { path = "../../macros/code-hasher" }
+rusk-profile = { path = "../../rusk-profile", optional = true }
+canonical_derive = { version = "0.6", optional = true }
 
 [dev-dependencies]
-canonical_derive = "0.6"
 rand = "0.8"
-rusk-profile = {path="../../rusk-profile"}
 
 [features]
-builder = ["canonical_derive", "rusk-profile"]
+builder = ["rusk-profile", "canonical_derive"]

--- a/circuits/transfer/Makefile
+++ b/circuits/transfer/Makefile
@@ -7,9 +7,4 @@ test: ## Run the transfer circuits tests
 	@cargo test --release \
 		--features builder
 
-test-no-rusk-profile: ## Run the transfer circuits tests
-	@RUSK_PROFILE_KEYS=false \
-		cargo test --release \
-		--features builder
-
 .PHONY: test help

--- a/circuits/transfer/src/error.rs
+++ b/circuits/transfer/src/error.rs
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_bytes::Error as BytesError;
+use dusk_plonk::error::Error as PlonkError;
+use dusk_poseidon::Error as PoseidonError;
+use phoenix_core::Error as PhoenixError;
+
+use std::str::ParseBoolError;
+use std::{error, fmt, io};
+
+#[derive(Debug)]
+pub enum Error {
+    BytesError(BytesError),
+    PhoenixError(PhoenixError),
+    PlonkError(PlonkError),
+    PoseidonError(PoseidonError),
+    ParseBoolError(ParseBoolError),
+    Io(io::Error),
+    KeysNotFound,
+    CircuitMaximumInputs,
+    CircuitMaximumOutputs,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::ParseBoolError(e) => Some(e),
+            Self::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<BytesError> for Error {
+    fn from(e: BytesError) -> Self {
+        Self::BytesError(e)
+    }
+}
+
+impl From<PhoenixError> for Error {
+    fn from(e: PhoenixError) -> Self {
+        Self::PhoenixError(e)
+    }
+}
+
+impl From<PlonkError> for Error {
+    fn from(e: PlonkError) -> Self {
+        Self::PlonkError(e)
+    }
+}
+
+impl From<PoseidonError> for Error {
+    fn from(e: PoseidonError) -> Self {
+        Self::PoseidonError(e)
+    }
+}
+
+impl From<ParseBoolError> for Error {
+    fn from(e: ParseBoolError) -> Self {
+        Self::ParseBoolError(e)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}

--- a/circuits/transfer/src/execute.rs
+++ b/circuits/transfer/src/execute.rs
@@ -4,26 +4,21 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::gadgets;
+use crate::Error;
 
 use crossover::CircuitCrossover;
 use input::{CircuitInput, WitnessInput};
 use output::{CircuitOutput, WitnessOutput};
 
-use anyhow::{anyhow, Result};
-use dusk_bytes::Serializable;
 use dusk_pki::{Ownable, SecretKey, SecretSpendKey, ViewKey};
 use dusk_plonk::bls12_381::BlsScalar;
-use dusk_plonk::jubjub::{
-    JubJubAffine, JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
-};
-use dusk_plonk::prelude::Error as PlonkError;
-use dusk_poseidon::cipher::PoseidonCipher;
-use dusk_poseidon::sponge;
+use dusk_plonk::jubjub::JubJubScalar;
 use dusk_poseidon::tree::{
-    self, PoseidonBranch, PoseidonLeaf, PoseidonTree, PoseidonTreeAnnotation,
+    PoseidonBranch, PoseidonLeaf, PoseidonTree, PoseidonTreeAnnotation,
 };
+use dusk_poseidon::Error as PoseidonError;
 use dusk_schnorr::Proof as SchnorrProof;
+use input::POSEIDON_BRANCH_DEPTH;
 use phoenix_core::{Crossover, Fee, Note};
 use rand_core::{CryptoRng, RngCore};
 
@@ -32,6 +27,9 @@ use dusk_plonk::prelude::*;
 mod crossover;
 mod input;
 mod output;
+mod variants;
+
+use variants::*;
 
 #[cfg(any(test, feature = "builder"))]
 pub mod builder;
@@ -48,35 +46,44 @@ pub mod builder;
 pub(crate) const SIGN_MESSAGE: BlsScalar = BlsScalar::one();
 
 /// The circuit responsible for creating a zero-knowledge proof
-#[derive(Debug, Default, Clone)]
-pub struct ExecuteCircuit {
-    inputs: Vec<CircuitInput>,
-    crossover: CircuitCrossover,
-    outputs: Vec<CircuitOutput>,
-    tx_hash: BlsScalar,
+#[derive(Debug, Clone)]
+pub enum ExecuteCircuit {
+    ExecuteCircuitOneZero(ExecuteCircuitOneZero),
+    ExecuteCircuitOneOne(ExecuteCircuitOneOne),
+    ExecuteCircuitOneTwo(ExecuteCircuitOneTwo),
+    ExecuteCircuitTwoZero(ExecuteCircuitTwoZero),
+    ExecuteCircuitTwoOne(ExecuteCircuitTwoOne),
+    ExecuteCircuitTwoTwo(ExecuteCircuitTwoTwo),
+    ExecuteCircuitThreeZero(ExecuteCircuitThreeZero),
+    ExecuteCircuitThreeOne(ExecuteCircuitThreeOne),
+    ExecuteCircuitThreeTwo(ExecuteCircuitThreeTwo),
+    ExecuteCircuitFourZero(ExecuteCircuitFourZero),
+    ExecuteCircuitFourOne(ExecuteCircuitFourOne),
+    ExecuteCircuitFourTwo(ExecuteCircuitFourTwo),
+}
+
+impl Default for ExecuteCircuit {
+    fn default() -> Self {
+        Self::ExecuteCircuitOneZero(Default::default())
+    }
 }
 
 impl ExecuteCircuit {
-    pub fn rusk_keys_id(&self) -> &'static str {
-        match (self.inputs.len(), self.outputs.len()) {
-            (1, 0) => "transfer-execute-1-0",
-            (1, 1) => "transfer-execute-1-1",
-            (1, 2) => "transfer-execute-1-2",
-            (2, 0) => "transfer-execute-2-0",
-            (2, 1) => "transfer-execute-2-1",
-            (2, 2) => "transfer-execute-2-2",
-            (3, 0) => "transfer-execute-3-0",
-            (3, 1) => "transfer-execute-3-1",
-            (3, 2) => "transfer-execute-3-2",
-            (4, 0) => "transfer-execute-4-0",
-            (4, 1) => "transfer-execute-4-1",
-            (4, 2) => "transfer-execute-4-2",
-            _ => unimplemented!(),
-        }
-    }
-
     pub fn set_tx_hash(&mut self, tx_hash: BlsScalar) {
-        self.tx_hash = tx_hash;
+        match self {
+            Self::ExecuteCircuitOneZero(c) => c.set_tx_hash(tx_hash),
+            Self::ExecuteCircuitOneOne(c) => c.set_tx_hash(tx_hash),
+            Self::ExecuteCircuitOneTwo(c) => c.set_tx_hash(tx_hash),
+            Self::ExecuteCircuitTwoZero(c) => c.set_tx_hash(tx_hash),
+            Self::ExecuteCircuitTwoOne(c) => c.set_tx_hash(tx_hash),
+            Self::ExecuteCircuitTwoTwo(c) => c.set_tx_hash(tx_hash),
+            Self::ExecuteCircuitThreeZero(c) => c.set_tx_hash(tx_hash),
+            Self::ExecuteCircuitThreeOne(c) => c.set_tx_hash(tx_hash),
+            Self::ExecuteCircuitThreeTwo(c) => c.set_tx_hash(tx_hash),
+            Self::ExecuteCircuitFourZero(c) => c.set_tx_hash(tx_hash),
+            Self::ExecuteCircuitFourOne(c) => c.set_tx_hash(tx_hash),
+            Self::ExecuteCircuitFourTwo(c) => c.set_tx_hash(tx_hash),
+        }
     }
 
     pub fn sign<R: RngCore + CryptoRng>(
@@ -97,31 +104,118 @@ impl ExecuteCircuit {
         note: Note,
         branch: PoseidonBranch<{ input::POSEIDON_BRANCH_DEPTH }>,
         signature: SchnorrProof,
-    ) -> Result<()> {
-        let vk = ssk.view_key();
-
-        let value = note
-            .value(Some(&vk))
-            .map_err(|e| anyhow!("Failed to decrypt value: {:?}", e))?;
-        let blinding_factor = note.blinding_factor(Some(&vk)).map_err(|e| {
-            anyhow!("Failed to decrypt blinding factor: {:?}", e)
-        })?;
-        let sk_r = ssk.sk_r(note.stealth_address()).as_ref().clone();
-        let nullifier = note.gen_nullifier(&ssk);
-
-        let input = CircuitInput::new(
-            signature,
-            branch,
-            sk_r,
-            note,
-            value,
-            blinding_factor,
-            nullifier,
-        );
-
-        self.inputs.push(input);
-
-        Ok(())
+    ) -> Result<(), Error> {
+        match self {
+            Self::ExecuteCircuitOneZero(c) => {
+                let result;
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                if c.inputs().len() > 1 {
+                    let mut c = ExecuteCircuitTwoZero::new(
+                        inputs, crossover, outputs, tx_hash,
+                    );
+                    result = c.add_input(ssk, note, branch, signature);
+                    *self = Self::ExecuteCircuitTwoZero(c);
+                } else {
+                    let mut c = ExecuteCircuitOneZero::new(
+                        inputs, crossover, outputs, tx_hash,
+                    );
+                    result = c.add_input(ssk, note, branch, signature);
+                    *self = Self::ExecuteCircuitOneZero(c);
+                }
+                result
+            }
+            Self::ExecuteCircuitOneOne(c) => {
+                let result;
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                if c.inputs().len() > 1 {
+                    let mut c = ExecuteCircuitTwoOne::new(
+                        inputs, crossover, outputs, tx_hash,
+                    );
+                    result = c.add_input(ssk, note, branch, signature);
+                    *self = Self::ExecuteCircuitTwoOne(c);
+                } else {
+                    let mut c = ExecuteCircuitOneOne::new(
+                        inputs, crossover, outputs, tx_hash,
+                    );
+                    result = c.add_input(ssk, note, branch, signature);
+                    *self = Self::ExecuteCircuitOneOne(c);
+                }
+                result
+            }
+            Self::ExecuteCircuitOneTwo(c) => {
+                let result;
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                if c.inputs().len() > 1 {
+                    let mut c = ExecuteCircuitTwoTwo::new(
+                        inputs, crossover, outputs, tx_hash,
+                    );
+                    result = c.add_input(ssk, note, branch, signature);
+                    *self = Self::ExecuteCircuitTwoTwo(c);
+                } else {
+                    let mut c = ExecuteCircuitOneTwo::new(
+                        inputs, crossover, outputs, tx_hash,
+                    );
+                    result = c.add_input(ssk, note, branch, signature);
+                    *self = Self::ExecuteCircuitOneTwo(c);
+                }
+                result
+            }
+            Self::ExecuteCircuitTwoZero(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitThreeZero::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                let result = c.add_input(ssk, note, branch, signature);
+                *self = Self::ExecuteCircuitThreeZero(c);
+                result
+            }
+            Self::ExecuteCircuitTwoOne(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitThreeOne::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                let result = c.add_input(ssk, note, branch, signature);
+                *self = Self::ExecuteCircuitThreeOne(c);
+                result
+            }
+            Self::ExecuteCircuitTwoTwo(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitThreeTwo::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                let result = c.add_input(ssk, note, branch, signature);
+                *self = Self::ExecuteCircuitThreeTwo(c);
+                result
+            }
+            Self::ExecuteCircuitThreeZero(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitFourZero::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                let result = c.add_input(ssk, note, branch, signature);
+                *self = Self::ExecuteCircuitFourZero(c);
+                result
+            }
+            Self::ExecuteCircuitThreeOne(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitFourOne::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                let result = c.add_input(ssk, note, branch, signature);
+                *self = Self::ExecuteCircuitFourOne(c);
+                result
+            }
+            Self::ExecuteCircuitThreeTwo(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitFourTwo::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                let result = c.add_input(ssk, note, branch, signature);
+                *self = Self::ExecuteCircuitFourTwo(c);
+                result
+            }
+            _ => Err(Error::CircuitMaximumInputs),
+        }
     }
 
     pub fn add_input_from_tree<L, A>(
@@ -130,40 +224,37 @@ impl ExecuteCircuit {
         tree: &PoseidonTree<L, A, { input::POSEIDON_BRANCH_DEPTH }>,
         pos: u64,
         signature: SchnorrProof,
-    ) -> Result<()>
+    ) -> Result<(), Error>
     where
         L: PoseidonLeaf + Into<Note>,
         A: PoseidonTreeAnnotation<L>,
     {
         let note = tree
-            .get(pos)
-            .map_err(|e| anyhow!("Failed to fetch note from the tree: {}", e))?
+            .get(pos)?
             .map(|n| n.into())
-            .ok_or(anyhow!("Note not found in the tree after push!"))?;
+            .ok_or(PoseidonError::TreeGetFailed)?;
 
-        let branch = tree
-            .branch(pos)
-            .map_err(|e| anyhow!("Failed to get the branch: {}", e))?
-            .ok_or(anyhow!("Failed to fetch the branch from the tree"))?;
+        let branch =
+            tree.branch(pos)?.ok_or(PoseidonError::TreeBranchFailed)?;
 
         self.add_input(ssk, note, branch, signature)
     }
 
-    pub fn set_fee(&mut self, fee: &Fee) -> Result<()> {
-        let value = 0;
-        let blinding_factor = JubJubScalar::zero();
-        let value_commitment = (GENERATOR_EXTENDED * JubJubScalar::zero())
-            + (GENERATOR_NUMS_EXTENDED * blinding_factor);
-
-        let fee = fee.gas_limit;
-        self.crossover = CircuitCrossover::new(
-            value_commitment,
-            value,
-            blinding_factor,
-            fee,
-        );
-
-        Ok(())
+    pub fn set_fee(&mut self, fee: &Fee) -> Result<(), Error> {
+        match self {
+            Self::ExecuteCircuitOneZero(c) => c.set_fee(fee),
+            Self::ExecuteCircuitOneOne(c) => c.set_fee(fee),
+            Self::ExecuteCircuitOneTwo(c) => c.set_fee(fee),
+            Self::ExecuteCircuitTwoZero(c) => c.set_fee(fee),
+            Self::ExecuteCircuitTwoOne(c) => c.set_fee(fee),
+            Self::ExecuteCircuitTwoTwo(c) => c.set_fee(fee),
+            Self::ExecuteCircuitThreeZero(c) => c.set_fee(fee),
+            Self::ExecuteCircuitThreeOne(c) => c.set_fee(fee),
+            Self::ExecuteCircuitThreeTwo(c) => c.set_fee(fee),
+            Self::ExecuteCircuitFourZero(c) => c.set_fee(fee),
+            Self::ExecuteCircuitFourOne(c) => c.set_fee(fee),
+            Self::ExecuteCircuitFourTwo(c) => c.set_fee(fee),
+        }
     }
 
     pub fn set_fee_crossover(
@@ -171,32 +262,45 @@ impl ExecuteCircuit {
         fee: &Fee,
         crossover: &Crossover,
         vk: &ViewKey,
-    ) -> Result<()> {
-        let shared_secret = fee.stealth_address().R() * vk.a();
-        let shared_secret = shared_secret.into();
-        let nonce = BlsScalar::from(*crossover.nonce());
-
-        let data: [BlsScalar; PoseidonCipher::capacity()] = crossover
-            .encrypted_data()
-            .decrypt(&shared_secret, &nonce)
-            .map_err(|e| anyhow!("Failed to decrypt crossover: {:?}", e))?;
-
-        let value = data[0].reduce();
-        let value = value.0[0];
-
-        let blinding_factor = JubJubScalar::from_bytes(&data[1].to_bytes())
-            .map_err(|e| anyhow!("Failed to convert bls to jubjub: {:?}", e))?;
-        let value_commitment = *crossover.value_commitment();
-
-        let fee = fee.gas_limit;
-        self.crossover = CircuitCrossover::new(
-            value_commitment,
-            value,
-            blinding_factor,
-            fee,
-        );
-
-        Ok(())
+    ) -> Result<(), Error> {
+        match self {
+            Self::ExecuteCircuitOneZero(c) => {
+                c.set_fee_crossover(fee, crossover, vk)
+            }
+            Self::ExecuteCircuitOneOne(c) => {
+                c.set_fee_crossover(fee, crossover, vk)
+            }
+            Self::ExecuteCircuitOneTwo(c) => {
+                c.set_fee_crossover(fee, crossover, vk)
+            }
+            Self::ExecuteCircuitTwoZero(c) => {
+                c.set_fee_crossover(fee, crossover, vk)
+            }
+            Self::ExecuteCircuitTwoOne(c) => {
+                c.set_fee_crossover(fee, crossover, vk)
+            }
+            Self::ExecuteCircuitTwoTwo(c) => {
+                c.set_fee_crossover(fee, crossover, vk)
+            }
+            Self::ExecuteCircuitThreeZero(c) => {
+                c.set_fee_crossover(fee, crossover, vk)
+            }
+            Self::ExecuteCircuitThreeOne(c) => {
+                c.set_fee_crossover(fee, crossover, vk)
+            }
+            Self::ExecuteCircuitThreeTwo(c) => {
+                c.set_fee_crossover(fee, crossover, vk)
+            }
+            Self::ExecuteCircuitFourZero(c) => {
+                c.set_fee_crossover(fee, crossover, vk)
+            }
+            Self::ExecuteCircuitFourOne(c) => {
+                c.set_fee_crossover(fee, crossover, vk)
+            }
+            Self::ExecuteCircuitFourTwo(c) => {
+                c.set_fee_crossover(fee, crossover, vk)
+            }
+        }
     }
 
     pub fn add_output_with_data(
@@ -204,304 +308,232 @@ impl ExecuteCircuit {
         note: Note,
         value: u64,
         blinding_factor: JubJubScalar,
-    ) {
-        let output = CircuitOutput::new(note, value, blinding_factor);
+    ) -> Result<(), Error> {
+        match self {
+            Self::ExecuteCircuitOneZero(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitOneOne::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                c.add_output_with_data(note, value, blinding_factor);
+                *self = Self::ExecuteCircuitOneOne(c);
+                Ok(())
+            }
 
-        self.outputs.push(output);
+            Self::ExecuteCircuitOneOne(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitOneTwo::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                c.add_output_with_data(note, value, blinding_factor);
+                *self = Self::ExecuteCircuitOneTwo(c);
+                Ok(())
+            }
+
+            Self::ExecuteCircuitTwoZero(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitTwoOne::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                c.add_output_with_data(note, value, blinding_factor);
+                *self = Self::ExecuteCircuitTwoOne(c);
+                Ok(())
+            }
+
+            Self::ExecuteCircuitTwoOne(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitTwoTwo::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                c.add_output_with_data(note, value, blinding_factor);
+                *self = Self::ExecuteCircuitTwoTwo(c);
+                Ok(())
+            }
+
+            Self::ExecuteCircuitThreeZero(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitThreeOne::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                c.add_output_with_data(note, value, blinding_factor);
+                *self = Self::ExecuteCircuitThreeOne(c);
+                Ok(())
+            }
+
+            Self::ExecuteCircuitThreeOne(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitThreeTwo::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                c.add_output_with_data(note, value, blinding_factor);
+                *self = Self::ExecuteCircuitThreeTwo(c);
+                Ok(())
+            }
+
+            Self::ExecuteCircuitFourZero(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitFourOne::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                c.add_output_with_data(note, value, blinding_factor);
+                *self = Self::ExecuteCircuitFourOne(c);
+                Ok(())
+            }
+
+            Self::ExecuteCircuitFourOne(c) => {
+                let (inputs, crossover, outputs, tx_hash) = c.into_inner();
+                let mut c = ExecuteCircuitFourTwo::new(
+                    inputs, crossover, outputs, tx_hash,
+                );
+                c.add_output_with_data(note, value, blinding_factor);
+                *self = Self::ExecuteCircuitFourTwo(c);
+                Ok(())
+            }
+
+            _ => Err(Error::CircuitMaximumOutputs),
+        }
     }
 
     pub fn add_output(
         &mut self,
         note: Note,
         vk: Option<&ViewKey>,
-    ) -> Result<()> {
-        let value = note
-            .value(vk)
-            .map_err(|e| anyhow!("Failed to decrypt value: {:?}", e))?;
-        let blinding_factor = note.blinding_factor(vk).map_err(|e| {
-            anyhow!("Failed to decrypt blinding factor: {:?}", e)
-        })?;
+    ) -> Result<(), Error> {
+        let value = note.value(vk)?;
+        let blinding_factor = note.blinding_factor(vk)?;
 
-        self.add_output_with_data(note, value, blinding_factor);
-
-        Ok(())
+        self.add_output_with_data(note, value, blinding_factor)
     }
 
     pub fn public_inputs(&self) -> Vec<PublicInputValue> {
-        let mut pi = vec![];
-
-        // step 1
-        let root = self
-            .inputs
-            .first()
-            .map(|i| *i.branch().root())
-            .unwrap_or_default();
-        pi.push(root.into());
-
-        // step 4
-        pi.extend(
-            self.inputs
-                .iter()
-                .map(|input| input.nullifier().clone().into()),
-        );
-
-        // step 7
-        pi.push(BlsScalar::from(self.crossover.fee()).into());
-
-        let crossover_value_commitment =
-            JubJubAffine::from(self.crossover.value_commitment());
-        pi.push(crossover_value_commitment.into());
-
-        // step 9
-        pi.extend(self.outputs.iter().map(|output| {
-            JubJubAffine::from(output.note().value_commitment()).into()
-        }));
-
-        // step 12
-        pi.push(self.tx_hash.into());
-
-        pi
+        match self {
+            Self::ExecuteCircuitOneZero(c) => c.public_inputs(),
+            Self::ExecuteCircuitOneOne(c) => c.public_inputs(),
+            Self::ExecuteCircuitOneTwo(c) => c.public_inputs(),
+            Self::ExecuteCircuitTwoZero(c) => c.public_inputs(),
+            Self::ExecuteCircuitTwoOne(c) => c.public_inputs(),
+            Self::ExecuteCircuitTwoTwo(c) => c.public_inputs(),
+            Self::ExecuteCircuitThreeZero(c) => c.public_inputs(),
+            Self::ExecuteCircuitThreeOne(c) => c.public_inputs(),
+            Self::ExecuteCircuitThreeTwo(c) => c.public_inputs(),
+            Self::ExecuteCircuitFourZero(c) => c.public_inputs(),
+            Self::ExecuteCircuitFourOne(c) => c.public_inputs(),
+            Self::ExecuteCircuitFourTwo(c) => c.public_inputs(),
+        }
     }
 
     pub fn inputs(&self) -> &[CircuitInput] {
-        self.inputs.as_slice()
+        match self {
+            Self::ExecuteCircuitOneZero(c) => c.inputs(),
+            Self::ExecuteCircuitOneOne(c) => c.inputs(),
+            Self::ExecuteCircuitOneTwo(c) => c.inputs(),
+            Self::ExecuteCircuitTwoZero(c) => c.inputs(),
+            Self::ExecuteCircuitTwoOne(c) => c.inputs(),
+            Self::ExecuteCircuitTwoTwo(c) => c.inputs(),
+            Self::ExecuteCircuitThreeZero(c) => c.inputs(),
+            Self::ExecuteCircuitThreeOne(c) => c.inputs(),
+            Self::ExecuteCircuitThreeTwo(c) => c.inputs(),
+            Self::ExecuteCircuitFourZero(c) => c.inputs(),
+            Self::ExecuteCircuitFourOne(c) => c.inputs(),
+            Self::ExecuteCircuitFourTwo(c) => c.inputs(),
+        }
     }
 
     pub fn outputs(&self) -> &[CircuitOutput] {
-        self.outputs.as_slice()
+        match self {
+            Self::ExecuteCircuitOneZero(c) => c.outputs(),
+            Self::ExecuteCircuitOneOne(c) => c.outputs(),
+            Self::ExecuteCircuitOneTwo(c) => c.outputs(),
+            Self::ExecuteCircuitTwoZero(c) => c.outputs(),
+            Self::ExecuteCircuitTwoOne(c) => c.outputs(),
+            Self::ExecuteCircuitTwoTwo(c) => c.outputs(),
+            Self::ExecuteCircuitThreeZero(c) => c.outputs(),
+            Self::ExecuteCircuitThreeOne(c) => c.outputs(),
+            Self::ExecuteCircuitThreeTwo(c) => c.outputs(),
+            Self::ExecuteCircuitFourZero(c) => c.outputs(),
+            Self::ExecuteCircuitFourOne(c) => c.outputs(),
+            Self::ExecuteCircuitFourTwo(c) => c.outputs(),
+        }
     }
-}
 
-impl Circuit for ExecuteCircuit {
-    // TODO Define ID
-    const CIRCUIT_ID: [u8; 32] = [0xff; 32];
+    pub const fn circuit_id(&self) -> &[u8; 32] {
+        match self {
+            Self::ExecuteCircuitOneZero(_) => {
+                &ExecuteCircuitOneZero::CIRCUIT_ID
+            }
+            Self::ExecuteCircuitOneOne(_) => &ExecuteCircuitOneOne::CIRCUIT_ID,
+            Self::ExecuteCircuitOneTwo(_) => &ExecuteCircuitOneTwo::CIRCUIT_ID,
+            Self::ExecuteCircuitTwoZero(_) => {
+                &ExecuteCircuitTwoZero::CIRCUIT_ID
+            }
+            Self::ExecuteCircuitTwoOne(_) => &ExecuteCircuitTwoOne::CIRCUIT_ID,
+            Self::ExecuteCircuitTwoTwo(_) => &ExecuteCircuitTwoTwo::CIRCUIT_ID,
+            Self::ExecuteCircuitThreeZero(_) => {
+                &ExecuteCircuitThreeZero::CIRCUIT_ID
+            }
+            Self::ExecuteCircuitThreeOne(_) => {
+                &ExecuteCircuitThreeOne::CIRCUIT_ID
+            }
+            Self::ExecuteCircuitThreeTwo(_) => {
+                &ExecuteCircuitThreeTwo::CIRCUIT_ID
+            }
+            Self::ExecuteCircuitFourZero(_) => {
+                &ExecuteCircuitFourZero::CIRCUIT_ID
+            }
+            Self::ExecuteCircuitFourOne(_) => {
+                &ExecuteCircuitFourOne::CIRCUIT_ID
+            }
+            Self::ExecuteCircuitFourTwo(_) => {
+                &ExecuteCircuitFourTwo::CIRCUIT_ID
+            }
+        }
+    }
 
-    fn gadget(
+    /// Wrapper method required while circuit implementation is not object safe
+    /// https://github.com/dusk-network/plonk/issues/531
+    pub fn gen_proof(
         &mut self,
-        composer: &mut StandardComposer,
-    ) -> Result<(), PlonkError> {
-        let mut base_root = None;
-
-        // 1. Prove the knowledge of the input Note paths to Note Tree, via root
-        // anchor
-        let inputs: Vec<WitnessInput> = self
-            .inputs
-            .iter()
-            .map(|input| {
-                let branch = input.branch();
-                let note = input.to_witness(composer);
-
-                let root_p = tree::merkle_opening(composer, branch);
-
-                // Test the public input only for the first root
-                //
-                // The remainder roots must be equal to the first (root is
-                // unique per proof)
-                match base_root {
-                    None => {
-                        let root = *branch.root();
-
-                        composer.constrain_to_constant(
-                            root_p,
-                            BlsScalar::zero(),
-                            Some(-root),
-                        );
-
-                        base_root.replace(root_p);
-                    }
-
-                    Some(base) => {
-                        composer.assert_equal(base, root_p);
-                    }
-                }
-
-                note
-            })
-            .collect();
-
-        // 2. Prove the knowledge of the pre-images of the input Notes
-        inputs.iter().for_each(|input| {
-            let note_hash = input.note_hash;
-            let hash_inputs = input.to_hash_inputs();
-
-            let note_hash_p = sponge::gadget(composer, &hash_inputs);
-
-            composer.assert_equal(note_hash, note_hash_p);
-        });
-
-        // 3. Prove the correctness of the Schnorr signatures.
-        inputs.iter().for_each(|input| {
-            dusk_schnorr::gadgets::double_key_verify(
-                composer,
-                input.schnorr_r,
-                input.schnorr_r_prime,
-                input.schnorr_u,
-                input.pk_r,
-                input.pk_r_prime,
-                input.schnorr_message,
-            );
-        });
-
-        // 4. Prove the correctness of the nullifiers
-        inputs.iter().for_each(|input| {
-            let nullifier = input.nullifier;
-            let sk_r = input.sk_r;
-            let pos = input.pos;
-
-            let nullifier_p = sponge::gadget(composer, &[sk_r, pos]);
-
-            composer.constrain_to_constant(
-                nullifier_p,
-                BlsScalar::zero(),
-                Some(-nullifier),
-            );
-        });
-
-        // 5. Prove the knowledge of the commitment openings of the commitments
-        // of the input Notes
-        inputs.iter().for_each(|input| {
-            let value_commitment = input.value_commitment;
-            let value_commitment_p = gadgets::commitment(
-                composer,
-                input.value,
-                input.blinding_factor,
-            );
-
-            composer.assert_equal_point(value_commitment, value_commitment_p);
-        });
-
-        // 6. Prove that the value of the openings of the commitments of the
-        // input Notes is in range
-        inputs.iter().for_each(|input| {
-            composer.range_gate(input.value, 64);
-        });
-
-        // 7. Prove the knowledge of the commitment opening of the Crossover
-        let crossover = self.crossover.to_witness(composer);
-        {
-            let value_commitment_p = gadgets::commitment(
-                composer,
-                crossover.value,
-                crossover.blinding_factor,
-            );
-
-            // fee value public input
-            composer.constrain_to_constant(
-                crossover.fee_value_witness,
-                BlsScalar::zero(),
-                Some(-crossover.fee_value),
-            );
-
-            // value commitment public input
-            let value_commitment = crossover.value_commitment.into();
-            composer.assert_equal_public_point(
-                value_commitment_p,
-                value_commitment,
-            );
-        }
-
-        // 8. Prove that the value of the opening of the commitment of the
-        // Crossover is within range
-        composer.range_gate(crossover.value, 64);
-
-        // 9. Prove the knowledge of the commitment openings of the commitments
-        // of the output Obfuscated Notes
-        let outputs: Vec<WitnessOutput> = self
-            .outputs
-            .iter()
-            .map(|output| {
-                let output = output.to_witness(composer);
-
-                let value_commitment_p = gadgets::commitment(
-                    composer,
-                    output.value,
-                    output.blinding_factor,
-                );
-
-                // value commitment public input
-                let value_commitment = output.value_commitment.into();
-                composer.assert_equal_public_point(
-                    value_commitment_p,
-                    value_commitment,
-                );
-
-                output
-            })
-            .collect();
-
-        // 10. Prove that the value of the openings of the commitments of the
-        // output Obfuscated Notes is in range
-        outputs.iter().for_each(|output| {
-            composer.range_gate(output.value, 64);
-        });
-
-        // 11. Prove that sum(inputs.value) - sum(outputs.value) -
-        // crossover_value - fee_value = 0
-        {
-            let zero =
-                composer.add_witness_to_circuit_description(BlsScalar::zero());
-
-            let inputs_sum = inputs.iter().fold(zero, |sum, input| {
-                composer.add(
-                    (BlsScalar::one(), sum),
-                    (BlsScalar::one(), input.value),
-                    BlsScalar::zero(),
-                    None,
-                )
-            });
-
-            let outputs_sum = outputs.iter().fold(zero, |sum, output| {
-                composer.add(
-                    (BlsScalar::one(), sum),
-                    (BlsScalar::one(), output.value),
-                    BlsScalar::zero(),
-                    None,
-                )
-            });
-
-            let fee_crossover = composer.add(
-                (BlsScalar::one(), crossover.value),
-                (BlsScalar::one(), crossover.fee_value_witness),
-                BlsScalar::zero(),
-                None,
-            );
-
-            composer.poly_gate(
-                inputs_sum,
-                outputs_sum,
-                fee_crossover,
-                BlsScalar::zero(),
-                BlsScalar::one(),
-                -BlsScalar::one(),
-                -BlsScalar::one(),
-                BlsScalar::zero(),
-                None,
-            );
-        }
-
-        // 12. Inject the transaction hash to tie it to the circuit
-        //
-        // This is a workaround while the transcript hash injection is not
-        // available in the API.
-        //
-        // This step is necessary to guarantee the outputs were not tampered by
-        // a malicious actor. It is cheaper than checking individually
-        // for the pre-image of every output.
-        let tx_hash = composer.add_input(self.tx_hash);
-        composer.constrain_to_constant(
-            tx_hash,
-            BlsScalar::zero(),
-            Some(-self.tx_hash),
-        );
-
-        Ok(())
-    }
-
-    fn padded_circuit_size(&self) -> usize {
-        match (self.inputs.len(), self.outputs.len()) {
-            (1, o) if o < 2 => 1 << 15,
-            (1, _) | (2, _) => 1 << 16,
-            _ => 1 << 17,
+        pp: &PublicParameters,
+        pk: &ProverKey,
+        label: &'static [u8],
+    ) -> Result<Proof, Error> {
+        match self {
+            Self::ExecuteCircuitOneZero(c) => {
+                c.gen_proof(pp, pk, label).map_err(|e| e.into())
+            }
+            Self::ExecuteCircuitOneOne(c) => {
+                c.gen_proof(pp, pk, label).map_err(|e| e.into())
+            }
+            Self::ExecuteCircuitOneTwo(c) => {
+                c.gen_proof(pp, pk, label).map_err(|e| e.into())
+            }
+            Self::ExecuteCircuitTwoZero(c) => {
+                c.gen_proof(pp, pk, label).map_err(|e| e.into())
+            }
+            Self::ExecuteCircuitTwoOne(c) => {
+                c.gen_proof(pp, pk, label).map_err(|e| e.into())
+            }
+            Self::ExecuteCircuitTwoTwo(c) => {
+                c.gen_proof(pp, pk, label).map_err(|e| e.into())
+            }
+            Self::ExecuteCircuitThreeZero(c) => {
+                c.gen_proof(pp, pk, label).map_err(|e| e.into())
+            }
+            Self::ExecuteCircuitThreeOne(c) => {
+                c.gen_proof(pp, pk, label).map_err(|e| e.into())
+            }
+            Self::ExecuteCircuitThreeTwo(c) => {
+                c.gen_proof(pp, pk, label).map_err(|e| e.into())
+            }
+            Self::ExecuteCircuitFourZero(c) => {
+                c.gen_proof(pp, pk, label).map_err(|e| e.into())
+            }
+            Self::ExecuteCircuitFourOne(c) => {
+                c.gen_proof(pp, pk, label).map_err(|e| e.into())
+            }
+            Self::ExecuteCircuitFourTwo(c) => {
+                c.gen_proof(pp, pk, label).map_err(|e| e.into())
+            }
         }
     }
 }

--- a/circuits/transfer/src/execute/variants.rs
+++ b/circuits/transfer/src/execute/variants.rs
@@ -1,0 +1,462 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use super::{
+    CircuitCrossover, CircuitInput, CircuitOutput, WitnessInput, WitnessOutput,
+    POSEIDON_BRANCH_DEPTH,
+};
+use crate::{gadgets, Error};
+
+use dusk_bytes::Serializable;
+use dusk_pki::{Ownable, SecretSpendKey, ViewKey};
+use dusk_plonk::bls12_381::BlsScalar;
+use dusk_plonk::jubjub::{
+    JubJubAffine, JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
+};
+use dusk_plonk::prelude::Error as PlonkError;
+use dusk_poseidon::cipher::PoseidonCipher;
+use dusk_poseidon::sponge;
+use dusk_poseidon::tree::{self, PoseidonBranch};
+use dusk_schnorr::Proof as SchnorrProof;
+use phoenix_core::{Crossover, Fee, Note};
+
+use dusk_plonk::prelude::*;
+
+macro_rules! execute_circuit_variant {
+    ($i:ident,$c:expr) => {
+        /// The circuit responsible for creating a zero-knowledge proof
+        #[derive(Debug, Default, Clone)]
+        pub struct $i {
+            inputs: Vec<CircuitInput>,
+            crossover: CircuitCrossover,
+            outputs: Vec<CircuitOutput>,
+            tx_hash: BlsScalar,
+        }
+
+        impl $i {
+            pub const fn identifier() {
+                // Workaround to generate different code hasher results for the
+                // gadget
+            }
+
+            pub fn new(
+                inputs: Vec<CircuitInput>,
+                crossover: CircuitCrossover,
+                outputs: Vec<CircuitOutput>,
+                tx_hash: BlsScalar,
+            ) -> Self {
+                Self {
+                    inputs,
+                    crossover,
+                    outputs,
+                    tx_hash,
+                }
+            }
+
+            pub fn into_inner(
+                &self,
+            ) -> (
+                Vec<CircuitInput>,
+                CircuitCrossover,
+                Vec<CircuitOutput>,
+                BlsScalar,
+            ) {
+                let inputs = self.inputs.clone();
+                let crossover = self.crossover.clone();
+                let outputs = self.outputs.clone();
+                let tx_hash = self.tx_hash.clone();
+
+                (inputs, crossover, outputs, tx_hash)
+            }
+
+            pub fn set_tx_hash(&mut self, tx_hash: BlsScalar) {
+                self.tx_hash = tx_hash;
+            }
+
+            pub fn add_input(
+                &mut self,
+                ssk: &SecretSpendKey,
+                note: Note,
+                branch: PoseidonBranch<POSEIDON_BRANCH_DEPTH>,
+                signature: SchnorrProof,
+            ) -> Result<(), Error> {
+                let vk = ssk.view_key();
+
+                let value = note.value(Some(&vk))?;
+                let blinding_factor = note.blinding_factor(Some(&vk))?;
+                let sk_r = ssk.sk_r(note.stealth_address()).as_ref().clone();
+                let nullifier = note.gen_nullifier(&ssk);
+
+                let input = CircuitInput::new(
+                    signature,
+                    branch,
+                    sk_r,
+                    note,
+                    value,
+                    blinding_factor,
+                    nullifier,
+                );
+
+                self.inputs.push(input);
+
+                Ok(())
+            }
+
+            pub fn set_fee(&mut self, fee: &Fee) -> Result<(), Error> {
+                let value = 0;
+                let blinding_factor = JubJubScalar::zero();
+                let value_commitment = (GENERATOR_EXTENDED
+                    * JubJubScalar::zero())
+                    + (GENERATOR_NUMS_EXTENDED * blinding_factor);
+
+                let fee = fee.gas_limit;
+                self.crossover = CircuitCrossover::new(
+                    value_commitment,
+                    value,
+                    blinding_factor,
+                    fee,
+                );
+
+                Ok(())
+            }
+
+            pub fn set_fee_crossover(
+                &mut self,
+                fee: &Fee,
+                crossover: &Crossover,
+                vk: &ViewKey,
+            ) -> Result<(), Error> {
+                let shared_secret = fee.stealth_address().R() * vk.a();
+                let shared_secret = shared_secret.into();
+                let nonce = BlsScalar::from(*crossover.nonce());
+
+                let data: [BlsScalar; PoseidonCipher::capacity()] = crossover
+                    .encrypted_data()
+                    .decrypt(&shared_secret, &nonce)?;
+
+                let value = data[0].reduce();
+                let value = value.0[0];
+
+                let blinding_factor =
+                    JubJubScalar::from_bytes(&data[1].to_bytes())?;
+                let value_commitment = *crossover.value_commitment();
+
+                let fee = fee.gas_limit;
+                self.crossover = CircuitCrossover::new(
+                    value_commitment,
+                    value,
+                    blinding_factor,
+                    fee,
+                );
+
+                Ok(())
+            }
+
+            pub fn add_output_with_data(
+                &mut self,
+                note: Note,
+                value: u64,
+                blinding_factor: JubJubScalar,
+            ) {
+                let output = CircuitOutput::new(note, value, blinding_factor);
+
+                self.outputs.push(output);
+            }
+
+            pub fn public_inputs(&self) -> Vec<PublicInputValue> {
+                let mut pi = vec![];
+
+                // step 1
+                let root = self
+                    .inputs
+                    .first()
+                    .map(|i| *i.branch().root())
+                    .unwrap_or_default();
+                pi.push(root.into());
+
+                // step 4
+                pi.extend(
+                    self.inputs
+                        .iter()
+                        .map(|input| input.nullifier().clone().into()),
+                );
+
+                // step 7
+                pi.push(BlsScalar::from(self.crossover.fee()).into());
+
+                let crossover_value_commitment =
+                    JubJubAffine::from(self.crossover.value_commitment());
+                pi.push(crossover_value_commitment.into());
+
+                // step 9
+                pi.extend(self.outputs.iter().map(|output| {
+                    JubJubAffine::from(output.note().value_commitment()).into()
+                }));
+
+                // step 12
+                pi.push(self.tx_hash.into());
+
+                pi
+            }
+
+            pub fn inputs(&self) -> &[CircuitInput] {
+                self.inputs.as_slice()
+            }
+
+            pub fn outputs(&self) -> &[CircuitOutput] {
+                self.outputs.as_slice()
+            }
+        }
+
+        #[code_hasher::hash(CIRCUIT_ID, version = "0.1.0")]
+        impl Circuit for $i {
+            fn gadget(
+                &mut self,
+                composer: &mut StandardComposer,
+            ) -> Result<(), PlonkError> {
+                let _ = $i::identifier();
+                let mut base_root = None;
+
+                // 1. Prove the knowledge of the input Note paths to Note Tree,
+                // via root anchor
+                let inputs: Vec<WitnessInput> = self
+                    .inputs
+                    .iter()
+                    .map(|input| {
+                        let branch = input.branch();
+                        let note = input.to_witness(composer);
+
+                        let root_p = tree::merkle_opening(composer, branch);
+
+                        // Test the public input only for the first root
+                        //
+                        // The remainder roots must be equal to the first (root
+                        // is unique per proof)
+                        match base_root {
+                            None => {
+                                let root = *branch.root();
+
+                                composer.constrain_to_constant(
+                                    root_p,
+                                    BlsScalar::zero(),
+                                    Some(-root),
+                                );
+
+                                base_root.replace(root_p);
+                            }
+
+                            Some(base) => {
+                                composer.assert_equal(base, root_p);
+                            }
+                        }
+
+                        note
+                    })
+                    .collect();
+
+                // 2. Prove the knowledge of the pre-images of the input Notes
+                inputs.iter().for_each(|input| {
+                    let note_hash = input.note_hash;
+                    let hash_inputs = input.to_hash_inputs();
+
+                    let note_hash_p = sponge::gadget(composer, &hash_inputs);
+
+                    composer.assert_equal(note_hash, note_hash_p);
+                });
+
+                // 3. Prove the correctness of the Schnorr signatures.
+                inputs.iter().for_each(|input| {
+                    dusk_schnorr::gadgets::double_key_verify(
+                        composer,
+                        input.schnorr_r,
+                        input.schnorr_r_prime,
+                        input.schnorr_u,
+                        input.pk_r,
+                        input.pk_r_prime,
+                        input.schnorr_message,
+                    );
+                });
+
+                // 4. Prove the correctness of the nullifiers
+                inputs.iter().for_each(|input| {
+                    let nullifier = input.nullifier;
+                    let sk_r = input.sk_r;
+                    let pos = input.pos;
+
+                    let nullifier_p = sponge::gadget(composer, &[sk_r, pos]);
+
+                    composer.constrain_to_constant(
+                        nullifier_p,
+                        BlsScalar::zero(),
+                        Some(-nullifier),
+                    );
+                });
+
+                // 5. Prove the knowledge of the commitment openings of the
+                // commitments of the input Notes
+                inputs.iter().for_each(|input| {
+                    let value_commitment = input.value_commitment;
+                    let value_commitment_p = gadgets::commitment(
+                        composer,
+                        input.value,
+                        input.blinding_factor,
+                    );
+
+                    composer.assert_equal_point(
+                        value_commitment,
+                        value_commitment_p,
+                    );
+                });
+
+                // 6. Prove that the value of the openings of the commitments of
+                // the input Notes is in range
+                inputs.iter().for_each(|input| {
+                    composer.range_gate(input.value, 64);
+                });
+
+                // 7. Prove the knowledge of the commitment opening of the
+                // Crossover
+                let crossover = self.crossover.to_witness(composer);
+                {
+                    let value_commitment_p = gadgets::commitment(
+                        composer,
+                        crossover.value,
+                        crossover.blinding_factor,
+                    );
+
+                    // fee value public input
+                    composer.constrain_to_constant(
+                        crossover.fee_value_witness,
+                        BlsScalar::zero(),
+                        Some(-crossover.fee_value),
+                    );
+
+                    // value commitment public input
+                    let value_commitment = crossover.value_commitment.into();
+                    composer.assert_equal_public_point(
+                        value_commitment_p,
+                        value_commitment,
+                    );
+                }
+
+                // 8. Prove that the value of the opening of the commitment of
+                // the Crossover is within range
+                composer.range_gate(crossover.value, 64);
+
+                // 9. Prove the knowledge of the commitment openings of the
+                // commitments of the output Obfuscated Notes
+                let outputs: Vec<WitnessOutput> = self
+                    .outputs
+                    .iter()
+                    .map(|output| {
+                        let output = output.to_witness(composer);
+
+                        let value_commitment_p = gadgets::commitment(
+                            composer,
+                            output.value,
+                            output.blinding_factor,
+                        );
+
+                        // value commitment public input
+                        let value_commitment = output.value_commitment.into();
+                        composer.assert_equal_public_point(
+                            value_commitment_p,
+                            value_commitment,
+                        );
+
+                        output
+                    })
+                    .collect();
+
+                // 10. Prove that the value of the openings of the commitments
+                // of the output Obfuscated Notes is in range
+                outputs.iter().for_each(|output| {
+                    composer.range_gate(output.value, 64);
+                });
+
+                // 11. Prove that sum(inputs.value) - sum(outputs.value) -
+                // crossover_value - fee_value = 0
+                {
+                    let zero = composer
+                        .add_witness_to_circuit_description(BlsScalar::zero());
+
+                    let inputs_sum = inputs.iter().fold(zero, |sum, input| {
+                        composer.add(
+                            (BlsScalar::one(), sum),
+                            (BlsScalar::one(), input.value),
+                            BlsScalar::zero(),
+                            None,
+                        )
+                    });
+
+                    let outputs_sum =
+                        outputs.iter().fold(zero, |sum, output| {
+                            composer.add(
+                                (BlsScalar::one(), sum),
+                                (BlsScalar::one(), output.value),
+                                BlsScalar::zero(),
+                                None,
+                            )
+                        });
+
+                    let fee_crossover = composer.add(
+                        (BlsScalar::one(), crossover.value),
+                        (BlsScalar::one(), crossover.fee_value_witness),
+                        BlsScalar::zero(),
+                        None,
+                    );
+
+                    composer.poly_gate(
+                        inputs_sum,
+                        outputs_sum,
+                        fee_crossover,
+                        BlsScalar::zero(),
+                        BlsScalar::one(),
+                        -BlsScalar::one(),
+                        -BlsScalar::one(),
+                        BlsScalar::zero(),
+                        None,
+                    );
+                }
+
+                // 12. Inject the transaction hash to tie it to the circuit
+                //
+                // This is a workaround while the transcript hash injection is
+                // not available in the API.
+                //
+                // This step is necessary to guarantee the outputs were not
+                // tampered by a malicious actor. It is cheaper than
+                // checking individually for the pre-image of every
+                // output.
+                let tx_hash = composer.add_input(self.tx_hash);
+                composer.constrain_to_constant(
+                    tx_hash,
+                    BlsScalar::zero(),
+                    Some(-self.tx_hash),
+                );
+
+                Ok(())
+            }
+
+            fn padded_circuit_size(&self) -> usize {
+                1 << $c
+            }
+        }
+    };
+}
+
+execute_circuit_variant!(ExecuteCircuitOneZero, 15);
+execute_circuit_variant!(ExecuteCircuitOneOne, 15);
+execute_circuit_variant!(ExecuteCircuitOneTwo, 15);
+execute_circuit_variant!(ExecuteCircuitTwoZero, 15);
+execute_circuit_variant!(ExecuteCircuitTwoOne, 15);
+execute_circuit_variant!(ExecuteCircuitTwoTwo, 16);
+execute_circuit_variant!(ExecuteCircuitThreeZero, 17);
+execute_circuit_variant!(ExecuteCircuitThreeOne, 17);
+execute_circuit_variant!(ExecuteCircuitThreeTwo, 17);
+execute_circuit_variant!(ExecuteCircuitFourZero, 17);
+execute_circuit_variant!(ExecuteCircuitFourOne, 17);
+execute_circuit_variant!(ExecuteCircuitFourTwo, 17);

--- a/circuits/transfer/src/lib.rs
+++ b/circuits/transfer/src/lib.rs
@@ -4,12 +4,18 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+mod error;
 mod execute;
 mod gadgets;
 mod send_to_contract_obfuscated;
 mod send_to_contract_transparent;
 mod withdraw_from_obfuscated;
 
+/// Label used for the ZK transcript initialization. Must be the same for prover
+/// and verifier.
+pub const TRANSCRIPT_LABEL: &'static [u8] = b"dusk-network";
+
+pub use error::Error;
 pub use execute::ExecuteCircuit;
 pub use send_to_contract_obfuscated::SendToContractObfuscatedCircuit;
 pub use send_to_contract_transparent::SendToContractTransparentCircuit;

--- a/circuits/transfer/src/send_to_contract_obfuscated.rs
+++ b/circuits/transfer/src/send_to_contract_obfuscated.rs
@@ -6,7 +6,6 @@
 
 use crate::gadgets;
 
-use anyhow::Result;
 use dusk_bytes::Serializable;
 use dusk_pki::{Ownable, PublicSpendKey, SecretKey, SecretSpendKey, ViewKey};
 use dusk_plonk::error::Error as PlonkError;
@@ -172,10 +171,8 @@ impl SendToContractObfuscatedCircuit {
     }
 }
 
+#[code_hasher::hash(CIRCUIT_ID, version = "0.1.0")]
 impl Circuit for SendToContractObfuscatedCircuit {
-    // TODO Define ID
-    const CIRCUIT_ID: [u8; 32] = [0xff; 32];
-
     fn gadget(
         &mut self,
         composer: &mut StandardComposer,

--- a/circuits/transfer/src/send_to_contract_transparent.rs
+++ b/circuits/transfer/src/send_to_contract_transparent.rs
@@ -6,7 +6,6 @@
 
 use crate::gadgets;
 
-use anyhow::Result;
 use dusk_bytes::Serializable;
 use dusk_pki::{Ownable, SecretKey, SecretSpendKey, ViewKey};
 use dusk_plonk::error::Error as PlonkError;
@@ -115,10 +114,8 @@ impl SendToContractTransparentCircuit {
     }
 }
 
+#[code_hasher::hash(CIRCUIT_ID, version = "0.1.0")]
 impl Circuit for SendToContractTransparentCircuit {
-    // TODO Define ID
-    const CIRCUIT_ID: [u8; 32] = [0xff; 32];
-
     fn gadget(
         &mut self,
         composer: &mut StandardComposer,

--- a/circuits/transfer/src/withdraw_from_obfuscated.rs
+++ b/circuits/transfer/src/withdraw_from_obfuscated.rs
@@ -6,7 +6,6 @@
 
 use crate::gadgets;
 
-use anyhow::Result;
 use dusk_pki::{PublicSpendKey, ViewKey};
 use dusk_plonk::error::Error as PlonkError;
 use dusk_plonk::jubjub::{JubJubAffine, JubJubExtended};
@@ -109,10 +108,8 @@ impl WithdrawFromObfuscatedCircuit {
     }
 }
 
+#[code_hasher::hash(CIRCUIT_ID, version = "0.1.0")]
 impl Circuit for WithdrawFromObfuscatedCircuit {
-    // TODO Define ID
-    const CIRCUIT_ID: [u8; 32] = [0xff; 32];
-
     fn gadget(
         &mut self,
         composer: &mut StandardComposer,

--- a/circuits/transfer/tests/execute.rs
+++ b/circuits/transfer/tests/execute.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use transfer_circuits::ExecuteCircuit;
+use transfer_circuits::{ExecuteCircuit, TRANSCRIPT_LABEL};
 
 use dusk_plonk::circuit;
 use rand::rngs::StdRng;
@@ -13,7 +13,6 @@ use rand::SeedableRng;
 #[test]
 fn execute() {
     let mut rng = StdRng::seed_from_u64(2324u64);
-    let use_rusk_profile = true;
 
     for inputs in 1..5 {
         for outputs in 0..3 {
@@ -21,11 +20,9 @@ fn execute() {
                 let (_, pp, _, vd, proof, pi) =
                     ExecuteCircuit::create_dummy_proof(
                         &mut rng,
-                        None,
                         inputs,
                         outputs,
                         *use_crossover,
-                        use_rusk_profile,
                     )
                     .expect("Failed to create the circuit!");
 
@@ -35,7 +32,7 @@ fn execute() {
                     &proof,
                     pi.as_slice(),
                     vd.pi_pos(),
-                    b"dusk-network",
+                    TRANSCRIPT_LABEL,
                 )
                 .expect("Failed to verify the proof!");
             }

--- a/circuits/transfer/tests/keys/mod.rs
+++ b/circuits/transfer/tests/keys/mod.rs
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use transfer_circuits::Error;
+
+use dusk_plonk::prelude::*;
+
+pub fn circuit_keys<C>(
+) -> Result<(PublicParameters, ProverKey, VerifierData), Error>
+where
+    C: Circuit,
+{
+    let pp = rusk_profile::get_common_reference_string().map(|pp| unsafe {
+        PublicParameters::from_slice_unchecked(pp.as_slice())
+    })?;
+
+    let keys = rusk_profile::keys_for(&C::CIRCUIT_ID)?;
+    let pk = keys.get_prover()?;
+    let vd = keys.get_verifier()?;
+
+    let pk = ProverKey::from_slice(pk.as_slice())?;
+    let vd = VerifierData::from_slice(vd.as_slice())?;
+
+    Ok((pp, pk, vd))
+}

--- a/circuits/transfer/tests/send_to_contract_obfuscated.rs
+++ b/circuits/transfer/tests/send_to_contract_obfuscated.rs
@@ -5,16 +5,17 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use std::convert::TryInto;
-use transfer_circuits::{builder, SendToContractObfuscatedCircuit};
+use transfer_circuits::{SendToContractObfuscatedCircuit, TRANSCRIPT_LABEL};
 
 use dusk_pki::SecretSpendKey;
 use dusk_plonk::circuit;
-use dusk_plonk::jubjub::JubJubAffine;
 use phoenix_core::{Message, Note};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
 use dusk_plonk::prelude::*;
+
+mod keys;
 
 #[test]
 fn send_to_contract_obfuscated_public_key() {
@@ -56,13 +57,11 @@ fn send_to_contract_obfuscated_public_key() {
     )
     .expect("Failed to generate circuit!");
 
-    let id = SendToContractObfuscatedCircuit::rusk_keys_id();
-    let (pp, pk, vd) =
-        builder::circuit_keys(&mut rng, None, &mut circuit, id, true)
-            .expect("Failed to generate circuit!");
+    let (pp, pk, vd) = keys::circuit_keys::<SendToContractObfuscatedCircuit>()
+        .expect("Failed to generate circuit!");
 
     let proof = circuit
-        .gen_proof(&pp, &pk, b"dusk-network")
+        .gen_proof(&pp, &pk, TRANSCRIPT_LABEL)
         .expect("Failed to generate proof!");
     let pi = circuit.public_inputs();
 
@@ -75,7 +74,7 @@ fn send_to_contract_obfuscated_public_key() {
         &proof,
         pi.as_slice(),
         vd.pi_pos(),
-        b"dusk-network",
+        TRANSCRIPT_LABEL,
     )
     .expect("Failed to verify the proof!");
 }
@@ -120,13 +119,11 @@ fn send_to_contract_obfuscated_private_key() {
     )
     .expect("Failed to generate circuit!");
 
-    let id = SendToContractObfuscatedCircuit::rusk_keys_id();
-    let (pp, pk, vd) =
-        builder::circuit_keys(&mut rng, None, &mut circuit, id, true)
-            .expect("Failed to generate circuit!");
+    let (pp, pk, vd) = keys::circuit_keys::<SendToContractObfuscatedCircuit>()
+        .expect("Failed to generate circuit!");
 
     let proof = circuit
-        .gen_proof(&pp, &pk, b"dusk-network")
+        .gen_proof(&pp, &pk, TRANSCRIPT_LABEL)
         .expect("Failed to generate proof!");
     let pi = circuit.public_inputs();
 
@@ -139,7 +136,7 @@ fn send_to_contract_obfuscated_private_key() {
         &proof,
         pi.as_slice(),
         vd.pi_pos(),
-        b"dusk-network",
+        TRANSCRIPT_LABEL,
     )
     .expect("Failed to verify the proof!");
 }

--- a/circuits/transfer/tests/send_to_contract_transparent.rs
+++ b/circuits/transfer/tests/send_to_contract_transparent.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use std::convert::TryInto;
-use transfer_circuits::{builder, SendToContractTransparentCircuit};
+use transfer_circuits::{SendToContractTransparentCircuit, TRANSCRIPT_LABEL};
 
 use dusk_pki::SecretSpendKey;
 use dusk_plonk::circuit;
@@ -14,6 +14,8 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 
 use dusk_plonk::prelude::*;
+
+mod keys;
 
 #[test]
 fn send_to_contract_transparent() {
@@ -48,13 +50,11 @@ fn send_to_contract_transparent() {
     )
     .expect("Failed to create STCT circuit!");
 
-    let id = SendToContractTransparentCircuit::rusk_keys_id();
-    let (pp, pk, vd) =
-        builder::circuit_keys(&mut rng, None, &mut circuit, id, true)
-            .expect("Failed to generate circuit!");
+    let (pp, pk, vd) = keys::circuit_keys::<SendToContractTransparentCircuit>()
+        .expect("Failed to generate circuit!");
 
     let proof = circuit
-        .gen_proof(&pp, &pk, b"dusk-network")
+        .gen_proof(&pp, &pk, TRANSCRIPT_LABEL)
         .expect("Failed to generate proof!");
     let pi = circuit.public_inputs();
 
@@ -64,7 +64,7 @@ fn send_to_contract_transparent() {
         &proof,
         pi.as_slice(),
         vd.pi_pos(),
-        b"dusk-network",
+        TRANSCRIPT_LABEL,
     )
     .expect("Failed to verify the proof!");
 }

--- a/circuits/transfer/tests/withdraw_from_obfuscated.rs
+++ b/circuits/transfer/tests/withdraw_from_obfuscated.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use transfer_circuits::{builder, WithdrawFromObfuscatedCircuit};
+use transfer_circuits::{WithdrawFromObfuscatedCircuit, TRANSCRIPT_LABEL};
 
 use dusk_pki::SecretSpendKey;
 use dusk_plonk::circuit;
@@ -13,6 +13,8 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 
 use dusk_plonk::prelude::*;
+
+mod keys;
 
 #[test]
 fn withdraw_from_obfuscated() {
@@ -49,13 +51,11 @@ fn withdraw_from_obfuscated() {
     )
     .expect("Failed to generate circuit!");
 
-    let id = WithdrawFromObfuscatedCircuit::rusk_keys_id();
-    let (pp, pk, vd) =
-        builder::circuit_keys(&mut rng, None, &mut circuit, id, true)
-            .expect("Failed to generate circuit!");
+    let (pp, pk, vd) = keys::circuit_keys::<WithdrawFromObfuscatedCircuit>()
+        .expect("Failed to generate circuit!");
 
     let proof = circuit
-        .gen_proof(&pp, &pk, b"dusk-network")
+        .gen_proof(&pp, &pk, TRANSCRIPT_LABEL)
         .expect("Failed to generate proof!");
     let pi = circuit.public_inputs();
 
@@ -65,7 +65,7 @@ fn withdraw_from_obfuscated() {
         &proof,
         pi.as_slice(),
         vd.pi_pos(),
-        b"dusk-network",
+        TRANSCRIPT_LABEL,
     )
     .expect("Failed to verify the proof!");
 }


### PR DESCRIPTION
Currently the transfer circuit is a single struct implementation that
will iterate its attributes to produce different circuits.

This doesn't work with the new circuit hasher structure because it uses
the gadget code to generate the identifier of a circuit.

The current implementation will produce different circuits with the same
gadget code depending on the inputs.

This commit splits the `ExecuteCircuit` into different concrete
structures and uses an enum mapping to encapsulate the inputs and
outputs operations.

Resolves #275