### PR TITLE
Implement STCT, WFCT, etc... prover services

### DIFF
--- a/rusk/src/lib/services/prover/handler.rs
+++ b/rusk/src/lib/services/prover/handler.rs
@@ -5,15 +5,30 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use super::{rusk_proto, ServiceRequestHandler};
-use dusk_bytes::Serializable;
 
+use std::collections::HashMap;
+
+use dusk_bytes::{DeserializableSlice, Serializable};
+use dusk_pki::PublicSpendKey;
 use dusk_plonk::prelude::*;
+use dusk_schnorr::Signature;
 use dusk_wallet_core::UnprovenTransaction;
 use lazy_static::lazy_static;
+use phoenix_core::{Crossover, Fee, Message};
 use rusk_profile::keys_for;
-use rusk_proto::{ProverRequest, ProverResponse};
+use rusk_proto::{
+    ExecuteProverRequest, ExecuteProverResponse, StcoProverRequest,
+    StcoProverResponse, StctProverRequest, StctProverResponse,
+    WfcoProverRequest, WfcoProverResponse, WfctProverRequest,
+    WfctProverResponse,
+};
 use tonic::{Request, Response, Status};
-use transfer_circuits::{CircuitInput, CircuitInputSignature, ExecuteCircuit};
+use transfer_circuits::{
+    CircuitInput, CircuitInputSignature, DeriveKey, ExecuteCircuit,
+    SendToContractObfuscatedCircuit, SendToContractTransparentCircuit,
+    StcoCrossover, StcoMessage, WfoChange, WfoCommitment,
+    WithdrawFromObfuscatedCircuit, WithdrawFromTransparentCircuit,
+};
 
 lazy_static! {
     static ref PP: PublicParameters = unsafe {
@@ -21,22 +36,69 @@ lazy_static! {
 
         PublicParameters::from_slice_unchecked(pp.as_slice())
     };
+    static ref EXECUTE_PROVER_KEYS: HashMap<(usize, usize), ProverKey> = {
+        let mut map = HashMap::new();
+
+        for ninputs in [1, 2, 3, 4] {
+            for noutputs in [0, 1, 2] {
+                let circ = circuit_from_numbers(ninputs, noutputs)
+                    .expect("circuit to exist");
+
+                let keys =
+                    keys_for(circ.circuit_id()).expect("keys to be available");
+                let pk = keys.get_prover().expect("prover to be available");
+                let pk =
+                    ProverKey::from_slice(&pk).expect("prover key to be valid");
+
+                map.insert((ninputs, noutputs), pk);
+            }
+        }
+
+        map
+    };
+    static ref WFCT_PROVER_KEY: ProverKey = {
+        let keys = keys_for(&WithdrawFromTransparentCircuit::CIRCUIT_ID)
+            .expect("keys to be available");
+        let pk = keys.get_prover().expect("prover to be available");
+        ProverKey::from_slice(&pk).expect("prover key to be valid")
+    };
+    static ref WFCO_PROVER_KEY: ProverKey = {
+        let keys = keys_for(&WithdrawFromObfuscatedCircuit::CIRCUIT_ID)
+            .expect("keys to be available");
+        let pk = keys.get_prover().expect("prover to be available");
+        ProverKey::from_slice(&pk).expect("prover key to be valid")
+    };
+    static ref STCT_PROVER_KEY: ProverKey = {
+        let keys = keys_for(&SendToContractTransparentCircuit::CIRCUIT_ID)
+            .expect("keys to be available");
+        let pk = keys.get_prover().expect("prover to be available");
+        ProverKey::from_slice(&pk).expect("prover key to be valid")
+    };
+    static ref STCO_PROVER_KEY: ProverKey = {
+        let keys = keys_for(&SendToContractObfuscatedCircuit::CIRCUIT_ID)
+            .expect("keys to be available");
+        let pk = keys.get_prover().expect("prover to be available");
+        ProverKey::from_slice(&pk).expect("prover key to be valid")
+    };
 }
 
-pub struct ProverHandler<'a> {
-    _request: &'a Request<ProverRequest>,
+pub struct ExecuteProverHandler<'a> {
+    _request: &'a Request<ExecuteProverRequest>,
 }
 
-impl<'a, 'b> ServiceRequestHandler<'a, 'b, ProverRequest, ProverResponse>
-    for ProverHandler<'a>
+impl<'a, 'b>
+    ServiceRequestHandler<'a, 'b, ExecuteProverRequest, ExecuteProverResponse>
+    for ExecuteProverHandler<'a>
 where
     'b: 'a,
 {
-    fn load_request(request: &'b Request<ProverRequest>) -> Self {
+    fn load_request(request: &'b Request<ExecuteProverRequest>) -> Self {
         Self { _request: request }
     }
 
-    fn handle_request(&self) -> Result<Response<ProverResponse>, Status> {
+    fn handle_request(
+        &self,
+    ) -> Result<Response<ExecuteProverResponse>, Status> {
         let utx = UnprovenTransaction::from_slice(&self._request.get_ref().utx)
             .map_err(|_| {
                 Status::invalid_argument("Failed parsing unproven TX")
@@ -51,12 +113,6 @@ where
                     num_inputs, num_outputs
                 ))
             })?;
-
-        let keys = keys_for(circ.circuit_id()).map_err(|_| Status::failed_precondition(format!("Couldn't find keys for circuit with number of inputs {} and outputs {}", num_inputs, num_outputs)))?;
-        let pk = keys.get_prover().map_err(|_| Status::internal(format!("Couldn't find prover key for circuit with number of inputs {} and outputs {}", num_inputs, num_outputs)))?;
-        let pk = ProverKey::from_slice(&pk).map_err(|e| {
-            Status::internal(format!("Prover key malformed: {}", e))
-        })?;
 
         for input in utx.inputs() {
             let cis = CircuitInputSignature::from(input.signature());
@@ -95,15 +151,394 @@ where
         let (crossover, value, blinder) = utx.crossover();
         circ.set_fee_crossover(utx.fee(), crossover, *value, *blinder);
 
-        let proof = circ.prove(&PP, &pk).map_err(|e| {
-            Status::invalid_argument(format!(
-                "Failed proving transaction: {}",
-                e
-            ))
-        })?;
+        let proof = circ
+            .prove(
+                &PP,
+                EXECUTE_PROVER_KEYS.get(&(num_inputs, num_outputs)).unwrap(),
+            )
+            .map_err(|e| {
+                Status::invalid_argument(format!(
+                    "Failed proving transaction: {}",
+                    e
+                ))
+            })?;
         let proof = proof.to_bytes().to_vec();
 
-        Ok(Response::new(ProverResponse { proof }))
+        Ok(Response::new(ExecuteProverResponse { proof }))
+    }
+}
+
+pub struct StctProverHandler<'a> {
+    _request: &'a Request<StctProverRequest>,
+}
+
+const STCT_INPUT_LEN: usize = Fee::SIZE
+    + Crossover::SIZE
+    + u64::SIZE
+    + JubJubScalar::SIZE
+    + BlsScalar::SIZE
+    + Signature::SIZE;
+
+impl<'a, 'b>
+    ServiceRequestHandler<'a, 'b, StctProverRequest, StctProverResponse>
+    for StctProverHandler<'a>
+where
+    'b: 'a,
+{
+    fn load_request(request: &'b Request<StctProverRequest>) -> Self {
+        Self { _request: request }
+    }
+
+    fn handle_request(&self) -> Result<Response<StctProverResponse>, Status> {
+        let mut reader = &self._request.get_ref().circuit_inputs[..];
+
+        if reader.len() != STCT_INPUT_LEN {
+            return Err(Status::invalid_argument(format!(
+                "Expected length {} got {}",
+                STCT_INPUT_LEN,
+                reader.len()
+            )));
+        }
+
+        let fee = Fee::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing fee")
+        })?;
+        let crossover = Crossover::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing crossover")
+        })?;
+        let crossover_value = u64::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing crossover value")
+        })?;
+        let crossover_blinder = JubJubScalar::from_reader(&mut reader)
+            .map_err(|_| {
+                Status::invalid_argument("Failed deserializing crossover value")
+            })?;
+        let contract_address =
+            BlsScalar::from_reader(&mut reader).map_err(|_| {
+                Status::invalid_argument(
+                    "Failed deserializing contract address",
+                )
+            })?;
+        let signature = Signature::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing signature")
+        })?;
+
+        let mut circ = SendToContractTransparentCircuit::new(
+            &fee,
+            &crossover,
+            crossover_value,
+            crossover_blinder,
+            contract_address,
+            signature,
+        );
+
+        let proof = circ
+            .prove(&*PP, &STCT_PROVER_KEY, b"dusk-network")
+            .map_err(|e| {
+                Status::internal(format!("Failed proving the circuit: {}", e))
+            })?;
+        let proof = proof.to_bytes().to_vec();
+
+        Ok(Response::new(StctProverResponse { proof }))
+    }
+}
+
+pub struct StcoProverHandler<'a> {
+    _request: &'a Request<StcoProverRequest>,
+}
+
+const STCO_INPUT_LEN: usize = u64::SIZE
+    + JubJubScalar::SIZE
+    + JubJubScalar::SIZE
+    + u64::SIZE
+    + PublicSpendKey::SIZE
+    + JubJubAffine::SIZE
+    + Message::SIZE
+    + JubJubScalar::SIZE
+    + Crossover::SIZE
+    + Fee::SIZE
+    + BlsScalar::SIZE
+    + Signature::SIZE;
+
+impl<'a, 'b>
+    ServiceRequestHandler<'a, 'b, StcoProverRequest, StcoProverResponse>
+    for StcoProverHandler<'a>
+where
+    'b: 'a,
+{
+    fn load_request(request: &'b Request<StcoProverRequest>) -> Self {
+        Self { _request: request }
+    }
+
+    fn handle_request(&self) -> Result<Response<StcoProverResponse>, Status> {
+        let mut reader = &self._request.get_ref().circuit_inputs[..];
+
+        if reader.len() != STCO_INPUT_LEN {
+            return Err(Status::invalid_argument(format!(
+                "Expected length {} got {}",
+                STCO_INPUT_LEN,
+                reader.len()
+            )));
+        }
+
+        let value = u64::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing value")
+        })?;
+        let r = JubJubScalar::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing 'r'")
+        })?;
+        let blinder = JubJubScalar::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing blinder")
+        })?;
+        let is_public = u64::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing is_public")
+        })? != 0;
+        let psk = PublicSpendKey::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing public spend key")
+        })?;
+        let pk_r = JubJubAffine::from_reader(&mut reader)
+            .map_err(|_| Status::invalid_argument("Failed deserializing pk_r"))?
+            .into();
+        let message = Message::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing message")
+        })?;
+        let crossover_blinder = JubJubScalar::from_reader(&mut reader)
+            .map_err(|_| {
+                Status::invalid_argument(
+                    "Failed deserializing crossover blinder",
+                )
+            })?;
+        let crossover = Crossover::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing crossover")
+        })?;
+        let fee = Fee::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing fee")
+        })?;
+        let contract_address =
+            BlsScalar::from_reader(&mut reader).map_err(|_| {
+                Status::invalid_argument(
+                    "Failed deserializing contract address",
+                )
+            })?;
+        let signature = Signature::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing signature")
+        })?;
+
+        let derive_key = DeriveKey::new(is_public, &psk);
+
+        let stco_message = StcoMessage {
+            r,
+            blinder,
+            derive_key,
+            pk_r,
+            message,
+        };
+        let stco_crossover = StcoCrossover::new(crossover, crossover_blinder);
+
+        let mut circ = SendToContractObfuscatedCircuit::new(
+            value,
+            stco_message,
+            stco_crossover,
+            &fee,
+            contract_address,
+            signature,
+        );
+
+        let proof = circ
+            .prove(&*PP, &STCO_PROVER_KEY, b"dusk-network")
+            .map_err(|e| {
+                Status::internal(format!("Failed proving the circuit: {}", e))
+            })?;
+        let proof = proof.to_bytes().to_vec();
+
+        Ok(Response::new(StcoProverResponse { proof }))
+    }
+}
+
+pub struct WfctProverHandler<'a> {
+    _request: &'a Request<WfctProverRequest>,
+}
+
+const WFCT_INPUT_LEN: usize =
+    JubJubAffine::SIZE + u64::SIZE + JubJubScalar::SIZE;
+
+impl<'a, 'b>
+    ServiceRequestHandler<'a, 'b, WfctProverRequest, WfctProverResponse>
+    for WfctProverHandler<'a>
+where
+    'b: 'a,
+{
+    fn load_request(request: &'b Request<WfctProverRequest>) -> Self {
+        Self { _request: request }
+    }
+
+    fn handle_request(&self) -> Result<Response<WfctProverResponse>, Status> {
+        let mut reader = &self._request.get_ref().circuit_inputs[..];
+
+        if reader.len() != WFCT_INPUT_LEN {
+            return Err(Status::invalid_argument(format!(
+                "Expected length {} got {}",
+                WFCT_INPUT_LEN,
+                reader.len()
+            )));
+        }
+
+        let commitment = JubJubAffine::from_reader(&mut reader)
+            .map_err(|_| {
+                Status::invalid_argument("Failed deserializing commitment")
+            })?
+            .into();
+
+        let value = u64::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing value")
+        })?;
+
+        let blinder = JubJubScalar::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing blinder")
+        })?;
+
+        let mut circ =
+            WithdrawFromTransparentCircuit::new(commitment, value, blinder);
+
+        let proof = circ
+            .prove(&*PP, &WFCT_PROVER_KEY, b"dusk-network")
+            .map_err(|e| {
+                Status::internal(format!("Failed proving the circuit: {}", e))
+            })?;
+        let proof = proof.to_bytes().to_vec();
+
+        Ok(Response::new(WfctProverResponse { proof }))
+    }
+}
+
+pub struct WfcoProverHandler<'a> {
+    _request: &'a Request<WfcoProverRequest>,
+}
+
+const WFCO_INPUT_LEN: usize = u64::SIZE
+    + JubJubScalar::SIZE
+    + JubJubAffine::SIZE
+    + u64::SIZE
+    + Message::SIZE
+    + JubJubScalar::SIZE
+    + JubJubScalar::SIZE
+    + u64::SIZE
+    + PublicSpendKey::SIZE
+    + JubJubAffine::SIZE
+    + u64::SIZE
+    + JubJubScalar::SIZE
+    + JubJubAffine::SIZE;
+
+impl<'a, 'b>
+    ServiceRequestHandler<'a, 'b, WfcoProverRequest, WfcoProverResponse>
+    for WfcoProverHandler<'a>
+where
+    'b: 'a,
+{
+    fn load_request(request: &'b Request<WfcoProverRequest>) -> Self {
+        Self { _request: request }
+    }
+
+    fn handle_request(&self) -> Result<Response<WfcoProverResponse>, Status> {
+        let mut reader = &self._request.get_ref().circuit_inputs[..];
+
+        if reader.len() != WFCO_INPUT_LEN {
+            return Err(Status::invalid_argument(format!(
+                "Expected length {} got {}",
+                WFCO_INPUT_LEN,
+                reader.len()
+            )));
+        }
+
+        let input_value = u64::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing input value")
+        })?;
+        let input_blinder =
+            JubJubScalar::from_reader(&mut reader).map_err(|_| {
+                Status::invalid_argument("Failed deserializing input blinder")
+            })?;
+        let input_commitment = JubJubAffine::from_reader(&mut reader)
+            .map_err(|_| {
+                Status::invalid_argument("Failed deserializing input blinder")
+            })?
+            .into();
+
+        let input = WfoCommitment {
+            value: input_value,
+            blinder: input_blinder,
+            commitment: input_commitment,
+        };
+
+        let change_value = u64::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing change value")
+        })?;
+        let change_message =
+            Message::from_reader(&mut reader).map_err(|_| {
+                Status::invalid_argument("Failed deserializing change message")
+            })?;
+        let change_blinder =
+            JubJubScalar::from_reader(&mut reader).map_err(|_| {
+                Status::invalid_argument("Failed deserializing change blinder")
+            })?;
+        let r = JubJubScalar::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing change 'r'")
+        })?;
+        let is_public = u64::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing is_public")
+        })? != 0;
+        let psk = PublicSpendKey::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing public spend key")
+        })?;
+        let pk_r = JubJubAffine::from_reader(&mut reader)
+            .map_err(|_| {
+                Status::invalid_argument("Failed deserializing 'pk_r'")
+            })?
+            .into();
+
+        let derive_key = DeriveKey::new(is_public, &psk);
+
+        let change = WfoChange {
+            value: change_value,
+            message: change_message,
+            blinder: change_blinder,
+            r,
+            derive_key,
+            pk_r,
+        };
+
+        let output_value = u64::from_reader(&mut reader).map_err(|_| {
+            Status::invalid_argument("Failed deserializing output value")
+        })?;
+        let output_blinder =
+            JubJubScalar::from_reader(&mut reader).map_err(|_| {
+                Status::invalid_argument("Failed deserializing output blinder")
+            })?;
+        let output_commitment = JubJubAffine::from_reader(&mut reader)
+            .map_err(|_| {
+                Status::invalid_argument("Failed deserializing output blinder")
+            })?
+            .into();
+
+        let output = WfoCommitment {
+            value: output_value,
+            blinder: output_blinder,
+            commitment: output_commitment,
+        };
+
+        let mut circ = WithdrawFromObfuscatedCircuit {
+            input,
+            change,
+            output,
+        };
+
+        let proof = circ
+            .prove(&*PP, &WFCO_PROVER_KEY, b"dusk-network")
+            .map_err(|e| {
+                Status::internal(format!("Failed proving the circuit: {}", e))
+            })?;
+        let proof = proof.to_bytes().to_vec();
+
+        Ok(Response::new(WfcoProverResponse { proof }))
     }
 }
 

--- a/rusk/tests/services/prover_service.rs
+++ b/rusk/tests/services/prover_service.rs
@@ -18,7 +18,7 @@ use dusk_wallet_core::{
 use phoenix_core::{Note, NoteType};
 use rand::{CryptoRng, RngCore};
 use rusk::services::rusk_proto::prover_client::ProverClient;
-use rusk::services::rusk_proto::ProverRequest;
+use rusk::services::rusk_proto::ExecuteProverRequest;
 use test_context::test_context;
 use tokio::runtime::Handle;
 use tokio::task::block_in_place;
@@ -135,12 +135,12 @@ impl NodeClient for TestNodeClient {
         utx: &UnprovenTransaction,
     ) -> Result<Proof, Self::Error> {
         let utx = utx.to_bytes().expect("transaction to serialize correctly");
-        let request = tonic::Request::new(ProverRequest { utx });
+        let request = tonic::Request::new(ExecuteProverRequest { utx });
 
         let mut prover = self.client.lock().expect("unlock to be successful");
         let proof = block_in_place(move || {
             Handle::current()
-                .block_on(async move { prover.prove(request).await })
+                .block_on(async move { prover.prove_execute(request).await })
         })
         .expect("successful call")
         .into_inner()

--- a/schema/prover.proto
+++ b/schema/prover.proto
@@ -1,19 +1,104 @@
 syntax = "proto3";
 package rusk;
 
-// A transaction that is yet to be proven. The byte contents are in the
-// `dusk-wallet-core` crate.
-message ProverRequest {
+// A serialized `UnprovenTransaction` from the `dusk-wallet-core` crate.
+message ExecuteProverRequest {
     bytes utx = 1;
 }
 
-// A Plonk proof.
-message ProverResponse {
+// A Plonk proof for the execute circuit.
+message ExecuteProverResponse {
+    bytes proof = 1;
+}
+
+// Request a proof for the STCT circuit.
+message StctProverRequest {
+    // Serialized in sequence:
+    // - Fee
+    // - Crossover
+    // - Crossover value (u64)
+    // - Crossover blinder (JubJubScalar)
+    // - Contract address (BlsScalar)
+    // - Signature
+    bytes circuit_inputs = 1;
+}
+
+// A Plonk proof for the STCT circuit.
+message StctProverResponse {
+    bytes proof = 1;
+}
+
+// Request a proof for the STCO circuit.
+message StcoProverRequest {
+    // Serialized in sequence:
+    // - Value (u64)
+    // - r (JubJubScalar)
+    // - StcoBlinder (JubJubScalar)
+    // - IsPublic (bool as u64 - 0 is false, other is true)
+    // - PublicSpendKey
+    // - pk_r (JubJubAffine)
+    // - Message
+    // - Crossover Blinder (JubJubScalar)
+    // - Crossover
+    // - Fee
+    // - Contract address (BlsScalar)
+    // - Signature
+    bytes circuit_inputs = 1;
+}
+
+// A Plonk proof for the STCO circuit.
+message StcoProverResponse {
+    bytes proof = 1;
+}
+
+// Request a proof for the WFCT circuit.
+message WfctProverRequest {
+    // Serialized in sequence:
+    // - Commitment (JubJubAffine)
+    // - Value (u64)
+    // - Blinder (JubJubScalar)
+    bytes circuit_inputs = 1;
+}
+
+// A Plonk proof for the WFCT circuit.
+message WfctProverResponse {
+    bytes proof = 1;
+}
+
+// Request a proof for the WFCO circuit.
+message WfcoProverRequest {
+    // Serialized in sequence:
+    // - InputValue (u64)
+    // - InputBlinder (JubJubScalar)
+    // - InputCommitment (JubJubExtended)
+    // - ChangeValue (u64)
+    // - ChangeMessage
+    // - ChangeBlinder (JubJubScalar)
+    // - ChangeR (JubJubScalar)
+    // - IsPublic (bool as u64 - 0 is false, other is true)
+    // - PublicSpendKey
+    // - pk_r (JubJubAffine)
+    // - OutputValue (u64)
+    // - OutputBlinder (JubJubScalar)
+    // - OutputCommitment (JubJubExtended)
+    bytes circuit_inputs = 1;
+}
+
+// A Plonk proof for the WFCO circuit.
+message WfcoProverResponse {
     bytes proof = 1;
 }
 
 service Prover {
     // Proves the unproven transaction by generating a Plonk proof of the
     // appropriate circuit.
-    rpc Prove(ProverRequest) returns (ProverResponse) {}
+    rpc ProveExecute(ExecuteProverRequest) returns (ExecuteProverResponse) {}
+    // Send to contract transparent proof request.
+    rpc ProveStct(StctProverRequest) returns (StctProverResponse) {}
+    // Send to contract obfuscated proof request.
+    rpc ProveStco(StcoProverRequest) returns (StcoProverResponse) {}
+    // Withdraw from contract transparent request.
+    rpc ProveWfct(WfctProverRequest) returns (WfctProverResponse) {}
+    // Withdraw from contract obfuscated request.
+    rpc ProveWfco(WfcoProverRequest) returns (WfcoProverResponse) {}
 }


### PR DESCRIPTION
Introduces prover services for STCT, STCO, WFCT, and WFCO.

The protos for the requests have a single field of bytes containing many variables serialized in sequence. The reason is this will help in the implementation of the extension using the wallet FFI.

Resolves: #437