### PR TITLE
rusk-abi: ensure contracts' ids are "BlsScalar-friendly"

### DIFF
--- a/rusk-abi/CHANGELOG.md
+++ b/rusk-abi/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+
+- Add `stake_contract` method for host and hosted [#338]
+- Add `transfer_contract` method for host [#338]
+- Add `gen_contract_id` method for host [#337]
+
+## Remove
+
+- Remove `transfer_address` and `stake_address` methods for host [#338]
+
 ## [0.4.0] - 2021-07-16
 
 ## Added
@@ -80,6 +90,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add LICENSE
 - Add README.md
 
+[#338]: https://github.com/dusk-network/rusk/issues/338
+[#337]: https://github.com/dusk-network/rusk/issues/337
 [#328]: https://github.com/dusk-network/rusk/issues/328
 [#327]: https://github.com/dusk-network/rusk/issues/327
 [#227]: https://github.com/dusk-network/rusk/issues/227

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -26,6 +26,7 @@ dusk-bytes = "0.1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dusk-plonk = { version = "0.8", default-features = false, features = ["canon"] }
 rusk-profile = { path = "../rusk-profile" }
+blake2b_simd = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 rusk-vm = "0.6.0-rc"

--- a/rusk-abi/src/host.rs
+++ b/rusk-abi/src/host.rs
@@ -6,12 +6,12 @@
 
 extern crate alloc;
 
-use crate::genesis;
 use alloc::vec::Vec;
+use blake2b_simd::Params;
 use canonical::{Canon, CanonError, Source};
-use dusk_abi::{HostModule, Query, ReturnValue};
+use dusk_abi::{ContractId, HostModule, Query, ReturnValue};
 use dusk_bls12_381::BlsScalar;
-use dusk_bytes::DeserializableSlice;
+use dusk_bytes::{DeserializableSlice, Serializable};
 use dusk_pki::PublicKey;
 use dusk_plonk::circuit::{self, VerifierData};
 use dusk_plonk::prelude::*;
@@ -19,14 +19,16 @@ use dusk_schnorr::Signature;
 
 use crate::{PublicInput, RuskModule};
 
-/// Returns the transfer address for the transfer contract in bytes
-pub const fn transfer_address() -> [u8; 32] {
-    genesis::TRANSFER_ADDRESS
-}
+/// Generate a [`ContractId`] address from the given slice of bytes, that is
+/// also a valid [`BlsScalar`]
+pub fn gen_contract_id(bytes: &[u8]) -> ContractId {
+    let mut state = Params::new().hash_length(64).to_state();
+    state.update(bytes);
 
-/// Returns the stake address for the transfer contract in bytes
-pub const fn stake_address() -> [u8; 32] {
-    genesis::STAKE_ADDRESS
+    let mut buf = [0u8; 64];
+    buf.copy_from_slice(state.finalize().as_ref());
+
+    ContractId::from_raw(BlsScalar::from_bytes_wide(&buf).to_bytes())
 }
 
 impl RuskModule {

--- a/rusk-abi/src/hosted.rs
+++ b/rusk-abi/src/hosted.rs
@@ -14,12 +14,7 @@ use dusk_bls12_381::BlsScalar;
 use dusk_pki::PublicKey;
 use dusk_schnorr::Signature;
 
-use crate::{genesis, PaymentInfo, PublicInput, PAYMENT_INFO};
-
-/// Contract ID of the deployed transfer contract
-pub const fn transfer_contract() -> ContractId {
-    ContractId::from_raw(genesis::TRANSFER_ADDRESS)
-}
+use crate::{PaymentInfo, PublicInput, PAYMENT_INFO};
 
 pub fn poseidon_hash(scalars: Vec<BlsScalar>) -> BlsScalar {
     dusk_abi::query(&RuskModule::id(), &(RuskModule::POSEIDON_HASH, scalars))

--- a/rusk-abi/src/lib.rs
+++ b/rusk-abi/src/lib.rs
@@ -63,19 +63,14 @@ pub enum PaymentInfo {
 /// Common QueryId used for Payment info retrival.
 pub const PAYMENT_INFO: u8 = 100;
 
-#[allow(dead_code)]
-pub(crate) mod genesis {
-    use dusk_bytes::hex;
+/// Contract ID of the genesis transfer contract
+pub const fn transfer_contract() -> ContractId {
+    ContractId::reserved(0x1)
+}
 
-    /// Transfer Contract Address
-    pub const TRANSFER_ADDRESS: [u8; 32] = hex(
-        b"d3f87ffc1bc7431dde815fb1e11bd0fe88371a154aec275ded024d8cc0f7995f",
-    );
-
-    /// Stake Contract Adddress
-    pub const STAKE_ADDRESS: [u8; 32] = hex(
-        b"286589afe95df3cc324ed9d168065038ef1ea2923054584f588d1c9e06920ef1",
-    );
+/// Contract ID of the genesis stake contract
+pub const fn stake_contract() -> ContractId {
+    ContractId::reserved(0x2)
 }
 
 cfg_if::cfg_if! {


### PR DESCRIPTION
- Add `stake_contract` method for host and hosted 
- Add `transfer_contract` method for host
- Add `gen_contract_id` method for host
- Remove `transfer_address` and `stake_address` methods for host

Resolves: #337, #338
