### PR TITLE
Update to Rusk VM 0.8 (release candidate)

### DIFF
--- a/contracts/transfer/Cargo.toml
+++ b/contracts/transfer/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1.4"
 rand = "0.8"
 
 dusk-plonk = "0.9"
-rusk-vm = "0.7.0-rc"
+rusk-vm = "0.8.0-rc"
 
 transfer-circuits = { path = "../../circuits/transfer", features = ["builder"] }
 rusk-profile = { path = "../../rusk-profile" }

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -26,7 +26,7 @@ canonical_derive = "0.6"
 dusk-plonk = { version = "0.9", default-features = false, features = ["canon"] }
 
 [dev-dependencies]
-rusk-vm = "0.7.0-rc"
+rusk-vm = "0.8.0-rc"
 dusk-bytes = "0.1"
 host_fn = { path = "tests/contracts/host_fn" }
 rand_core = { version = "0.6", features = ["std"] }

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -33,7 +33,7 @@ transfer-circuits = { path = "../circuits/transfer", features=["builder"] }
 transfer-contract = { path = "../contracts/transfer", default-features = false }
 stake-contract = { path = "../contracts/stake", default-features = false }
 microkelvin = { version = "0.10", features = ["persistence"] }
-rusk-vm = { version = "0.7.0-rc", features = ["persistence"] }
+rusk-vm = { version = "0.8.0-rc", features = ["persistence"] }
 rusk-profile = { path = "../rusk-profile" }
 rusk-abi = { path = "../rusk-abi" }
 lazy_static = "1.4"

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -35,7 +35,7 @@ dusk-jubjub = { version = "0.10", features = ["canon"] }
 dusk-pki = "0.9.0-rc"
 dusk-bytes = "0.1"
 dusk-wallet-core = "0.1"
-rusk-vm = "0.7.0-rc"
+rusk-vm = "0.8.0-rc"
 phoenix-core = "0.15.0-rc"
 kadcast = "0.3"
 canonical = "0.6"

--- a/test-utils/transfer-wrapper/Cargo.toml
+++ b/test-utils/transfer-wrapper/Cargo.toml
@@ -22,4 +22,4 @@ transfer-circuits = { path = "../../circuits/transfer", features = ["builder"] }
 transfer-contract = { path = "../../contracts/transfer" }
 rusk-profile = { path = "../../rusk-profile" }
 dusk-plonk = "0.9"
-rusk-vm = "0.7.0-rc"
+rusk-vm = "0.8.0-rc"


### PR DESCRIPTION
- rusk-recovery: Update rusk-vm from `0.7.0-rc` to `0.8.0-rc`
- rusk: Update rusk-vm from `0.7.0-rc` to `0.8.0-rc`
- test-utils: Update rusk-vm from `0.7.0-rc` to `0.8.0-rc`
- rusk-abi: Update rusk-vm from `0.7.0-rc` to `0.8.0-rc`
- transfer-contract: Update rusk-vm from `0.7.0-rc` to `0.8.0-rc`