### PR TITLE
Fix kadcast auto broadcast

### DIFF
--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -265,6 +265,6 @@ fn create_network(args: &ArgMatches) -> RuskNetwork {
             .unwrap_or_default()
             .map(|s| s.to_string())
             .collect(),
-        args.value_of("kadcast_autobroadcast").is_some(),
+        args.is_present("kadcast_autobroadcast"),
     )
 }


### PR DESCRIPTION
If a clap arg is configure to not take a value, the `value_of` is alway `None`

Fix #423