### PR TITLE
Implement the missing gRPCs

### DIFF
--- a/contracts/stake/Cargo.toml
+++ b/contracts/stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stake-contract"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [lib]

--- a/contracts/stake/Cargo.toml
+++ b/contracts/stake/Cargo.toml
@@ -13,6 +13,7 @@ dusk-abi = "0.10"
 dusk-bls12_381 = { version = "0.8", default-features = false, features = ["canon"] }
 dusk-bls12_381-sign = { version = "0.1.0-rc", features = ["canon"] }
 dusk-bytes = "0.1"
+microkelvin = "0.10"
 dusk-hamt = { version = "0.5", default-features = false }
 dusk-pki = { version = "0.9.0-rc", default-features = false }
 dusk-plonk = { version = "0.9", optional = true }

--- a/contracts/stake/src/contract.rs
+++ b/contracts/stake/src/contract.rs
@@ -10,6 +10,7 @@ use canonical_derive::Canon;
 use dusk_bls12_381_sign::PublicKey;
 use dusk_bytes::Serializable;
 use dusk_hamt::Map;
+use microkelvin::First;
 use phoenix_core::Note;
 
 use alloc::vec::Vec;
@@ -66,6 +67,20 @@ impl StakeContract {
             .is_some();
 
         Ok(is_staked)
+    }
+
+    /// Gets a vector of all public keys and stakes.
+    pub fn stakes(&self) -> Result<Vec<(PublicKey, Stake)>, Error> {
+        let mut stakes = Vec::new();
+
+        if let Some(branch) = self.staked.first()? {
+            for leaf in branch {
+                let leaf = leaf?;
+                stakes.push((leaf.key, leaf.val));
+            }
+        }
+
+        Ok(stakes)
     }
 
     pub fn stake_sign_message(block_height: u64, stake: &Stake) -> Vec<u8> {

--- a/contracts/stake/tests/stake.rs
+++ b/contracts/stake/tests/stake.rs
@@ -157,6 +157,13 @@ fn stake() {
 
     assert!(is_staked);
 
+    let stakes = wrapper
+        .stake_state()
+        .stakes()
+        .expect("Failed to fetch all stakes");
+
+    assert_eq!(stakes.len(), 1);
+
     let stake_p = wrapper
         .stake_state()
         .get_stake(&stake_pk)

--- a/rusk/src/lib/services/state.rs
+++ b/rusk/src/lib/services/state.rs
@@ -133,11 +133,15 @@ impl Rusk {
 impl State for Rusk {
     async fn echo(
         &self,
-        _request: Request<EchoRequest>,
+        request: Request<EchoRequest>,
     ) -> Result<Response<EchoResponse>, Status> {
         info!("Received Echo request");
 
-        Err(Status::unimplemented("Request not implemented"))
+        let request = request.into_inner();
+
+        Ok(Response::new(EchoResponse {
+            message: request.message,
+        }))
     }
 
     /// TODO: Currently it's just a pass through, does not verify the tx

--- a/rusk/src/lib/services/state.rs
+++ b/rusk/src/lib/services/state.rs
@@ -28,7 +28,8 @@ pub use super::rusk_proto::{
     GetOpeningRequest, GetOpeningResponse, GetProvisionersRequest,
     GetProvisionersResponse, GetStakeRequest, GetStakeResponse,
     GetStateRootRequest, GetStateRootResponse, PreverifyRequest,
-    PreverifyResponse, StateTransitionRequest, StateTransitionResponse,
+    PreverifyResponse, Provisioner, Stake as StakeProto,
+    StateTransitionRequest, StateTransitionResponse,
     Transaction as TransactionProto, VerifyStateTransitionRequest,
     VerifyStateTransitionResponse,
 };
@@ -305,7 +306,29 @@ impl State for Rusk {
     ) -> Result<Response<GetProvisionersResponse>, Status> {
         info!("Received GetProvisioners request");
 
-        Err(Status::unimplemented("Request not implemented"))
+        let state = self.state()?;
+        let provisioners = state
+            .get_provisioners()?
+            .into_iter()
+            .map(|(key, stake)| {
+                let raw_public_key_bls = key.to_raw_bytes().to_vec();
+                let public_key_bls = key.to_bytes().to_vec();
+
+                let stake = StakeProto {
+                    start_height: stake.eligibility(),
+                    end_height: stake.expiration(),
+                    amount: stake.value(),
+                };
+
+                Provisioner {
+                    raw_public_key_bls,
+                    public_key_bls,
+                    stakes: vec![stake],
+                }
+            })
+            .collect();
+
+        Ok(Response::new(GetProvisionersResponse { provisioners }))
     }
 
     async fn get_state_root(

--- a/rusk/src/lib/state.rs
+++ b/rusk/src/lib/state.rs
@@ -103,6 +103,12 @@ impl RuskState {
             .get_contract_cast_state(&rusk_abi::stake_contract())?)
     }
 
+    /// Gets the provisioners currently in the stake contract.
+    pub fn get_provisioners(&self) -> Result<Vec<(PublicKey, Stake)>> {
+        let stake = self.stake_contract()?;
+        Ok(stake.stakes()?)
+    }
+
     /// Mints two notes into the transfer contract state, to pay gas fees.
     pub fn mint(
         &mut self,


### PR DESCRIPTION
This PR implements `GetProvisioners` and `Echo` for the purposes of finalizing the services surface.