### PR TITLE
Bump `rusk-abi` to `0.6.0`

### DIFF
--- a/contracts/stake/Cargo.toml
+++ b/contracts/stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stake-contract"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/contracts/transfer/Cargo.toml
+++ b/contracts/transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-contract"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [lib]

--- a/contracts/transfer/tests/wrapper/alice/Cargo.toml
+++ b/contracts/transfer/tests/wrapper/alice/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alice"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 resolver = "2"
 

--- a/contracts/transfer/tests/wrapper/bob/Cargo.toml
+++ b/contracts/transfer/tests/wrapper/bob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bob"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 resolver = "2"
 

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-abi"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 repository = "https://github.com/dusk-network/rusk"

--- a/rusk-abi/tests/contracts/host_fn/Cargo.toml
+++ b/rusk-abi/tests/contracts/host_fn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host_fn"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/test-utils/transfer-wrapper/Cargo.toml
+++ b/test-utils/transfer-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-wrapper"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Also bump the versions of other internal crates to reflect the changes
in PR #433.

Resolves: #455