### PR TITLE
Fix keys cache process

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           cache-name: cache-rusk-profile-v2
         with:
-          path: ${{ github.workspace }}
+          path: ${{ github.workspace }}/.rusk
           key: ${{ runner.os }}-build-${{ env.cache-name }}
           restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}
 

--- a/.github/workflows/profile_ci.yml
+++ b/.github/workflows/profile_ci.yml
@@ -13,7 +13,7 @@ jobs:
         env:
           cache-name: cache-rusk-profile-v2
         with:
-          path: ${{ github.workspace }}
+          path: ${{ github.workspace }}/.rusk
           key: ${{ runner.os }}-build-${{ env.cache-name }}
           restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}
 

--- a/circuits/bid/Cargo.toml
+++ b/circuits/bid/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 dusk-plonk = "0.8"
 plonk_gadgets = "0.6.0-rc"
 dusk-blindbid = "0.8.0-rc"
-code-hasher = {version = "0.1", path = "../../macros/code-hasher"}
+code-hasher = {path = "../../macros/code-hasher"}
 
 [dev-dependencies]
 rand = "0.8"

--- a/contracts/bid/Makefile
+++ b/contracts/bid/Makefile
@@ -3,22 +3,22 @@ help: ## Display this help screen
 		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-# wasm: ## Build the WASM files
-# 	@mkdir -p ./target/verifier-keys/
-# 	@cp -fr ~/.rusk/keys/bid-circuits/**/*.vk ./target/verifier-keys
-# 	@cargo rustc \
-# 		--release \
-# 		--target wasm32-unknown-unknown \
-# 		--no-default-features \
-# 		-- -C link-args=-s
+wasm: ## Build the WASM files
+	@cargo rustc \
+		-vvv \
+		--release \
+		--target wasm32-unknown-unknown \
+		--no-default-features \
+		-- -C link-args=-s
 
-# check: wasm ## Run the Rust check on the project features
-# 	@cargo check --target wasm32-unknown-unknown
-# 	@cargo check
+check: wasm ## Run the Rust check on the project features
+	@cargo check --target wasm32-unknown-unknown
+	@cargo check
 
-# test: wasm ## Perform the contract tests defined in the host module
-# 	@cargo test \
-# 		--release \
-# 		--features host
+test: wasm ## Perform the contract tests defined in the host module
+	@cargo test \
+		-vvv \
+		--release \
+		--features host
 
 .PHONY: wasm check test help

--- a/contracts/bid/Makefile
+++ b/contracts/bid/Makefile
@@ -5,7 +5,6 @@ help: ## Display this help screen
 
 wasm: ## Build the WASM files
 	@cargo rustc \
-		-vvv \
 		--release \
 		--target wasm32-unknown-unknown \
 		--no-default-features \

--- a/contracts/transfer/Makefile
+++ b/contracts/transfer/Makefile
@@ -8,6 +8,7 @@ wasm: ## Build the WASM files
 	@rm -fr ./target/verifier-keys/*.vk
 	@cp -fr ~/.rusk/keys/transfer-circuits/**/*.vk ./target/verifier-keys/
 	@cargo rustc \
+		-vvv \
 		--release \
 		--target wasm32-unknown-unknown \
 		--no-default-features \
@@ -21,6 +22,7 @@ check: wasm ## Run the Rust check on the project features
 	@cargo check
 
 test: wasm ## Perform the contract tests defined in the host module
-	@cargo test --release
+	@cargo test -vvv --release
+		
 
 .PHONY: wasm check test help

--- a/contracts/transfer/Makefile
+++ b/contracts/transfer/Makefile
@@ -8,7 +8,6 @@ wasm: ## Build the WASM files
 	@rm -fr ./target/verifier-keys/*.vk
 	@cp -fr ~/.rusk/keys/transfer-circuits/**/*.vk ./target/verifier-keys/
 	@cargo rustc \
-		-vvv \
 		--release \
 		--target wasm32-unknown-unknown \
 		--no-default-features \

--- a/macros/code-hasher/Cargo.toml
+++ b/macros/code-hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-hasher"
-version = "0.1.0"
+version = "0.2.0-rc.0"
 authors = ["CPerezz <carlos@dusk.network>"]
 edition = "2018"
 

--- a/macros/code-hasher/src/lib.rs
+++ b/macros/code-hasher/src/lib.rs
@@ -39,18 +39,19 @@ use proc_macro::TokenStream;
 #[proc_macro_attribute]
 pub fn hash(attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut hasher = Hasher::new();
+    let input_string = format!("{:?}", input);
 
     // We need to `let` this otherways it gets freed while borrowed.
-    let attrs_string = format!("{}", attr.to_string());
+    let attrs_string = attr.to_string();
     let attrs_split: Vec<&str> = attrs_string.split(",").collect();
 
     // Add the code version (passed as attribute) to the hasher.
     hasher.update(attrs_split.get(1).unwrap_or(&"").as_bytes());
     // Add code-block to the hasher.
-    hasher.update(input.to_string().as_bytes());
+    hasher.update(input_string.as_bytes());
 
     let id = hasher.finalize().as_bytes().clone();
-    let mut token_stream = format!("{}", input.to_string());
+    let mut token_stream = input.to_string();
     token_stream.pop();
     token_stream.push_str(&format!(
         "    const {}: [u8; 32] = {:?};",

--- a/rusk/Makefile
+++ b/rusk/Makefile
@@ -2,10 +2,11 @@ help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 keys: ## Build circuit keys
-	cargo build --release
+	cargo build -vvv --release
 
 test: ## Run Rusk tests
 	@cargo test \
+		-vvv \
 		--release \
 		-- --nocapture \
 		--test-threads 1


### PR DESCRIPTION
Due to the fact that we're not printing directly the AST but we're
stringlyfiyng it, the ID's that the macro was producing were different
IDs for the same circuit when different toolchains were used (most
likely due to padding and formatting issues).

- Fixed the `code-hasher` macro to avoid `String` usage and just use AST prints to avoid formatting.
- Updated Makefiles of the workspace to provide extra-verbose output when calling `rustc`.

Resolves: #314