### PR TITLE
Handle coinbases correctly

### DIFF
--- a/contracts/transfer/Cargo.toml
+++ b/contracts/transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-contract"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 [lib]

--- a/contracts/transfer/src/transfer/host.rs
+++ b/contracts/transfer/src/transfer/host.rs
@@ -12,8 +12,7 @@ use dusk_bytes::Serializable;
 use dusk_pki::PublicSpendKey;
 use lazy_static::lazy_static;
 use phoenix_core::Note;
-use rand::rngs::StdRng;
-use rand::SeedableRng;
+use rand::rngs::OsRng;
 
 lazy_static! {
     /// The key Dusk is paid to.
@@ -27,19 +26,14 @@ impl TransferContract {
     /// Adds two notes to the state - one as a reward for the block generator
     /// and another for Dusk foundation. The first note returned is the Dusk
     /// note, and the second the generator note.
-    ///
-    /// 90% of the value goes to the generator (rounded up).
-    /// 10% of the value goes to the Dusk address (rounded down).
     pub fn mint(
         &mut self,
         block_height: u64,
-        value: u64,
+        dusk_value: u64,
+        generator_value: u64,
         generator: Option<&PublicSpendKey>,
     ) -> Result<(Note, Note), Error> {
-        let mut rng = StdRng::seed_from_u64(block_height);
-
-        let dusk_value = value / 10;
-        let generator_value = value - dusk_value;
+        let mut rng = OsRng::default();
 
         let generator = generator.unwrap_or(&DUSK_KEY);
 

--- a/rusk/src/lib/error.rs
+++ b/rusk/src/lib/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     OpeningNoteUndefined(u64),
     /// Bytes Serialization Errors
     Serialization(dusk_bytes::Error),
+    /// Originating from Phoenix.
+    Phoenix(phoenix_core::Error),
     /// Rusk VM internal Errors
     Vm(rusk_vm::VMError),
     /// IO Errors
@@ -37,6 +39,8 @@ pub enum Error {
     Canonical(canonical::CanonError),
     /// Stake not found for key.
     StakeNotFound(PublicKey),
+    /// Bad coinbase value (got, expected).
+    CoinbaseValue(u64, u64),
 }
 
 impl std::error::Error for Error {}
@@ -44,6 +48,12 @@ impl std::error::Error for Error {}
 impl From<rusk_vm::VMError> for Error {
     fn from(err: rusk_vm::VMError) -> Self {
         Error::Vm(err)
+    }
+}
+
+impl From<phoenix_core::Error> for Error {
+    fn from(pe: phoenix_core::Error) -> Self {
+        Self::Phoenix(pe)
     }
 }
 
@@ -111,6 +121,12 @@ impl fmt::Display for Error {
             Error::StakeNotFound(pk) => {
                 write!(f, "Couldn't find stake for {:?}", pk.to_bytes())
             }
+            Error::CoinbaseValue(got, expected) => write!(
+                f,
+                "Received coinbase with value {}, expected {}",
+                got, expected
+            ),
+            Error::Phoenix(err) => write!(f, "Phoenix error: {}", err),
         }
     }
 }

--- a/rusk/src/lib/services/state.rs
+++ b/rusk/src/lib/services/state.rs
@@ -78,7 +78,11 @@ impl Rusk {
             &transfer_txs,
         );
 
-        state.push_coinbase(request.block_height, coinbase)?;
+        state.push_coinbase(
+            request.block_height,
+            block_gas_meter.spent(),
+            coinbase,
+        )?;
         let state_root = state.root().to_vec();
 
         Ok((
@@ -220,7 +224,11 @@ impl State for Rusk {
             }));
         }
 
-        state.push_coinbase(request.block_height, coinbase)?;
+        state.push_coinbase(
+            request.block_height,
+            block_gas_meter.spent(),
+            coinbase,
+        )?;
 
         Ok(Response::new(VerifyStateTransitionResponse { success }))
     }


### PR DESCRIPTION
 rusk: Handle coinbases correctly
    
- Add emissions schedule
    
As defined in the economic paper, the emission schedule is the amount
of Dusk freshly minted each block not coming from spent gas.
    
- Add checking coinbase values
    
This checks if the coinbase values are what we expect from both the gas
fees and the emission schedule.
    
Resolves: #485
Resolves: #483

transfer: Add randomness and lift value logic
    
This supports lifting the logic of distribution of rewards to rusk to
also allow for checking incoming coinbases, and adds randomness to the
creation of notes.
    
Resolves: #485