### PR TITLE
Make Stake proto consistent with other services

### DIFF
--- a/schema/provisioner.proto
+++ b/schema/provisioner.proto
@@ -6,5 +6,5 @@ import "stake.proto";
 message Provisioner {
     bytes public_key_bls = 1;
     bytes raw_public_key_bls = 2;
-    repeated Stake stakes = 3;
+    repeated StakeDetails stakes = 3;
 }

--- a/schema/stake.proto
+++ b/schema/stake.proto
@@ -3,10 +3,11 @@ package rusk;
 
 import "transaction.proto";
 
-message Stake {
+message StakeDetails {
     fixed64 amount = 1;
-    fixed64 start_height = 2;
-    fixed64 end_height = 3;
+    fixed32 expiration = 2;
+    fixed64 start_height = 3;
+    fixed64 end_height = 4;
 }
 
 message StakeTransactionRequest {
@@ -21,10 +22,10 @@ message FindStakeRequest {
 }
 
 message FindStakeResponse {
-    repeated Stake stakes = 1;
+    StakeDetails stake = 1;
 }
 
-service StakeService {
+service Stake {
     // Generate a new Stake transaction.
     rpc NewStake(StakeTransactionRequest) returns (Transaction) {}
 


### PR DESCRIPTION
 - Rename `StakeService` to `Stake` for consistency with all other services
 - Rename `Stake` (message) to `StakeDetails`
 - Add `expiration` to `StakeDetails` message
 - Remove `repeated` stakes in `FindStakeResponse`

Closes #467