### PR TITLE
Implement prover service

### DIFF
--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Prover service implementation [#410]
+
 ### Changed
 
 - Update `dusk-poseidon` to `0.22.0-rc` [#327]
@@ -64,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add linking between Rusk and Protobuff structs
 - Add build system that generates keys for circuits and caches them.
 
+[#401]: https://github.com/dusk-network/rusk/issues/401
 [#369]: https://github.com/dusk-network/rusk/issues/369
 [#327]: https://github.com/dusk-network/rusk/issues/327
 [#307]: https://github.com/dusk-network/rusk/issues/307

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -46,6 +46,8 @@ canonical_derive = "0.6"
 wasmi = "0.6"
 dusk-bytes = "0.1"
 kadcast = "0.3"
+dusk-wallet-core = "0.1"
+transfer-circuits = { path = "../circuits/transfer" }
 
 [dev-dependencies]
 tower = "0.4"

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -13,6 +13,7 @@ use futures::TryFutureExt;
 use rusk::services::network::NetworkServer;
 use rusk::services::network::RuskNetwork;
 use rusk::services::pki::KeysServer;
+use rusk::services::prover::ProverServer;
 use rusk::services::state::StateServer;
 use rusk::Rusk;
 use rustc_tools_util::{get_version_info, VersionInfo};
@@ -203,11 +204,12 @@ async fn startup_with_tcp_ip(
     let keys = KeysServer::new(rusk);
     let network = NetworkServer::new(kadcast);
     let state = StateServer::new(rusk);
+    let prover = ProverServer::new(rusk);
 
-    // Build the Server with the `Echo` service attached to it.
     Ok(Server::builder()
         .add_service(keys)
         .add_service(network)
+        .add_service(prover)
         .add_service(state)
         .serve(addr)
         .await?)

--- a/rusk/src/lib/services.rs
+++ b/rusk/src/lib/services.rs
@@ -8,6 +8,7 @@ use tonic::{Request, Response, Status};
 
 pub mod network;
 pub mod pki;
+pub mod prover;
 pub mod state;
 
 pub mod rusk_proto {

--- a/rusk/src/lib/services/prover.rs
+++ b/rusk/src/lib/services/prover.rs
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Prover service implementation for the Rusk server.
+
+mod handler;
+
+use handler::ProverHandler;
+
+use crate::services::{rusk_proto, ServiceRequestHandler};
+use crate::Rusk;
+
+use tonic::{Request, Response, Status};
+use tracing::{error, info};
+
+pub use rusk_proto::{
+    prover_client::ProverClient,
+    prover_server::{Prover, ProverServer},
+    ProverRequest, ProverResponse,
+};
+
+#[tonic::async_trait]
+impl Prover for Rusk {
+    async fn prove(
+        &self,
+        request: Request<ProverRequest>,
+    ) -> Result<Response<ProverResponse>, Status> {
+        info!("Received Prove request");
+        let handler = ProverHandler::load_request(&request);
+        match handler.handle_request() {
+            Ok(response) => {
+                info!("Prove request was successfully processed. Sending response...");
+                Ok(response)
+            }
+            Err(e) => {
+                error!(
+                    "An error ocurred processing the Prove request: {:?}",
+                    e
+                );
+                Err(e)
+            }
+        }
+    }
+}

--- a/rusk/src/lib/services/prover/handler.rs
+++ b/rusk/src/lib/services/prover/handler.rs
@@ -1,0 +1,131 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use super::{rusk_proto, ServiceRequestHandler};
+use dusk_bytes::Serializable;
+
+use dusk_plonk::prelude::*;
+use dusk_wallet_core::UnprovenTransaction;
+use lazy_static::lazy_static;
+use rusk_profile::keys_for;
+use rusk_proto::{ProverRequest, ProverResponse};
+use tonic::{Request, Response, Status};
+use transfer_circuits::{CircuitInput, CircuitInputSignature, ExecuteCircuit};
+
+lazy_static! {
+    static ref PP: PublicParameters = unsafe {
+        let pp = rusk_profile::get_common_reference_string().unwrap();
+
+        PublicParameters::from_slice_unchecked(pp.as_slice())
+    };
+}
+
+pub struct ProverHandler<'a> {
+    _request: &'a Request<ProverRequest>,
+}
+
+impl<'a, 'b> ServiceRequestHandler<'a, 'b, ProverRequest, ProverResponse>
+    for ProverHandler<'a>
+where
+    'b: 'a,
+{
+    fn load_request(request: &'b Request<ProverRequest>) -> Self {
+        Self { _request: request }
+    }
+
+    fn handle_request(&self) -> Result<Response<ProverResponse>, Status> {
+        let utx = UnprovenTransaction::from_slice(&self._request.get_ref().utx)
+            .map_err(|_| {
+                Status::invalid_argument("Failed parsing unproven TX")
+            })?;
+
+        let (num_inputs, num_outputs) =
+            (utx.inputs().len(), utx.outputs().len());
+        let mut circ = circuit_from_numbers(num_inputs, num_outputs)
+            .ok_or_else(|| {
+                Status::invalid_argument(format!(
+                    "No circuit found for number of inputs {} and outputs {}",
+                    num_inputs, num_outputs
+                ))
+            })?;
+
+        let keys = keys_for(circ.circuit_id()).map_err(|_| Status::failed_precondition(format!("Couldn't find keys for circuit with number of inputs {} and outputs {}", num_inputs, num_outputs)))?;
+        let pk = keys.get_prover().map_err(|_| Status::internal(format!("Couldn't find prover key for circuit with number of inputs {} and outputs {}", num_inputs, num_outputs)))?;
+        let pk = ProverKey::from_slice(&pk).map_err(|e| {
+            Status::internal(format!("Prover key malformed: {}", e))
+        })?;
+
+        for input in utx.inputs() {
+            let cis = CircuitInputSignature::from(input.signature());
+            let cinput = CircuitInput::new(
+                input.opening().clone(),
+                *input.note(),
+                input.pk_r_prime().into(),
+                input.value(),
+                input.blinding_factor(),
+                input.nullifier(),
+                cis,
+            );
+            circ.add_input(cinput).map_err(|e| {
+                Status::internal(format!(
+                    "Failed adding input to circuit: {}",
+                    e
+                ))
+            })?;
+        }
+        for (note, value, blinder) in utx.outputs() {
+            circ.add_output_with_data(*note, *value, *blinder).map_err(
+                |e| {
+                    Status::internal(format!(
+                        "Failed adding output to circuit: {}",
+                        e
+                    ))
+                },
+            )?;
+        }
+
+        circ.set_tx_hash(utx.hash());
+        circ.set_fee(utx.fee()).map_err(|e| {
+            Status::invalid_argument(format!("Failed setting fee: {}", e))
+        })?;
+
+        let (crossover, value, blinder) = utx.crossover();
+        circ.set_fee_crossover(utx.fee(), crossover, *value, *blinder);
+
+        let proof = circ.prove(&PP, &pk).map_err(|e| {
+            Status::invalid_argument(format!(
+                "Failed proving transaction: {}",
+                e
+            ))
+        })?;
+        let proof = proof.to_bytes().to_vec();
+
+        Ok(Response::new(ProverResponse { proof }))
+    }
+}
+
+fn circuit_from_numbers(
+    num_inputs: usize,
+    num_outputs: usize,
+) -> Option<ExecuteCircuit> {
+    use ExecuteCircuit::*;
+
+    match (num_inputs, num_outputs) {
+        (1, 0) => Some(ExecuteCircuitOneZero(Default::default())),
+        (1, 1) => Some(ExecuteCircuitOneOne(Default::default())),
+        (1, 2) => Some(ExecuteCircuitOneTwo(Default::default())),
+        (2, 0) => Some(ExecuteCircuitTwoZero(Default::default())),
+        (2, 1) => Some(ExecuteCircuitTwoOne(Default::default())),
+        (2, 2) => Some(ExecuteCircuitTwoTwo(Default::default())),
+        (3, 0) => Some(ExecuteCircuitThreeZero(Default::default())),
+        (3, 1) => Some(ExecuteCircuitThreeOne(Default::default())),
+        (3, 2) => Some(ExecuteCircuitThreeTwo(Default::default())),
+        (4, 0) => Some(ExecuteCircuitFourZero(Default::default())),
+        (4, 1) => Some(ExecuteCircuitFourOne(Default::default())),
+        (4, 2) => Some(ExecuteCircuitFourTwo(Default::default())),
+        _ => None,
+    }
+}

--- a/rusk/tests/services/mod.rs
+++ b/rusk/tests/services/mod.rs
@@ -5,5 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 pub mod pki_service;
+pub mod prover_service;
 
 pub use super::TestContext;

--- a/rusk/tests/services/pki_service.rs
+++ b/rusk/tests/services/pki_service.rs
@@ -11,6 +11,7 @@ use dusk_plonk::prelude::*;
 use rusk::services::rusk_proto::keys_client::KeysClient;
 use rusk::services::rusk_proto::GenerateKeysRequest;
 use test_context::test_context;
+
 #[test_context(TestContext)]
 #[tokio::test]
 pub async fn pki_walkthrough_uds(

--- a/rusk/tests/services/prover_service.rs
+++ b/rusk/tests/services/prover_service.rs
@@ -1,0 +1,171 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use super::TestContext;
+
+use std::sync::Mutex;
+
+use dusk_bytes::DeserializableSlice;
+use dusk_pki::{PublicSpendKey, ViewKey};
+use dusk_plonk::prelude::*;
+use dusk_poseidon::tree::PoseidonBranch;
+use dusk_wallet_core::{
+    NodeClient, Store, UnprovenTransaction, Wallet, POSEIDON_TREE_DEPTH,
+};
+use phoenix_core::{Note, NoteType};
+use rand::{CryptoRng, RngCore};
+use rusk::services::rusk_proto::prover_client::ProverClient;
+use rusk::services::rusk_proto::ProverRequest;
+use test_context::test_context;
+use tokio::runtime::Handle;
+use tokio::task::block_in_place;
+use tonic::transport::Channel;
+
+/// Create a new wallet meant for tests. It includes a client that will always
+/// return a random anchor (same every time), and the default opening.
+///
+/// The number of notes available is determined by `note_values`.
+fn mock_wallet<Rng: RngCore + CryptoRng>(
+    rng: &mut Rng,
+    client: ProverClient<Channel>,
+    note_values: &[u64],
+) -> Wallet<TestStore, TestNodeClient> {
+    let store = TestStore::new(rng);
+    let psk = store.retrieve_key(0).unwrap().public_spend_key();
+
+    let notes = new_notes(rng, &psk, note_values);
+    let anchor = BlsScalar::random(rng);
+    let opening = Default::default();
+
+    let node = TestNodeClient::new(client, notes, anchor, opening);
+
+    Wallet::new(store, node)
+}
+
+/// Returns obfuscated notes with the given value.
+fn new_notes<Rng: RngCore + CryptoRng>(
+    rng: &mut Rng,
+    psk: &PublicSpendKey,
+    note_values: &[u64],
+) -> Vec<Note> {
+    note_values
+        .iter()
+        .map(|val| {
+            let blinder = JubJubScalar::random(rng);
+            Note::new(rng, NoteType::Obfuscated, psk, *val, blinder)
+        })
+        .collect()
+}
+
+/// An in-memory seed store.
+#[derive(Debug)]
+pub struct TestStore {
+    seed: [u8; 64],
+}
+
+impl TestStore {
+    /// Instantiate a new in-memory store with a random seed.
+    fn new<Rng: RngCore + CryptoRng>(rng: &mut Rng) -> Self {
+        let mut seed = [0; 64];
+        rng.fill_bytes(&mut seed);
+        Self { seed }
+    }
+}
+
+impl Store for TestStore {
+    type Error = ();
+
+    fn get_seed(&self) -> Result<[u8; 64], Self::Error> {
+        Ok(self.seed)
+    }
+}
+
+#[derive(Debug)]
+struct TestNodeClient {
+    client: Mutex<ProverClient<Channel>>,
+
+    notes: Vec<Note>,
+    anchor: BlsScalar,
+    opening: PoseidonBranch<POSEIDON_TREE_DEPTH>,
+}
+
+impl TestNodeClient {
+    fn new(
+        client: ProverClient<Channel>,
+        notes: Vec<Note>,
+        anchor: BlsScalar,
+        opening: PoseidonBranch<POSEIDON_TREE_DEPTH>,
+    ) -> Self {
+        Self {
+            client: Mutex::new(client),
+            notes,
+            anchor,
+            opening,
+        }
+    }
+}
+
+impl NodeClient for TestNodeClient {
+    type Error = ();
+
+    fn fetch_notes(
+        &self,
+        _: u64,
+        _: &ViewKey,
+    ) -> Result<Vec<Note>, Self::Error> {
+        Ok(self.notes.clone())
+    }
+
+    fn fetch_anchor(&self) -> Result<BlsScalar, Self::Error> {
+        Ok(self.anchor)
+    }
+
+    fn fetch_opening(
+        &self,
+        _: &Note,
+    ) -> Result<PoseidonBranch<POSEIDON_TREE_DEPTH>, Self::Error> {
+        Ok(self.opening.clone())
+    }
+
+    fn request_proof(
+        &self,
+        utx: &UnprovenTransaction,
+    ) -> Result<Proof, Self::Error> {
+        let utx = utx.to_bytes().expect("transaction to serialize correctly");
+        let request = tonic::Request::new(ProverRequest { utx });
+
+        let mut prover = self.client.lock().expect("unlock to be successful");
+        let proof = block_in_place(move || {
+            Handle::current()
+                .block_on(async move { prover.prove(request).await })
+        })
+        .expect("successful call")
+        .into_inner()
+        .proof;
+
+        let proof = Proof::from_slice(&proof).expect("valid proof");
+        Ok(proof)
+    }
+}
+
+#[test_context(TestContext)]
+#[tokio::test(flavor = "multi_thread")]
+pub async fn prover_walkthrough_uds(ctx: &mut TestContext) {
+    let mut rng = rand::thread_rng();
+    let client = ProverClient::new(ctx.channel.clone());
+
+    let wallet = mock_wallet(&mut rng, client, &[5000, 2500, 2500]);
+
+    let send_psk = wallet.public_spend_key(0).unwrap();
+    let recv_psk = wallet.public_spend_key(1).unwrap();
+
+    let ref_id = BlsScalar::random(&mut rng);
+    let _ = wallet
+        .create_transfer_tx(
+            &mut rng, 0, &send_psk, &recv_psk, 100, 100, 1, ref_id,
+        )
+        .expect("Transaction creation to be successful");
+}

--- a/rusk/tests/tests.rs
+++ b/rusk/tests/tests.rs
@@ -7,15 +7,24 @@
 pub mod common;
 pub mod services;
 
+use std::env::temp_dir;
+use std::path::PathBuf;
+
 pub use common::TestContext;
 use lazy_static::lazy_static;
-use std::{env::temp_dir, fs, path::PathBuf};
+use rand::RngCore;
+
+/// Returns a new random socket path withing `SOCKET_DIR`.
+pub fn new_socket_path() -> PathBuf {
+    let mut rng = rand::thread_rng();
+    SOCKET_DIR
+        .join(rng.next_u32().to_string())
+        .with_extension("rusk")
+}
 
 lazy_static! {
-    /// Default UDS path that Rusk GRPC-server will connect to.
-    pub static ref SOCKET_PATH: PathBuf = {
-        let tmp_dir = temp_dir().join(".rusk").join(".tmp_test");
-        fs::create_dir_all(tmp_dir.clone()).expect("Error creating tmp testing dir");
-        tmp_dir.join("rusk_listener")
+    /// Default UDS directory that will contains UDSs for Rusk's GRPC-server to bind on.
+    pub static ref SOCKET_DIR: PathBuf = {
+        temp_dir().join(".rusk_test_sockets")
     };
 }

--- a/schema/prover.proto
+++ b/schema/prover.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+package rusk;
+
+// A transaction that is yet to be proven. The byte contents are in the
+// `dusk-wallet-core` crate.
+message ProverRequest {
+    bytes utx = 1;
+}
+
+// A Plonk proof.
+message ProverResponse {
+    bytes proof = 1;
+}
+
+service Prover {
+    // Proves the unproven transaction by generating a Plonk proof of the
+    // appropriate circuit.
+    rpc Prove(ProverRequest) returns (ProverResponse) {}
+}

--- a/schema/state.proto
+++ b/schema/state.proto
@@ -3,6 +3,7 @@ package rusk;
 
 import "echo.proto";
 import "network.proto";
+import "prover.proto";
 import "provisioner.proto";
 import "transaction.proto";
 


### PR DESCRIPTION
This is an implementation of the prover service for execute transactions. It also introduces some logic to create different socket for each instance of `TestContext`.

Resolves #401