### PR TITLE
Improve CI execution time

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -5,7 +5,7 @@ name: Continuous integration
 jobs:
   analyze:
     name: Dusk Analyzer
-    runs-on: ubuntu-latest
+    runs-on: core
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -22,29 +22,32 @@ jobs:
 
   test_nightly:
     name: Nightly tests
-    runs-on: ubuntu-latest
+    runs-on: core
     steps:
       - uses: actions/checkout@v2
-
-      - name: Cache .rusk profile
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-rusk-profile-v2
-        with:
-          path: ${{ github.workspace }}/.rusk
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
-          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}
-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
       - run: rustup component add rustfmt
       - run: rustup target add wasm32-unknown-unknown
-      - run: RUSK_PROFILE_PATH=$GITHUB_WORKSPACE make test
+
+      - name: Cache Cargo home
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-cargo-home
+        with:
+          # See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{env.cache-name}}-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+
+      - run: RUSK_PROFILE_PATH="/var/opt/build-cache" make -j test
 
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-latest
+    runs-on: core
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Makefile
+++ b/Makefile
@@ -13,20 +13,21 @@ keys: ## Create the keys for the circuits
 	$(MAKE) -C ./rusk keys
 
 wasm: ## Generate the WASM for all the contracts
-	$(MAKE) -C ./contracts wasm
+	$(MAKE) -j -C ./contracts wasm
 
 circuits: keys ## Build and test circuit crates
-	$(MAKE) -C ./circuits test
+	$(MAKE) -j -C ./circuits test
 
 contracts: ## Execute the test for all contracts
-	$(MAKE) -C ./contracts test
+	$(MAKE) -j1 -C ./contracts test
 
 utils: ## Execute the test for utils 
 	$(MAKE) -C ./test-utils test
 
-test: abi circuits macros contracts utils ## Run the tests
+test: abi circuits macros contracts ## Run the tests
 	$(MAKE) -C ./rusk/ $@
-	
+	$(MAKE) -C ./test-utils test
+
 run: wasm ## Run the server
 	cargo run --release
 

--- a/circuits/transfer/tests/execute.rs
+++ b/circuits/transfer/tests/execute.rs
@@ -10,18 +10,20 @@ use dusk_plonk::circuit;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
-#[test]
-fn execute() {
-    let mut rng = StdRng::seed_from_u64(2324u64);
+macro_rules! execute {
+    ($test_name:ident, $inputs:expr, $outputs:expr) => {
+        #[test]
+        fn $test_name() {
+            let mut rng = StdRng::seed_from_u64(2324u64);
 
-    for inputs in 1..5 {
-        for outputs in 0..3 {
+            // for inputs in 1..5 {
+            //     for outputs in 0..3 {
             for use_crossover in [true, false].iter() {
                 let (_, pp, _, vd, proof, pi) =
                     ExecuteCircuit::create_dummy_proof(
                         &mut rng,
-                        inputs,
-                        outputs,
+                        $inputs,
+                        $outputs,
                         *use_crossover,
                     )
                     .expect("Failed to create the circuit!");
@@ -37,5 +39,21 @@ fn execute() {
                 .expect("Failed to verify the proof!");
             }
         }
-    }
+    };
 }
+
+execute!(execute_1_0, 1, 0);
+execute!(execute_1_1, 1, 1);
+execute!(execute_1_2, 1, 2);
+
+execute!(execute_2_0, 2, 0);
+execute!(execute_2_1, 2, 1);
+execute!(execute_2_2, 2, 2);
+
+execute!(execute_3_0, 3, 0);
+execute!(execute_3_1, 3, 1);
+execute!(execute_3_2, 3, 2);
+
+execute!(execute_4_0, 4, 0);
+execute!(execute_4_1, 4, 1);
+execute!(execute_4_2, 4, 2);

--- a/contracts/bid/src/lib.rs
+++ b/contracts/bid/src/lib.rs
@@ -32,9 +32,7 @@ use map::KeyToIdxMap;
 
 /// `VerifierKey` used by the `BidCorrectnessCircuit` to verify a
 /// Bid correctness `Proof` using the PLONK proving systyem.
-pub const BID_CORRECTNESS_VD: &[u8] = core::include_bytes!(
-    "../../../.rusk/keys/9213f1d9a165da07ceb3eafebefbd1216bb80ab151e7e1ae888ad4670c2bef70.vd"
-);
+pub const BID_CORRECTNESS_VD: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/9213f1d9a165da07ceb3eafebefbd1216bb80ab151e7e1ae888ad4670c2bef70.vd"));
 
 /// OPCODEs for each contract method
 pub mod ops {
@@ -51,12 +49,15 @@ pub mod ops {
 pub mod contract_constants {
     use rusk_abi::PaymentInfo;
 
-    /// Value of an epoch in blocks. Unit computable against block_height values.
+    /// Value of an epoch in blocks. Unit computable against block_height
+    /// values.
     pub const EPOCH: u64 = 2_160;
-    /// Amount of blocks it takes for the bid to be eligible to participate in the consensus after
-    /// the originating bid transaction has been included in the block.
+    /// Amount of blocks it takes for the bid to be eligible to participate in
+    /// the consensus after the originating bid transaction has been
+    /// included in the block.
     pub const MATURITY_PERIOD: u64 = 2 * EPOCH;
-    /// Amount of blocks the bid can be eligible to participate in the consensus before expiring.
+    /// Amount of blocks the bid can be eligible to participate in the consensus
+    /// before expiring.
     pub const VALIDITY_PERIOD: u64 = 56 * EPOCH;
     /// Height of the `BidTree` used inside of the BidContract in order to
     /// store the `Bid`s and provide merkle openings to them.

--- a/contracts/transfer/src/transfer/circuits.rs
+++ b/contracts/transfer/src/transfer/circuits.rs
@@ -10,23 +10,23 @@ use dusk_abi::ContractId;
 use dusk_bls12_381::BlsScalar;
 use phoenix_core::{Crossover, Message};
 
-const VD_EXEC_1_0: &[u8] = include_bytes!("../../../../.rusk/keys/cc6893178ef24743becdef0b4a076ccc1eb9d289dd2bc1ce781cd0886298ffa7.vd");
-const VD_EXEC_1_1: &[u8] = include_bytes!("../../../../.rusk/keys/9102a739a4d9421e46d68f0f804ebe923618fa5219a6e6518301071b6d305682.vd");
-const VD_EXEC_1_2: &[u8] = include_bytes!("../../../../.rusk/keys/10054c6f8c4db14adaa9e7781fab32035bb95b1403910b92f28f11fa32b3e730.vd");
-const VD_EXEC_2_0: &[u8] = include_bytes!("../../../../.rusk/keys/fa741d95897d77fd5519c521bfbe4b4a015383b41302abd93a33e258bd4b8e63.vd");
-const VD_EXEC_2_1: &[u8] = include_bytes!("../../../../.rusk/keys/66d564fa7e0c3539d20d30d09b58a179f462b82579c9ef021fa455b6e4048c30.vd");
-const VD_EXEC_2_2: &[u8] = include_bytes!("../../../../.rusk/keys/e3111ac2549ed2c94a15959122e122be228e18ed99da0a192ce5af7bb1608a04.vd");
-const VD_EXEC_3_0: &[u8] = include_bytes!("../../../../.rusk/keys/7c3baf0b6a6c5c18868f94152da5ac17038d7e6ddd4a51a29cd8535bcf53d975.vd");
-const VD_EXEC_3_1: &[u8] = include_bytes!("../../../../.rusk/keys/74b1e904743aadc2d3521bb270e560a8a15132651f78e441bde8c1c9affc0d99.vd");
-const VD_EXEC_3_2: &[u8] = include_bytes!("../../../../.rusk/keys/806435350ca58d106ebfc8ecd5d7ff28681408d033cfcf507e84dd348d72078d.vd");
-const VD_EXEC_4_0: &[u8] = include_bytes!("../../../../.rusk/keys/d16fc8a82893cb5ff46c9ba209e8bb996d32a2f0f996d9a88b5d208f97b38872.vd");
-const VD_EXEC_4_1: &[u8] = include_bytes!("../../../../.rusk/keys/6882ebd5829fad487422444655dcfcc74f8886b91b7e7919ed3cc6fc9d8bf927.vd");
-const VD_EXEC_4_2: &[u8] = include_bytes!("../../../../.rusk/keys/4dd500add96f7a5f9a5ed3edf7532774d8c2679db357ec7ddce2723e4d12b798.vd");
+const VD_EXEC_1_0: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/cc6893178ef24743becdef0b4a076ccc1eb9d289dd2bc1ce781cd0886298ffa7.vd"));
+const VD_EXEC_1_1: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/9102a739a4d9421e46d68f0f804ebe923618fa5219a6e6518301071b6d305682.vd"));
+const VD_EXEC_1_2: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/10054c6f8c4db14adaa9e7781fab32035bb95b1403910b92f28f11fa32b3e730.vd"));
+const VD_EXEC_2_0: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/fa741d95897d77fd5519c521bfbe4b4a015383b41302abd93a33e258bd4b8e63.vd"));
+const VD_EXEC_2_1: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/66d564fa7e0c3539d20d30d09b58a179f462b82579c9ef021fa455b6e4048c30.vd"));
+const VD_EXEC_2_2: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/e3111ac2549ed2c94a15959122e122be228e18ed99da0a192ce5af7bb1608a04.vd"));
+const VD_EXEC_3_0: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/7c3baf0b6a6c5c18868f94152da5ac17038d7e6ddd4a51a29cd8535bcf53d975.vd"));
+const VD_EXEC_3_1: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/74b1e904743aadc2d3521bb270e560a8a15132651f78e441bde8c1c9affc0d99.vd"));
+const VD_EXEC_3_2: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/806435350ca58d106ebfc8ecd5d7ff28681408d033cfcf507e84dd348d72078d.vd"));
+const VD_EXEC_4_0: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/d16fc8a82893cb5ff46c9ba209e8bb996d32a2f0f996d9a88b5d208f97b38872.vd"));
+const VD_EXEC_4_1: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/6882ebd5829fad487422444655dcfcc74f8886b91b7e7919ed3cc6fc9d8bf927.vd"));
+const VD_EXEC_4_2: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/4dd500add96f7a5f9a5ed3edf7532774d8c2679db357ec7ddce2723e4d12b798.vd"));
 
-const VD_STCT: &[u8] = include_bytes!("../../../../.rusk/keys/5e80819a6fb131d3eb9631d53cc31e17dcdf300d8f998ada58d972cba1bb666e.vd");
-const VD_STCO: &[u8] = include_bytes!("../../../../.rusk/keys/119f07727cd7cb33aad7e0d53f22fdb398cbe7cb35dd0ad752e4d1fa5abf2799.vd");
-const VD_WDFT: &[u8] = include_bytes!("../../../../.rusk/keys/ca00902797ac1d0cdf4d1b67e6959b2d79c4837c18bb60c49cffdfa5530f552a.vd");
-const VD_WDFO: &[u8] = include_bytes!("../../../../.rusk/keys/00001fbf781109d2867196fc5afb9b687e1394a414cf2bb3510af2bc199b9033.vd");
+const VD_STCT: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/5e80819a6fb131d3eb9631d53cc31e17dcdf300d8f998ada58d972cba1bb666e.vd"));
+const VD_STCO: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/119f07727cd7cb33aad7e0d53f22fdb398cbe7cb35dd0ad752e4d1fa5abf2799.vd"));
+const VD_WDFT: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/ca00902797ac1d0cdf4d1b67e6959b2d79c4837c18bb60c49cffdfa5530f552a.vd"));
+const VD_WDFO: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/00001fbf781109d2867196fc5afb9b687e1394a414cf2bb3510af2bc199b9033.vd"));
 
 impl TransferContract {
     pub const fn verifier_data_execute(


### PR DESCRIPTION
- Change workflow to run on self hosted
- Change `Makefile` to have more parallels builds and tests
- transfer-contract: Change `execute` test to run in parallel
-  bid-contract: Use `RUSK_PROFILE_PATH` to include the verifier data
- transfer-contract: Use `RUSK_PROFILE_PATH` to include the verifier data

    We assumed the profile path for the verifier data was always the
    repository root, but this might not be the case.
    For example, the rusk profile path on self hosted is outside
    the docker container (where the repos are mounted).

Resolves: #367