### PR TITLE
Add an interactive mode to the wallet CLI

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Introduce interactive mode by default [#492]
 
 ## [0.1.1] - 2022-01-27
 
@@ -32,3 +33,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#482]: https://github.com/dusk-network/rusk/issues/482
 [#479]: https://github.com/dusk-network/rusk/issues/479
+[#492]: https://github.com/dusk-network/rusk/issues/492

--- a/rusk-wallet/src/lib/error.rs
+++ b/rusk-wallet/src/lib/error.rs
@@ -36,6 +36,8 @@ pub enum Error {
     IO(io::Error),
     /// Wallet Core lib errors
     WalletCore(Box<CoreError>),
+    /// User graceful exit
+    UserExit,
 }
 
 impl From<dusk_bytes::Error> for Error {
@@ -137,6 +139,9 @@ impl fmt::Display for Error {
             Error::WalletCore(err) => {
                 write!(f, "Wallet Core lib errors: {:?}", err)
             }
+            Error::UserExit => {
+                write!(f, "Done")
+            }
         }
     }
 }
@@ -183,6 +188,9 @@ impl fmt::Debug for Error {
             }
             Error::WalletCore(err) => {
                 write!(f, "Wallet Core lib errors: {:?}", err)
+            }
+            Error::UserExit => {
+                write!(f, "Done")
             }
         }
     }

--- a/rusk-wallet/src/lib/mod.rs
+++ b/rusk-wallet/src/lib/mod.rs
@@ -9,3 +9,4 @@ pub mod crypto;
 pub mod error;
 pub mod prompt;
 pub mod store;
+pub mod wallet;

--- a/rusk-wallet/src/lib/prompt.rs
+++ b/rusk-wallet/src/lib/prompt.rs
@@ -4,8 +4,12 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use std::path::PathBuf;
+
 use blake3::Hash;
 use requestty::Question;
+
+use crate::CliCommand;
 
 /// Request the user to authenticate with a password
 pub(crate) fn request_auth() -> Hash {
@@ -19,6 +23,7 @@ pub(crate) fn request_auth() -> Hash {
     pwd
 }
 
+/// Request the user to create a wallet password
 pub(crate) fn create_password() -> Hash {
     let mut pwd = String::from("");
 
@@ -53,6 +58,7 @@ pub(crate) fn create_password() -> Hash {
     pwd
 }
 
+/// Display the recovery phrase to the user and ask for confirmation
 pub(crate) fn confirm_recovery_phrase(phrase: String) {
     // inform the user about the mnemonic phrase
     println!("The following phrase is essential for you to regain access to your wallet\nin case you lose access to this computer.");
@@ -73,6 +79,7 @@ pub(crate) fn confirm_recovery_phrase(phrase: String) {
     }
 }
 
+/// Request the user to input the recovery phrase
 pub(crate) fn request_recovery_phrase() -> String {
     // let the user input the recovery phrase
     let q = Question::input("phrase")
@@ -81,4 +88,217 @@ pub(crate) fn request_recovery_phrase() -> String {
     let a = requestty::prompt_one(q).unwrap();
     let phrase = a.as_string().unwrap().to_string();
     phrase
+}
+
+/// Welcome the user into interactive mode and ask for an action
+pub(crate) fn welcome() -> u8 {
+    let q = Question::select("welcome")
+        .message("What would you like to do?")
+        .choices(vec![
+            "Create a new wallet and store it in this computer",
+            "Access a lost wallet using the recovery phrase",
+        ])
+        .default_separator()
+        .choice("Exit")
+        .build();
+    let answer = requestty::prompt_one(q).unwrap();
+    match answer.as_list_item().unwrap().index {
+        0 => 1,
+        1 => 2,
+        _ => 0,
+    }
+}
+
+/// Request the user to select a wallet to open
+pub(crate) fn select_wallet(dir: &str, wallets: Vec<String>) -> PathBuf {
+    // select the wallet
+    let q = Question::select("wallet")
+        .message("Please select the wallet you wish to use:")
+        .choices(&wallets)
+        .build();
+    let a = requestty::prompt_one(q).unwrap();
+    let wi = a.as_list_item().unwrap().index;
+
+    // gen full path for selected wallet
+    let mut path = PathBuf::new();
+    path.push(dir);
+    path.push(wallets[wi].clone());
+    path
+}
+
+/// Let the user choose a command to execute
+pub(crate) fn command() -> Option<CliCommand> {
+    let msg = "What would you like to do?";
+    let q = Question::select("action")
+        .message(msg)
+        .choices(vec![
+            "Check my current balance",
+            "Retrieve my public spend key",
+            "Send Dusk",
+            "Stake Dusk",
+            "Extend stake for a particular key",
+            "Withdraw a key's stake",
+        ])
+        .default_separator()
+        .choice("Exit")
+        .build();
+
+    let answer = requestty::prompt_one(q).unwrap();
+
+    use CliCommand::*;
+    match answer.as_list_item().unwrap().index {
+        // Check balance
+        0 => {
+            let key = request_key_index("spend");
+            Some(Balance { key })
+        }
+        // Public spend key
+        1 => {
+            let key = request_key_index("spend");
+            Some(Address { key })
+        }
+        // Create transfer
+        2 => {
+            let key = request_key_index("spend");
+            let rcvr = request_rcvr_addr();
+            let amt = request_token_amt("transfer");
+            let gas_limit = request_gas_limit();
+            let gas_price = Some(0);
+            Some(Transfer {
+                key,
+                rcvr,
+                amt,
+                gas_limit,
+                gas_price,
+            })
+        }
+        // Stake
+        3 => {
+            let key = request_key_index("spend");
+            let stake_key = request_key_index("stake");
+            let amt = request_token_amt("stake");
+            let gas_limit = request_gas_limit();
+            let gas_price = Some(0);
+            Some(Stake {
+                key,
+                stake_key,
+                amt,
+                gas_limit,
+                gas_price,
+            })
+        }
+        // Extend stake
+        5 => {
+            let key = request_key_index("spend");
+            let stake_key = request_key_index("stake");
+            let gas_limit = request_gas_limit();
+            let gas_price = Some(0);
+            Some(ExtendStake {
+                key,
+                stake_key,
+                gas_limit,
+                gas_price,
+            })
+        }
+        // Withdraw stake
+        6 => {
+            let key = request_key_index("spend");
+            let stake_key = request_key_index("stake");
+            let gas_limit = request_gas_limit();
+            let gas_price = Some(0);
+            Some(WithdrawStake {
+                key,
+                stake_key,
+                gas_limit,
+                gas_price,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Request a key index from the user
+pub(crate) fn request_key_index(key_type: &str) -> u64 {
+    let question = requestty::Question::int("key")
+        .message(format!("Select a {} key:", key_type))
+        .default(0)
+        .validate_on_key(|i, _| i > 0 && i < i64::MAX)
+        .validate(|i, _| {
+            if i > 0 && i < i64::MAX {
+                Ok(())
+            } else {
+                Err(format!("Please choose a key between 0 and {}", i64::MAX))
+            }
+        })
+        .build();
+
+    let a = requestty::prompt_one(question).unwrap();
+    let val = a.as_int().unwrap();
+    u64::try_from(val).ok().unwrap()
+}
+
+/// Request a receiver address
+pub(crate) fn request_rcvr_addr() -> String {
+    // let the user input the recovery phrase
+    let q = Question::input("addr")
+        .message("Please enter the recipients address:")
+        .validate_on_key(|addr, _| is_valid_addr(addr))
+        .validate(|addr, _| {
+            if is_valid_addr(addr) {
+                Ok(())
+            } else {
+                Err("Please introduce a valid Dusk address".to_string())
+            }
+        })
+        .build();
+
+    let a = requestty::prompt_one(q).unwrap();
+    a.as_string().unwrap().to_string()
+}
+
+/// Utility function to check if an address is valid
+fn is_valid_addr(addr: &str) -> bool {
+    bs58::decode(addr).into_vec().is_ok()
+}
+
+/// Request amount of tokens
+pub(crate) fn request_token_amt(action: &str) -> u64 {
+    let question = requestty::Question::float("amt")
+        .message(format!("Introduce the amount to {} (Dusk):", action))
+        .default(0.0)
+        .validate(|num, _| {
+            if num.is_finite() && num.is_sign_positive() {
+                Ok(())
+            } else {
+                Err("Please enter a finite number".to_owned())
+            }
+        })
+        .build();
+
+    let a = requestty::prompt_one(question).unwrap();
+    let dusk_amt = a.as_float().unwrap();
+    (dusk_amt * 1_000_000.0) as u64
+}
+
+/// Request gas spend limit
+pub(crate) fn request_gas_limit() -> u64 {
+    let question = requestty::Question::int("amt")
+        .message("Introduce the gas spend limit for this transaction (µDusk):")
+        .default(0)
+        .validate_on_key(|i, _| i > 0 && i < i64::MAX)
+        .validate(|i, _| {
+            if i > 0 && i < i64::MAX {
+                Ok(())
+            } else {
+                Err(format!(
+                    "Please introduce an amount between 0 and {}",
+                    i64::MAX
+                ))
+            }
+        })
+        .build();
+
+    let a = requestty::prompt_one(question).unwrap();
+    let val = a.as_int().unwrap();
+    u64::try_from(val).ok().unwrap()
 }

--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -1,0 +1,156 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+use dusk_bytes::Serializable;
+use dusk_jubjub::BlsScalar;
+use dusk_wallet_core::Wallet;
+
+use crate::lib::clients::{Prover, State};
+use crate::lib::prompt;
+use crate::lib::store::LocalStore;
+use crate::{CliCommand, Error};
+
+/// Interface to wallet_core lib
+pub(crate) struct CliWallet {
+    wallet: Wallet<LocalStore, State, Prover>,
+}
+
+impl CliWallet {
+    /// Creates a new CliWallet instance
+    pub fn new(store: LocalStore, state: State, prover: Prover) -> Self {
+        CliWallet {
+            wallet: Wallet::new(store, state, prover),
+        }
+    }
+
+    /// Runs the CliWallet in interactive mode
+    pub fn interactive(&self) -> Result<(), Error> {
+        loop {
+            match prompt::command() {
+                Some(cmd) => self.run(cmd)?,
+                None => return Ok(()),
+            }
+        }
+    }
+
+    /// Runs a command through wallet core lib
+    pub fn run(&self, cmd: CliCommand) -> Result<(), Error> {
+        // perform whatever action user requested
+        use CliCommand::*;
+        match cmd {
+            // Check your current balance
+            Balance { key } => {
+                let balance = self.wallet.get_balance(key)?;
+                println!("Your balance is: {} Dusk", balance / 1_000_000);
+            }
+
+            // Retrieve public spend key
+            Address { key } => {
+                let pk = self.wallet.public_spend_key(key)?;
+                let addr = pk.to_bytes();
+                let addr = bs58::encode(addr).into_string();
+                println!("The public address for key {} is: {:?}", key, addr);
+            }
+
+            // Send Dusk through the network
+            Transfer {
+                key,
+                rcvr,
+                amt,
+                gas_limit,
+                gas_price,
+            } => {
+                let mut addr_bytes = [0u8; 64];
+                addr_bytes.copy_from_slice(&bs58::decode(rcvr).into_vec()?);
+                let dest_addr =
+                    dusk_pki::PublicSpendKey::from_bytes(&addr_bytes)?;
+                let my_addr = self.wallet.public_spend_key(key)?;
+                let mut rng = StdRng::from_entropy();
+                self.wallet.transfer(
+                    &mut rng,
+                    key,
+                    &my_addr,
+                    &dest_addr,
+                    amt,
+                    gas_limit,
+                    gas_price.unwrap_or(0),
+                    BlsScalar::zero(),
+                )?;
+                println!("Transfer sent!");
+            }
+
+            // Start staking Dusk
+            Stake {
+                key,
+                stake_key,
+                amt,
+                gas_limit,
+                gas_price,
+            } => {
+                let my_addr = self.wallet.public_spend_key(key)?;
+                let mut rng = StdRng::from_entropy();
+                self.wallet.stake(
+                    &mut rng,
+                    key,
+                    stake_key,
+                    &my_addr,
+                    amt,
+                    gas_limit,
+                    gas_price.unwrap_or(0),
+                )?;
+                println!("Staked succesfully!");
+            }
+
+            // Extend stake for a particular key
+            ExtendStake {
+                key,
+                stake_key,
+                gas_limit,
+                gas_price,
+            } => {
+                let my_addr = self.wallet.public_spend_key(key)?;
+                let mut rng = StdRng::from_entropy();
+                self.wallet.extend_stake(
+                    &mut rng,
+                    key,
+                    stake_key,
+                    &my_addr,
+                    gas_limit,
+                    gas_price.unwrap_or(0),
+                )?;
+                println!("Stake extended succesfully!");
+            }
+
+            // Withdraw a key's stake
+            WithdrawStake {
+                key,
+                stake_key,
+                gas_limit,
+                gas_price,
+            } => {
+                let my_addr = self.wallet.public_spend_key(key)?;
+                let mut rng = StdRng::from_entropy();
+                self.wallet.withdraw_stake(
+                    &mut rng,
+                    key,
+                    stake_key,
+                    &my_addr,
+                    gas_limit,
+                    gas_price.unwrap_or(0),
+                )?;
+                println!("Stake withdrawn succesfully!");
+            }
+
+            // Do nothing
+            _ => {}
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Provides users with an interactive mode by default if no subcommand is specified at runtime.

Interactive mode guides the user through the different commands, making it easier for first-timers to get a hang of the CLI tool.

Supports wallet creation, recovery, and all `wallet_core` commands.


Closes #492 