### PR TITLE
rusk: Add transfer circuits in keys build scheme

### DIFF
--- a/circuits/transfer/CHANGELOG.md
+++ b/circuits/transfer/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [0.1.0] - 2021-05-20
+
+### Added
+
+- Add `transfer-circuits` to Rusk keys scheme [#302]
+
+[#302]: https://github.com/dusk-network/rusk/issues/302
+[0.1.0]: https://github.com/dusk-network/rusk/releases/tag/transfer-circuits-0.1.0

--- a/circuits/transfer/src/error.rs
+++ b/circuits/transfer/src/error.rs
@@ -23,6 +23,7 @@ pub enum Error {
     KeysNotFound,
     CircuitMaximumInputs,
     CircuitMaximumOutputs,
+    IncorrectExecuteCircuitVariant(usize, usize),
 }
 
 impl fmt::Display for Error {

--- a/circuits/transfer/src/execute.rs
+++ b/circuits/transfer/src/execute.rs
@@ -29,7 +29,7 @@ mod input;
 mod output;
 mod variants;
 
-use variants::*;
+pub use variants::*;
 
 #[cfg(any(test, feature = "builder"))]
 pub mod builder;
@@ -109,7 +109,7 @@ impl ExecuteCircuit {
             Self::ExecuteCircuitOneZero(c) => {
                 let result;
                 let (inputs, crossover, outputs, tx_hash) = c.into_inner();
-                if c.inputs().len() > 1 {
+                if !c.inputs().is_empty() {
                     let mut c = ExecuteCircuitTwoZero::new(
                         inputs, crossover, outputs, tx_hash,
                     );
@@ -127,7 +127,7 @@ impl ExecuteCircuit {
             Self::ExecuteCircuitOneOne(c) => {
                 let result;
                 let (inputs, crossover, outputs, tx_hash) = c.into_inner();
-                if c.inputs().len() > 1 {
+                if !c.inputs().is_empty() {
                     let mut c = ExecuteCircuitTwoOne::new(
                         inputs, crossover, outputs, tx_hash,
                     );
@@ -145,7 +145,7 @@ impl ExecuteCircuit {
             Self::ExecuteCircuitOneTwo(c) => {
                 let result;
                 let (inputs, crossover, outputs, tx_hash) = c.into_inner();
-                if c.inputs().len() > 1 {
+                if !c.inputs().is_empty() {
                     let mut c = ExecuteCircuitTwoTwo::new(
                         inputs, crossover, outputs, tx_hash,
                     );

--- a/circuits/transfer/src/execute/variants.rs
+++ b/circuits/transfer/src/execute/variants.rs
@@ -5,8 +5,8 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use super::{
-    CircuitCrossover, CircuitInput, CircuitOutput, WitnessInput, WitnessOutput,
-    POSEIDON_BRANCH_DEPTH,
+    CircuitCrossover, CircuitInput, CircuitOutput, ExecuteCircuit,
+    WitnessInput, WitnessOutput, POSEIDON_BRANCH_DEPTH,
 };
 use crate::{gadgets, Error};
 
@@ -22,6 +22,8 @@ use dusk_poseidon::sponge;
 use dusk_poseidon::tree::{self, PoseidonBranch};
 use dusk_schnorr::Proof as SchnorrProof;
 use phoenix_core::{Crossover, Fee, Note};
+
+use std::convert::TryFrom;
 
 use dusk_plonk::prelude::*;
 
@@ -208,6 +210,20 @@ macro_rules! execute_circuit_variant {
 
             pub fn outputs(&self) -> &[CircuitOutput] {
                 self.outputs.as_slice()
+            }
+        }
+
+        impl TryFrom<ExecuteCircuit> for $i {
+            type Error = Error;
+
+            fn try_from(c: ExecuteCircuit) -> Result<Self, Self::Error> {
+                match c {
+                    ExecuteCircuit::$i(c) => Ok(c),
+                    _ => Err(Error::IncorrectExecuteCircuitVariant(
+                        c.inputs().len(),
+                        c.outputs().len(),
+                    )),
+                }
             }
         }
 
@@ -450,9 +466,9 @@ macro_rules! execute_circuit_variant {
 
 execute_circuit_variant!(ExecuteCircuitOneZero, 15);
 execute_circuit_variant!(ExecuteCircuitOneOne, 15);
-execute_circuit_variant!(ExecuteCircuitOneTwo, 15);
-execute_circuit_variant!(ExecuteCircuitTwoZero, 15);
-execute_circuit_variant!(ExecuteCircuitTwoOne, 15);
+execute_circuit_variant!(ExecuteCircuitOneTwo, 16);
+execute_circuit_variant!(ExecuteCircuitTwoZero, 16);
+execute_circuit_variant!(ExecuteCircuitTwoOne, 16);
 execute_circuit_variant!(ExecuteCircuitTwoTwo, 16);
 execute_circuit_variant!(ExecuteCircuitThreeZero, 17);
 execute_circuit_variant!(ExecuteCircuitThreeOne, 17);

--- a/circuits/transfer/src/lib.rs
+++ b/circuits/transfer/src/lib.rs
@@ -16,7 +16,7 @@ mod withdraw_from_obfuscated;
 pub const TRANSCRIPT_LABEL: &'static [u8] = b"dusk-network";
 
 pub use error::Error;
-pub use execute::ExecuteCircuit;
+pub use execute::*;
 pub use send_to_contract_obfuscated::SendToContractObfuscatedCircuit;
 pub use send_to_contract_transparent::SendToContractTransparentCircuit;
 pub use withdraw_from_obfuscated::WithdrawFromObfuscatedCircuit;

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -62,7 +62,7 @@ dusk-plonk = { version = "0.8", features = ["canon", "std"] }
 dusk-poseidon = { version = "0.21.0-rc", features=["canon"] }
 dusk-blindbid = "0.8.0-rc"
 dusk-pki = "0.7.0-rc"
-phoenix-core = "0.11.0-rc.0"
+phoenix-core = "0.11.0-rc"
 anyhow = "1.0"
 rand = "0.8"
 bid-circuits = { path = "../circuits/bid" }


### PR DESCRIPTION
The transfer circuits keys were removed from the rusk build script while
the update to `dusk-plonk` latest was being performed.

With the recent change on transfer circuits to comply with plonk latest
and implement code-hasher, these keys can be reintroduced to the script.

Resolves #302