### PR TITLE
rusk: Improve the ergonomics `Rusk` state API

### DIFF
--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 autobins = false
 

--- a/rusk/src/lib/error.rs
+++ b/rusk/src/lib/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     BackendRegistrationFailed,
     /// Failed to restore a network state from disk
     RestoreFailed,
+    /// Failed to build a Rusk instance
+    BuilderInvalidState,
     /// Failed to fetch opening
     OpeningPositionNotFound(u64),
     /// Failed to fetch opening due to undefined Note
@@ -83,6 +85,9 @@ impl fmt::Display for Error {
             }
             Error::RestoreFailed => {
                 write!(f, "Failed to restore a network state")
+            }
+            Error::BuilderInvalidState => {
+                write!(f, "Failed to build a Rusk instance")
             }
             Error::OpeningPositionNotFound(pos) => {
                 write!(f, "Failed to fetch opening of position {}", pos)


### PR DESCRIPTION
- Add `RuskBuilder` type

  This builder helps to construct a `Rusk` instance for both tests and binary
  use cases, ensure we're not risking on overwrite the wrong state during tests.
  It also ensure we can clone safely a `Rusk` instance, while still retain not
  only the state id, but the original backend.
  It also include an optional `path` where to store the `state_id`, instead of
  having hard coded - this was a problem since a misusage of that feature could
  result in the binary state corruption during tests.

- Add private `execute_ephemeral_state_transition` method

  This method encapsulate the logic of `execute_state_transition`, returning
  both a `Response` for tonic and a `RuskState`.
  In this way we can have `execute_state_transition` that discard the state,
  `accept` that persist the state, and `finalize` that commit and persist the
  state.

- Change `persist` method to accept just a `RuskState`

  In this way we explicitly pass the state we want to persist, both inside
  `Rusk` instance and on disk. Previously accessing to the current state
  could lead to wrong or missing state persisted.

- Change implementation of `accept` and `finalize` to work as intended

- Add `contract_state` method in `RuskState` to return the contract's state
  from the given contract's id

- Add unsafe `set_contract_state` to update a contract's state for the
  given contract's id

- Update tests

Resolves: #473 