### PR TITLE
Upgrade to `wasmer`-enabled `rusk`

### DIFF
--- a/contracts/transfer/Cargo.toml
+++ b/contracts/transfer/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.8"
 transfer-circuits = { path = "../../circuits/transfer", features = ["builder"] }
 rusk-profile = { path = "../../rusk-profile" }
 dusk-plonk = "0.8"
-rusk-vm = "0.6"
+rusk-vm = "0.7.0-rc"
 
 [features]
 no-bridge = []

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -29,7 +29,7 @@ rusk-profile = { path = "../rusk-profile" }
 blake2b_simd = { version = "0.3", default-features = false }
 
 [dev-dependencies]
-rusk-vm = "0.6.0-rc"
+rusk-vm = "0.7.0-rc"
 dusk-bytes = "0.1"
 host_fn = { path = "tests/contracts/host_fn" }
 rand_core = { version = "0.6", features = ["std"] }

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -43,7 +43,6 @@ rusk-profile = { path = "../rusk-profile" }
 rusk-vm = "0.7.0-rc"
 canonical = "0.6"
 canonical_derive = "0.6"
-wasmi = "0.6"
 dusk-bytes = "0.1"
 
 [dev-dependencies]

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -40,7 +40,7 @@ rustc_tools_util = "0.2"
 rand = "0.8"
 lazy_static = "1.4"
 rusk-profile = { path = "../rusk-profile" }
-rusk-vm = "0.6"
+rusk-vm = "0.7.0-rc"
 canonical = "0.6"
 canonical_derive = "0.6"
 wasmi = "0.6"


### PR DESCRIPTION
Upgrades to the new `wasmer`-enabled version of rusk. The version is still a release candidate, but shouldn't change too much afterwards - besides integrating `rkyv` that is.