### PR TITLE
Expose a pre-verification of a transaction

### DIFF
--- a/contracts/transfer/src/transfer.rs
+++ b/contracts/transfer/src/transfer.rs
@@ -126,6 +126,15 @@ impl TransferContract {
 
         hasher.finalize()
     }
+
+    pub fn any_nullifier_exists(
+        &self,
+        nullifiers: &[BlsScalar],
+    ) -> Result<bool, Error> {
+        nullifiers.iter().try_fold(false, |t, n| {
+            Ok(t || self.nullifiers.get(n).map(|n| n.is_some())?)
+        })
+    }
 }
 
 impl TryFrom<Note> for TransferContract {

--- a/contracts/transfer/src/wasm/internal.rs
+++ b/contracts/transfer/src/wasm/internal.rs
@@ -41,15 +41,6 @@ impl TransferContract {
         1
     }
 
-    pub(crate) fn any_nullifier_exists(
-        &self,
-        nullifiers: &[BlsScalar],
-    ) -> Result<bool, Error> {
-        nullifiers.iter().try_fold(false, |t, n| {
-            Ok(t || self.nullifiers.get(n).map(|n| n.is_some())?)
-        })
-    }
-
     pub(crate) fn root_exists(&self, root: &BlsScalar) -> Result<bool, Error> {
         let root = self.roots.get(root)?;
 

--- a/contracts/transfer/tests/circuits.rs
+++ b/contracts/transfer/tests/circuits.rs
@@ -26,8 +26,9 @@ fn sign_message_stct() {
     let psk = ssk.public_spend_key();
 
     let value = 100;
-    let mut address = ContractId::default();
-    rng.fill_bytes(address.as_bytes_mut());
+    let mut bytes = [0u8; 32];
+    rng.fill_bytes(&mut bytes);
+    let address = rusk_abi::gen_contract_id(&bytes[..]);
 
     let blinding_factor = JubJubScalar::random(&mut rng);
     let note = Note::obfuscated(&mut rng, &psk, value, blinding_factor);
@@ -52,8 +53,9 @@ fn sign_message_stco() {
     let psk = ssk.public_spend_key();
 
     let value = 100;
-    let mut address = ContractId::default();
-    rng.fill_bytes(address.as_bytes_mut());
+    let mut bytes = [0u8; 32];
+    rng.fill_bytes(&mut bytes);
+    let address = rusk_abi::gen_contract_id(&bytes[..]);
 
     let r = JubJubScalar::random(&mut rng);
     let message = Message::new(&mut rng, &r, &psk, value);

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-abi"
-version = "0.6.0"
+version = "0.6.2"
 edition = "2021"
 
 repository = "https://github.com/dusk-network/rusk"

--- a/rusk-abi/src/lib.rs
+++ b/rusk-abi/src/lib.rs
@@ -17,6 +17,8 @@
 #![deny(clippy::all)]
 
 pub use dusk_abi::ContractId;
+use dusk_bls12_381::BlsScalar;
+use dusk_bytes::DeserializableSlice;
 
 /// Constant depth of the merkle tree that provides the opening proofs.
 pub const POSEIDON_TREE_DEPTH: usize = 17;
@@ -33,6 +35,16 @@ pub const fn transfer_contract() -> ContractId {
 /// Contract ID of the genesis stake contract
 pub const fn stake_contract() -> ContractId {
     ContractId::reserved(0x2)
+}
+
+/// Converts a `ContractId` to a `BlsScalar`
+///
+/// This cannot fail since the contract id should be generated always using
+/// `rusk_abi::gen_contract_id` that ensures the bytes are inside the BLS field.
+pub fn contract_to_scalar(contract_id: &ContractId) -> BlsScalar {
+    BlsScalar::from_slice(contract_id.as_bytes()).expect(
+        "Something went REALLY wrong if a contract id cannot be a scalar",
+    )
 }
 
 #[doc(hidden)]

--- a/rusk-abi/src/module/host.rs
+++ b/rusk-abi/src/module/host.rs
@@ -50,8 +50,8 @@ pub fn gen_contract_id(bytes: &[u8]) -> ContractId {
 
 pub fn verify_proof(
     pp: &PublicParameters,
-    vd: &[u8],
     proof: &[u8],
+    vd: &[u8],
     pi: Vec<PublicInput>,
 ) -> Result<bool, CanonError> {
     let proof =
@@ -98,7 +98,7 @@ impl HostModule for RuskModule {
                 let vd = Vec::<u8>::decode(&mut source)?;
                 let pi = Vec::<PublicInput>::decode(&mut source)?;
 
-                let ret = verify_proof(self.pp, &proof, &vd, pi);
+                let ret = verify_proof(self.pp, &proof, &vd, pi)?;
 
                 Ok(ReturnValue::from_canon(&ret))
             }

--- a/rusk/src/lib/services/state.rs
+++ b/rusk/src/lib/services/state.rs
@@ -9,7 +9,8 @@ use crate::services::prover::RuskProver;
 use crate::{Result, Rusk, RuskState};
 
 use canonical::{Canon, Sink};
-use dusk_bls12_381_sign::{BlsScalar, PublicKey};
+use dusk_bls12_381::BlsScalar;
+use dusk_bls12_381_sign::PublicKey;
 use dusk_bytes::{DeserializableSlice, Serializable};
 use dusk_pki::ViewKey;
 use dusk_wallet_core::Transaction;

--- a/test-utils/transfer-wrapper/src/wrapper.rs
+++ b/test-utils/transfer-wrapper/src/wrapper.rs
@@ -114,8 +114,10 @@ impl TransferWrapper {
         C: Canon,
     {
         let contract = Contract::new(contract, bytecode.to_vec());
-
-        network.deploy(contract).expect("Failed to deploy contract")
+        let contract_id = rusk_abi::gen_contract_id(bytecode);
+        network
+            .deploy_with_id(contract_id, contract)
+            .expect("Failed to deploy contract")
     }
 
     pub fn state<C>(&self, contract: &ContractId) -> C


### PR DESCRIPTION
- `rusk`: Add `preverify` method
    - Add `any_nullifiers_exists` to `RustState`
    - Add `preverify` method to `RuskProver`

- `transfer-contract`:  Change `any_nullifiers_exists` scope
- `rusk-abi`: release a new version needed for Rusk's preverify
    - Add `contract_to_scalar` function
    - Change `verify_proof` to be also in host code not only hosted

Resolves: #458

Co-authored-by: Eduardo Leegwater Simões <eduardo@dusk.network>