### PR TITLE
Use `DeriveKey` in WFO/STCO messages

### DIFF
--- a/circuits/transfer/src/types.rs
+++ b/circuits/transfer/src/types.rs
@@ -10,11 +10,11 @@ use dusk_plonk::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DeriveKey {
-    is_public: bool,
-    secret_a: JubJubExtended,
-    secret_b: JubJubExtended,
-    public_a: JubJubExtended,
-    public_b: JubJubExtended,
+    pub(crate) is_public: bool,
+    pub(crate) secret_a: JubJubExtended,
+    pub(crate) secret_b: JubJubExtended,
+    pub(crate) public_a: JubJubExtended,
+    pub(crate) public_b: JubJubExtended,
 }
 
 impl DeriveKey {

--- a/contracts/transfer/src/transfer/circuits.rs
+++ b/contracts/transfer/src/transfer/circuits.rs
@@ -10,10 +10,10 @@ use dusk_abi::ContractId;
 use dusk_bls12_381::BlsScalar;
 use phoenix_core::{Crossover, Message};
 
-const VD_STCT: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/6e3fe967d842bd072a71b5cad311d6c9543e641772c216c4d076fed205a28cba.vd"));
-const VD_STCO: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/b5b4cfc5185dcc78b82dab83bb157adc6f697ede910f952040f3fae640ead862.vd"));
-const VD_WDFT: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/ab5b3b3611c93625889416e283a8e2673b192dd7c816c88df6007399ee3dc6c1.vd"));
-const VD_WDFO: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/74251989785fa50fda409b714189c54a68363b1d534b4fc9b5a31226102a2b6e.vd"));
+const VD_STCT: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/5fdb4f60d0c7dc5be4aa605aac887e160c15d560f64f29fc094e5fd8ef80cef0.vd"));
+const VD_STCO: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/cebc1c86576ae9c177dbed3cda29aea480525ba2655d5d599bb780a9ee349951.vd"));
+const VD_WDFT: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/c9efc0095962b81aa46d2a57329dc83cb2490097dc08b056bdf8b9a76d28b729.vd"));
+const VD_WDFO: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/3a55c8691347b8abef3a391974d2f982ca761c0e239d49456e17e6f17b80cbc9.vd"));
 
 const VD_EXEC_1_0: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/4a00c40792f14a79c2c8e46f01b6902f72e46a8a496b5adf56015af32747a17d.vd"));
 const VD_EXEC_1_1: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/89421c761c054e16ab6d5147defd4bd13a11bc59ca9446d998a69482243b6222.vd"));

--- a/contracts/transfer/tests/transfer.rs
+++ b/contracts/transfer/tests/transfer.rs
@@ -381,31 +381,35 @@ fn withdraw_from_obfuscated() {
         withdraw_blinder,
     );
 
-    let change_derive_key = DeriveKey::new(false, &change_psk);
+    let wfo_input = WfoCommitment {
+        value: message_value,
+        blinder: message_blinder,
+        commitment: *message.value_commitment(),
+    };
 
-    let wfo_input = WfoCommitment::new(
-        message_value,
-        message_blinder,
-        *message.value_commitment(),
-    );
+    let wfo_change = {
+        let derive_key = DeriveKey::new(false, &change_psk);
+        WfoChange {
+            blinder: change_blinder,
+            derive_key,
+            message: change,
+            pk_r: change_pk_r,
+            r: change_r,
+            value: change_value,
+        }
+    };
 
-    let wfo_change = WfoChange::new(
-        change,
-        change_value,
-        change_blinder,
-        change_r,
-        change_pk_r,
-        change_derive_key,
-    );
+    let wfo_output = WfoCommitment {
+        blinder: withdraw_blinder,
+        commitment: *withdraw.value_commitment(),
+        value: withdraw_value,
+    };
 
-    let wfo_output = WfoCommitment::new(
-        withdraw_value,
-        withdraw_blinder,
-        *withdraw.value_commitment(),
-    );
-
-    let wfo_circuit =
-        WithdrawFromObfuscatedCircuit::new(wfo_input, wfo_change, wfo_output);
+    let wfo_circuit = WithdrawFromObfuscatedCircuit {
+        input: wfo_input,
+        change: wfo_change,
+        output: wfo_output,
+    };
 
     let wfo_proof = wrapper.generate_proof(wfo_circuit);
     let wfo_tx = TransferWrapper::tx_withdraw_obfuscated(

--- a/rusk/build.rs
+++ b/rusk/build.rs
@@ -215,8 +215,14 @@ mod transfer {
                 rng, &c_ssk, &fee, &crossover, &message, &address,
             );
 
-            let message =
-                StcoMessage::new(message, m_r, m_derive_key, m_pk_r, m_blinder);
+            let message = StcoMessage {
+                blinder: m_blinder,
+                derive_key: m_derive_key,
+                message,
+                pk_r: m_pk_r,
+                r: m_r,
+            };
+
             let crossover = StcoCrossover::new(crossover, c_blinder);
 
             let mut circuit = SendToContractObfuscatedCircuit::new(
@@ -277,60 +283,71 @@ mod transfer {
             let pub_params = &PUB_PARAMS;
             let rng = &mut StdRng::seed_from_u64(0xbeef);
 
-            let i_ssk = SecretSpendKey::random(rng);
-            let i_psk = i_ssk.public_spend_key();
+            let input = {
+                let ssk = SecretSpendKey::random(rng);
+                let psk = ssk.public_spend_key();
 
-            let i_value = 100;
-            let i_r = JubJubScalar::random(rng);
-            let input = Message::new(rng, &i_r, &i_psk, i_value);
+                let value = 100;
+                let r = JubJubScalar::random(rng);
+                let message = Message::new(rng, &r, &psk, value);
+                let commitment = *message.value_commitment();
 
-            let (_, i_blinder) = input
-                .decrypt(&i_r, &i_psk)
-                .expect("Failed to decrypt message");
+                let (_, blinder) = message
+                    .decrypt(&r, &psk)
+                    .expect("Failed to decrypt message");
 
-            let c_ssk = SecretSpendKey::random(rng);
-            let c_psk = c_ssk.public_spend_key();
+                WfoCommitment {
+                    blinder,
+                    commitment,
+                    value,
+                }
+            };
+            let change = {
+                let ssk = SecretSpendKey::random(rng);
+                let psk = ssk.public_spend_key();
 
-            let c_value = 25;
-            let c_r = JubJubScalar::random(rng);
-            let change = Message::new(rng, &c_r, &c_psk, c_value);
-            let c_pk_r = *c_psk.gen_stealth_address(&c_r).pk_r().as_ref();
+                let value = 25;
+                let r = JubJubScalar::random(rng);
+                let message = Message::new(rng, &r, &psk, value);
+                let pk_r = *psk.gen_stealth_address(&r).pk_r().as_ref();
 
-            let (_, c_blinder) = change
-                .decrypt(&c_r, &c_psk)
-                .expect("Failed to decrypt message");
+                let (_, blinder) = message
+                    .decrypt(&r, &psk)
+                    .expect("Failed to decrypt message");
 
-            let c_derive_key = DeriveKey::new(false, &c_psk);
+                let derive_key = DeriveKey::new(false, &psk);
 
-            let o_ssk = SecretSpendKey::random(rng);
-            let o_psk = o_ssk.public_spend_key();
+                WfoChange {
+                    blinder,
+                    derive_key,
+                    message,
+                    pk_r,
+                    r,
+                    value,
+                }
+            };
 
-            let o_value = 75;
+            let output = {
+                let ssk = SecretSpendKey::random(rng);
+                let psk = ssk.public_spend_key();
 
-            let o_blinder = JubJubScalar::random(rng);
-            let output = Note::obfuscated(rng, &o_psk, o_value, o_blinder);
+                let value = 75;
 
-            let input = WfoCommitment::new(
-                i_value,
-                i_blinder,
-                *input.value_commitment(),
-            );
-            let change = WfoChange::new(
+                let blinder = JubJubScalar::random(rng);
+                let output = Note::obfuscated(rng, &psk, value, blinder);
+                let commitment = *output.value_commitment();
+                WfoCommitment {
+                    blinder,
+                    commitment,
+                    value,
+                }
+            };
+
+            let mut circuit = WithdrawFromObfuscatedCircuit {
+                input,
                 change,
-                c_value,
-                c_blinder,
-                c_r,
-                c_pk_r,
-                c_derive_key,
-            );
-            let output = WfoCommitment::new(
-                o_value,
-                o_blinder,
-                *output.value_commitment(),
-            );
-
-            let mut circuit =
-                WithdrawFromObfuscatedCircuit::new(input, change, output);
+                output,
+            };
 
             let (pk, vd) = circuit.compile(pub_params)?;
             Ok((pk.to_var_bytes(), vd.to_var_bytes()))


### PR DESCRIPTION
- Avoid using a long list of anonymous parameters in methods.
- Remove anonymous `new` constructors in favour of explicit named parameters
- Regenerate rusk keys

Resolves #407