### PR TITLE
Initial Preverify implementation

### DIFF
--- a/rusk/src/lib/encoding.rs
+++ b/rusk/src/lib/encoding.rs
@@ -10,7 +10,10 @@ use crate::transaction::{Transaction, TransactionPayload};
 use core::convert::TryFrom;
 use dusk_bytes::{DeserializableSlice, Serializable};
 use dusk_jubjub::{JubJubAffine, JubJubScalar};
-use dusk_pki::{PublicSpendKey, SecretSpendKey, StealthAddress, ViewKey};
+use dusk_pki::{
+    Ownable, PublicSpendKey, SecretSpendKey, StealthAddress, ViewKey,
+};
+use phoenix_core::Fee;
 use std::convert::TryInto;
 use tonic::{Code, Status};
 
@@ -61,6 +64,16 @@ impl From<StealthAddress> for rusk_proto::StealthAddress {
 impl From<&StealthAddress> for rusk_proto::StealthAddress {
     fn from(value: &StealthAddress) -> Self {
         (*value).into()
+    }
+}
+
+impl From<&Fee> for rusk_proto::Fee {
+    fn from(fee: &Fee) -> Self {
+        Self {
+            gas_limit: fee.gas_limit,
+            gas_price: fee.gas_price,
+            stealth_address: Some(fee.stealth_address().into()),
+        }
     }
 }
 

--- a/rusk/src/lib/services/state.rs
+++ b/rusk/src/lib/services/state.rs
@@ -158,7 +158,6 @@ impl State for Rusk {
         let tx_hash = tx.hash().to_bytes().to_vec();
 
         Ok(Response::new(PreverifyResponse {
-            tx: Some(tx_proto),
             tx_hash,
             fee: Some((tx.fee()).into()),
         }))

--- a/rusk/src/lib/services/state.rs
+++ b/rusk/src/lib/services/state.rs
@@ -12,10 +12,9 @@ use dusk_bytes::{DeserializableSlice, Serializable};
 use dusk_pki::{PublicKey, ViewKey};
 use dusk_wallet_core::Transaction;
 use phoenix_core::Note;
+use rusk_vm::{GasMeter, NetworkState};
 use tonic::{Request, Response, Status};
 use tracing::info;
-
-use rusk_vm::{GasMeter, NetworkState};
 
 pub use super::rusk_proto::state_server::{State, StateServer};
 pub use super::rusk_proto::{
@@ -24,7 +23,8 @@ pub use super::rusk_proto::{
     GetNotesOwnedByRequest, GetNotesOwnedByResponse, GetOpeningRequest,
     GetOpeningResponse, GetProvisionersRequest, GetProvisionersResponse,
     GetStakeRequest, GetStakeResponse, GetStateRootRequest,
-    GetStateRootResponse, StateTransitionRequest, StateTransitionResponse,
+    GetStateRootResponse, PreverifyRequest, PreverifyResponse,
+    StateTransitionRequest, StateTransitionResponse,
     Transaction as TransactionProto, VerifyStateTransitionRequest,
     VerifyStateTransitionResponse,
 };
@@ -133,6 +133,31 @@ impl State for Rusk {
         info!("Received Echo request");
 
         Err(Status::unimplemented("Request not implemented"))
+    }
+
+    /// TODO: Currently it's just a pass through, does not verify the tx
+    async fn preverify(
+        &self,
+        request: Request<PreverifyRequest>,
+    ) -> Result<Response<PreverifyResponse>, Status> {
+        info!("Received Preverify request");
+
+        let request = request.into_inner();
+
+        let tx_proto = request.tx.ok_or_else(|| {
+            Status::invalid_argument("Transaction is required")
+        })?;
+
+        let tx = Transaction::from_slice(&tx_proto.payload)
+            .map_err(Error::Serialization)?;
+
+        let tx_hash = tx.hash().to_bytes().to_vec();
+
+        Ok(Response::new(PreverifyResponse {
+            tx: Some(tx_proto),
+            tx_hash,
+            fee: Some((tx.fee()).into()),
+        }))
     }
 
     async fn execute_state_transition(

--- a/schema/state.proto
+++ b/schema/state.proto
@@ -7,6 +7,16 @@ import "prover.proto";
 import "provisioner.proto";
 import "transaction.proto";
 
+message PreverifyRequest {
+    Transaction tx = 1;
+}
+
+message PreverifyResponse {
+    Transaction tx = 1;
+    bytes tx_hash = 2;
+    Fee fee = 3;
+}
+
 message StateTransitionRequest {
     repeated Transaction txs = 1;
     fixed64 block_gas_limit = 2;
@@ -87,6 +97,7 @@ message GetStakeResponse {
 
 service State {
     rpc Echo(EchoRequest) returns (EchoResponse) {}
+    rpc Preverify(PreverifyRequest) returns (PreverifyResponse) {}
     rpc ExecuteStateTransition(ExecuteStateTransitionRequest) returns (ExecuteStateTransitionResponse) {}
     rpc VerifyStateTransition(VerifyStateTransitionRequest) returns (VerifyStateTransitionResponse) {}
     rpc Accept(StateTransitionRequest) returns (StateTransitionResponse) {}

--- a/schema/state.proto
+++ b/schema/state.proto
@@ -12,9 +12,8 @@ message PreverifyRequest {
 }
 
 message PreverifyResponse {
-    Transaction tx = 1;
-    bytes tx_hash = 2;
-    Fee fee = 3;
+    bytes tx_hash = 1;
+    Fee fee = 2;
 }
 
 message StateTransitionRequest {


### PR DESCRIPTION
- Add Preverify to the state schema
- rusk: Add the Preverify service to rusk
- rusk: Add conversion between phoenix Fee and gRPC Fee type

See also: #458