### PR TITLE
Add `RUSK_KEEP_KEYS` env var to build.rs and CI

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -43,7 +43,10 @@ jobs:
             ~/.cargo/git/db
           key: ${{env.cache-name}}-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
 
-      - run: RUSK_PROFILE_PATH="/var/opt/build-cache" make -j test
+      - run: >
+          RUSK_PROFILE_PATH="/var/opt/build-cache"
+          RUSK_KEEP_KEYS="1"
+          make -j test
       - name: "Upload Rusk Artifact"
         uses: actions/upload-artifact@v2
         with:

--- a/rusk/build.rs
+++ b/rusk/build.rs
@@ -523,7 +523,9 @@ mod profile_tooling {
     pub fn run_circuit_keys_checks(
         loader_list: Vec<&dyn CircuitLoader>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        clear_outdated_keys(&loader_list)?;
+        if option_env!("RUSK_KEEP_KEYS").is_none() {
+            clear_outdated_keys(&loader_list)?;
+        }
         check_keys_cache(&loader_list).map(|_| ())
     }
 }


### PR DESCRIPTION
The default behavior it's still to remove the old keys, so if the
env var is not set (e.g. locally) nothing is changed.

Resolves: #412