### PR TITLE
Add Coinbase Transaction to the transactions returned by the ExecuteStateTransition

### DIFF
--- a/rusk/src/lib/services.rs
+++ b/rusk/src/lib/services.rs
@@ -10,6 +10,7 @@ pub mod network;
 pub mod pki;
 pub mod prover;
 pub mod state;
+pub mod transaction;
 
 pub mod rusk_proto {
     tonic::include_proto!("rusk");

--- a/rusk/src/lib/services/transaction.rs
+++ b/rusk/src/lib/services/transaction.rs
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Transaction helper service implementation for the Rusk server.
+
+use crate::Rusk;
+use tonic::{Request, Response, Status};
+use tracing::info;
+
+pub use super::rusk_proto::{
+    transaction_service_client::TransactionServiceClient,
+    CoinbaseTransactionRequest, Transaction, TransactionRequest,
+};
+
+pub use super::rusk_proto::transaction_service_server::{
+    TransactionService, TransactionServiceServer,
+};
+
+#[tonic::async_trait]
+impl TransactionService for Rusk {
+    async fn coinbase_transaction(
+        &self,
+        _: Request<CoinbaseTransactionRequest>,
+    ) -> Result<Response<Transaction>, Status> {
+        info!("Recieved coinbase_transaction request");
+        Err(Status::unimplemented("Request not implemented"))
+    }
+
+    async fn new_transaction(
+        &self,
+        _: Request<TransactionRequest>,
+    ) -> Result<Response<Transaction>, Status> {
+        info!("Recieved coinbase_transaction request");
+        Err(Status::unimplemented("Request not implemented"))
+    }
+}

--- a/schema/transaction.proto
+++ b/schema/transaction.proto
@@ -41,8 +41,17 @@ message TransactionRequest {
     Fee fee = 4;
 }
 
+message CoinbaseTransactionRequest {
+    fixed64 block_height = 1;
+}
+
 service TransactionService {
     // A generic method to create a transaction which requires
     // no special fields (no crossover, outputs, or specific proofs).
     rpc NewTransaction(TransactionRequest) returns (Transaction) {}
+
+
+    // A method to create a coinbase transaction. It requires a `CoinbaseTransactionRequest` 
+    // which include the current block_height to check token release schedule.
+    rpc CoinbaseTransaction(CoinbaseTransactionRequest) returns (Transaction) {}
 }


### PR DESCRIPTION
This service include the method to request `rusk` to generate a Coinbase transaction.

Resolves #425 