### PR TITLE
Fix prover

### DIFF
--- a/contracts/transfer/src/transfer/host.rs
+++ b/contracts/transfer/src/transfer/host.rs
@@ -41,6 +41,18 @@ impl TransferContract {
         let generator_note =
             Note::transparent(&mut rng, generator, generator_value);
 
+        // Here we are adding the notes to the state without passing from the
+        // WebAssembly side. So we need to canonicalize them since any inner
+        // [`JubJubExtended`] would result a different form otherwise.
+        let dusk_note = Note::from_bytes(&dusk_note.to_bytes()).expect(
+            "Must be possible to deserialized a Note from its serialized form",
+        );
+
+        let generator_note = Note::from_bytes(&generator_note.to_bytes())
+            .expect(
+            "Must be possible to deserialized a Note from its serialized form",
+        );
+
         let dusk_note = self.push_note(block_height, dusk_note)?;
         let generator_note = self.push_note(block_height, generator_note)?;
 

--- a/contracts/transfer/tests/circuits.rs
+++ b/contracts/transfer/tests/circuits.rs
@@ -6,7 +6,6 @@
 
 use transfer_contract::TransferContract;
 
-use dusk_abi::ContractId;
 use dusk_jubjub::JubJubScalar;
 use dusk_pki::SecretSpendKey;
 use phoenix_core::{Message, Note};

--- a/rusk-abi/src/module/host.rs
+++ b/rusk-abi/src/module/host.rs
@@ -21,7 +21,7 @@ use dusk_plonk::prelude::*;
 use dusk_schnorr::Signature;
 
 use crate::hash::Hasher;
-use crate::{PublicInput, RuskModule};
+use crate::{PublicInput, RuskModule, TRANSCRIPT_LABEL};
 
 /// Hashes a vector of [`BlsScalar`] using Poseidon's sponge function
 pub fn poseidon_hash(scalars: &[BlsScalar]) -> BlsScalar {
@@ -68,7 +68,7 @@ pub fn verify_proof(
         &verifier_data,
         &proof,
         pi.as_slice(),
-        b"dusk-network",
+        TRANSCRIPT_LABEL,
     )
     .is_ok())
 }

--- a/rusk-abi/src/module/public_input.rs
+++ b/rusk-abi/src/module/public_input.rs
@@ -10,7 +10,7 @@ use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{JubJubAffine, JubJubExtended, JubJubScalar};
 
 /// Enum that represents all possible types of public inputs
-#[derive(Canon, Clone)]
+#[derive(Debug, Canon, Clone)]
 pub enum PublicInput {
     /// A Public Input Point
     Point(JubJubAffine),

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -38,7 +38,7 @@ dusk-bls12_381-sign = { version = "0.1.0-rc", features = ["canon"] }
 dusk-jubjub = { version = "0.10", features = ["canon"] }
 dusk-pki = "0.9.0-rc"
 dusk-bytes = "0.1"
-dusk-wallet-core = "0.6"
+dusk-wallet-core = "0.8.0-rc"
 dusk-abi = "0.10"
 rusk-vm = { version = "0.8.0-rc", features = ["persistence"] }
 phoenix-core = "0.15.0-rc"

--- a/rusk/src/lib/services/network.rs
+++ b/rusk/src/lib/services/network.rs
@@ -235,7 +235,7 @@ mod serialization {
         tx_wire.write_all(&TX_VERSION.to_le_bytes()[..])?;
         tx_wire.write_all(&TX_TYPE_TRANSFER.to_le_bytes()[..])?;
 
-        let payload = tx.to_bytes();
+        let payload = tx.to_var_bytes();
         tx_wire.write_all(&(payload.len() as u32).to_le_bytes()[..])?;
         tx_wire.write_all(&payload[..])?;
         tx_wire.write_all(&DUMMY_HASH[..])?;

--- a/rusk/src/lib/services/prover.rs
+++ b/rusk/src/lib/services/prover.rs
@@ -34,7 +34,6 @@ pub use rusk_proto::{
     WfcoProverRequest, WfcoProverResponse, WfctProverRequest,
     WfctProverResponse,
 };
-use std::collections::HashMap;
 
 use transfer_circuits::{
     CircuitInput, CircuitInputSignature, DeriveKey, ExecuteCircuit,
@@ -81,12 +80,21 @@ impl RuskProver {
                 ))
             })?;
 
-        let mut pi = Vec::with_capacity(5 + inputs.len() + 2 * outputs.len());
+        let mut pi: Vec<rusk_abi::PublicInput> =
+            Vec::with_capacity(5 + inputs.len() + 2 * outputs.len());
 
         pi.push(tx_hash.into());
         pi.push(tx.anchor().into());
         pi.extend(inputs.iter().map(|n| n.into()));
-        pi.push(tx.crossover().value_commitment().into());
+
+        pi.push(
+            tx.crossover()
+                .copied()
+                .unwrap_or_default()
+                .value_commitment()
+                .into(),
+        );
+
         pi.push(tx.fee().gas_limit.into());
         pi.extend(outputs.iter().map(|n| n.value_commitment().into()));
 

--- a/rusk/src/lib/services/prover/execute.rs
+++ b/rusk/src/lib/services/prover/execute.rs
@@ -6,28 +6,6 @@
 
 use super::*;
 
-pub static EXECUTE_PROVER_KEYS: Lazy<HashMap<(usize, usize), ProverKey>> =
-    Lazy::new(|| {
-        let mut map = HashMap::new();
-
-        for ninputs in [1, 2, 3, 4] {
-            for noutputs in [0, 1, 2] {
-                let circ = circuit_from_numbers(ninputs, noutputs)
-                    .expect("circuit to exist");
-
-                let keys =
-                    keys_for(circ.circuit_id()).expect("keys to be available");
-                let pk = keys.get_prover().expect("prover to be available");
-                let pk =
-                    ProverKey::from_slice(&pk).expect("prover key to be valid");
-
-                map.insert((ninputs, noutputs), pk);
-            }
-        }
-
-        map
-    });
-
 impl RuskProver {
     pub(crate) fn prove_execute(
         &self,
@@ -38,24 +16,7 @@ impl RuskProver {
                 Status::invalid_argument("Failed parsing unproven TX")
             })?;
 
-        let (num_inputs, num_outputs) =
-            (utx.inputs().len(), utx.outputs().len());
-        let mut circ = circuit_from_numbers(num_inputs, num_outputs)
-            .ok_or_else(|| {
-                Status::invalid_argument(format!(
-                    "No circuit found for number of inputs {} and outputs {}",
-                    num_inputs, num_outputs
-                ))
-            })?;
-
-        let pk = EXECUTE_PROVER_KEYS
-            .get(&(num_inputs, num_outputs))
-            .ok_or_else(|| {
-                Status::invalid_argument(format!(
-                    "Couldn't find prover key for circuit with number of inputs {} and outputs {}",
-                    num_inputs, num_outputs
-                ))
-            })?;
+        let mut circ = ExecuteCircuit::default();
 
         for input in utx.inputs() {
             let cis = CircuitInputSignature::from(input.signature());
@@ -68,6 +29,7 @@ impl RuskProver {
                 input.nullifier(),
                 cis,
             );
+
             circ.add_input(cinput).map_err(|e| {
                 Status::internal(format!(
                     "Failed adding input to circuit: {}",
@@ -75,6 +37,7 @@ impl RuskProver {
                 ))
             })?;
         }
+
         for (note, value, blinder) in utx.outputs() {
             circ.add_output_with_data(*note, *value, *blinder).map_err(
                 |e| {
@@ -87,22 +50,27 @@ impl RuskProver {
         }
 
         circ.set_tx_hash(utx.hash());
-        circ.set_fee(utx.fee()).map_err(|e| {
-            Status::invalid_argument(format!("Failed setting fee: {}", e))
-        })?;
 
-        let (crossover, value, blinder) = utx.crossover();
-        circ.set_fee_crossover(utx.fee(), crossover, *value, *blinder);
+        if let Some((crossover, value, blinder)) = utx.crossover() {
+            circ.set_fee_crossover(utx.fee(), crossover, *value, *blinder);
+        } else {
+            circ.set_fee(utx.fee()).map_err(|e| {
+                Status::invalid_argument(format!("Failed setting fee: {}", e))
+            })?;
+        }
 
-        let proof = circ.prove(&crate::PUB_PARAMS, pk).map_err(|e| {
+        let keys = rusk_profile::keys_for(circ.circuit_id())?;
+        let pk = &keys.get_prover()?;
+        let pk = ProverKey::from_slice(pk).unwrap();
+
+        let proof = circ.prove(&crate::PUB_PARAMS, &pk).map_err(|e| {
             Status::invalid_argument(format!(
                 "Failed proving transaction: {}",
                 e
             ))
         })?;
 
-        let tx = utx.prove(proof).to_bytes();
-
+        let tx = utx.prove(proof).to_var_bytes();
         Ok(Response::new(ExecuteProverResponse { tx }))
     }
 }

--- a/rusk/src/lib/services/state.rs
+++ b/rusk/src/lib/services/state.rs
@@ -100,13 +100,16 @@ impl Rusk {
         ))
     }
 
-    fn execute_transactions<T: From<Transaction>>(
+    fn execute_transactions<T>(
         &self,
         network: &mut NetworkState,
         block_gas_meter: &mut GasMeter,
         block_height: u64,
         txs: &[TransactionProto],
-    ) -> Vec<T> {
+    ) -> Vec<T>
+    where
+        T: From<Transaction>,
+    {
         txs.iter()
             .map(|tx| Transaction::from_slice(&tx.payload))
             .filter_map(|tx| tx.ok())
@@ -422,7 +425,7 @@ impl State for Rusk {
 
 impl From<Transaction> for TransactionProto {
     fn from(tx: Transaction) -> Self {
-        let payload = tx.to_bytes();
+        let payload = tx.to_var_bytes();
 
         TransactionProto {
             version: TX_VERSION,

--- a/rusk/src/lib/services/state.rs
+++ b/rusk/src/lib/services/state.rs
@@ -45,7 +45,7 @@ fn extract_coinbase(
 
     // There must always be two Coinbase transactions
     let coinbases = coinbase_txs.len();
-    if coinbases == 2 {
+    if coinbases != 2 {
         return Err(Status::invalid_argument(format!(
             "Expected 2 coinbase transactions, got {}",
             coinbases

--- a/rusk/src/lib/transaction.rs
+++ b/rusk/src/lib/transaction.rs
@@ -435,7 +435,7 @@ mod tests {
     fn transaction_read_write() -> Result<()> {
         let mut tx = deterministic_tx();
 
-        let buf = tx.to_bytes();
+        let buf = tx.to_var_bytes();
         let decoded_tx = Transaction::from_bytes(&buf)?;
 
         assert_eq!(tx, decoded_tx);

--- a/rusk/tests/services/mod.rs
+++ b/rusk/tests/services/mod.rs
@@ -7,3 +7,4 @@
 pub mod pki_service;
 pub mod prover_service;
 pub mod state_service;
+pub mod transactions;

--- a/rusk/tests/services/prover_service.rs
+++ b/rusk/tests/services/prover_service.rs
@@ -5,14 +5,17 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::common::setup;
-use dusk_bls12_381_sign::{PublicKey, Signature};
+use dusk_bls12_381::BlsScalar;
+use dusk_bls12_381_sign::PublicKey;
 use dusk_pki::{PublicSpendKey, ViewKey};
 use dusk_plonk::prelude::*;
 use dusk_poseidon::tree::PoseidonBranch;
+use dusk_schnorr::Signature;
 use dusk_wallet_core::{
     ProverClient as WalletProverClient, StateClient, Store,
     UnprovenTransaction, Wallet, POSEIDON_TREE_DEPTH,
 };
+use parking_lot::Mutex;
 use phoenix_core::{Crossover, Fee};
 use phoenix_core::{Note, NoteType};
 use rand::{CryptoRng, RngCore};
@@ -23,8 +26,6 @@ use tokio::runtime::Handle;
 use tokio::task::block_in_place;
 use tonic::transport::Channel;
 use tonic::transport::Server;
-
-use parking_lot::Mutex;
 /// Create a new wallet meant for tests. It includes a client that will always
 /// return a random anchor (same every time), and the default opening.
 ///

--- a/rusk/tests/services/state_service.rs
+++ b/rusk/tests/services/state_service.rs
@@ -93,7 +93,7 @@ fn generate_note(rusk: &mut Rusk) -> Result<Option<Note>> {
 
     let psk = SSK.public_spend_key();
 
-    let initial_balance = 1_000_000_000; // 1 DUSK
+    let initial_balance = 1_000_000_000;
 
     let note = Note::transparent(&mut rng, &psk, initial_balance);
 

--- a/rusk/tests/services/transactions.rs
+++ b/rusk/tests/services/transactions.rs
@@ -262,7 +262,7 @@ impl wallet::ProverClient for TestProverClient {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-pub async fn whatever() -> Result<()> {
+pub async fn wallet_grpc() -> Result<()> {
     let rusk = STATE_LOCK.lock();
 
     let (channel, incoming) = setup().await;

--- a/rusk/tests/services/transactions.rs
+++ b/rusk/tests/services/transactions.rs
@@ -1,0 +1,312 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::common::*;
+use canonical::{Canon, Source};
+use dusk_bls12_381_sign::PublicKey;
+use dusk_pki::{Ownable, SecretSpendKey, ViewKey};
+use dusk_schnorr::{PublicKeyPair, Signature};
+use parking_lot::Mutex;
+use rusk::services::prover::ExecuteProverRequest;
+use rusk::services::rusk_proto::prover_client::ProverClient;
+use rusk::services::rusk_proto::state_client::StateClient;
+use rusk::services::rusk_proto::Transaction as TransactionProto;
+use rusk::services::state::{
+    GetAnchorRequest, GetNotesOwnedByRequest, GetOpeningRequest,
+    PreverifyRequest,
+};
+
+use dusk_bytes::{DeserializableSlice, Serializable};
+
+use once_cell::sync::Lazy;
+use rand::prelude::*;
+use rand::rngs::StdRng;
+use rusk::error::Error;
+use rusk::{Result, Rusk};
+
+use microkelvin::{BackendCtor, DiskBackend};
+
+use tracing::info;
+
+use tonic::transport::Server;
+
+use rusk::services::pki::{KeysServer, RuskKeys};
+use rusk::services::prover::{ProverServer, RuskProver};
+use rusk::services::state::StateServer;
+
+use dusk_wallet_core::{
+    self as wallet, Store, Transaction, UnprovenTransaction,
+};
+
+use phoenix_core::{Crossover, Fee, Note};
+
+use dusk_bls12_381::BlsScalar;
+use dusk_jubjub::{JubJubAffine, JubJubScalar};
+use dusk_plonk::proof_system::Proof;
+
+use dusk_poseidon::tree::PoseidonBranch;
+use rusk_abi::POSEIDON_TREE_DEPTH;
+
+pub fn testbackend() -> BackendCtor<DiskBackend> {
+    BackendCtor::new(DiskBackend::ephemeral)
+}
+
+static STATE_LOCK: Lazy<Mutex<Rusk>> = Lazy::new(|| {
+    let state_id = rusk_recovery_tools::state::deploy(&testbackend())
+        .expect("Failed to deploy state");
+
+    let mut rusk = Rusk::builder(testbackend)
+        .id(state_id)
+        .build()
+        .expect("Error creating Rusk Instance");
+
+    generate_note(&mut rusk).expect("Failed to generate note");
+
+    Mutex::new(rusk)
+});
+
+const BLOCK_HEIGHT: u64 = 1;
+
+pub static SSK: Lazy<SecretSpendKey> = Lazy::new(|| {
+    info!("Generating SecretSpendKey");
+    TestStore.retrieve_ssk(0).expect("Should not fail in test")
+});
+
+fn generate_note(rusk: &mut Rusk) -> Result<()> {
+    info!("Generating a note");
+    let mut rng = StdRng::seed_from_u64(0xdead);
+
+    let psk = SSK.public_spend_key();
+
+    let initial_balance = 1_000_000_000_000;
+
+    let note = Note::transparent(&mut rng, &psk, initial_balance);
+
+    let mut rusk_state = rusk.state()?;
+    let mut transfer = rusk_state.transfer_contract()?;
+
+    transfer.push_note(BLOCK_HEIGHT, note)?;
+    transfer.update_root()?;
+
+    info!("Updating the new transfer contract state");
+    unsafe {
+        rusk_state
+            .set_contract_state(&rusk_abi::transfer_contract(), &transfer)?;
+    }
+    rusk.persist(&mut rusk_state)?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct TestStore;
+
+impl wallet::Store for TestStore {
+    type Error = ();
+
+    fn get_seed(&self) -> Result<[u8; 64], Self::Error> {
+        Ok([0; 64])
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TestStateClient {
+    channel: tonic::transport::Channel,
+}
+
+impl wallet::StateClient for TestStateClient {
+    type Error = Error;
+
+    /// Find notes for a view key, starting from the given block height.
+    fn fetch_notes(
+        &self,
+        height: u64,
+        vk: &ViewKey,
+    ) -> Result<Vec<Note>, Self::Error> {
+        let mut client = StateClient::new(self.channel.clone());
+
+        let request = tonic::Request::new(GetNotesOwnedByRequest {
+            height,
+            vk: vk.to_bytes().to_vec(),
+        });
+
+        let response = client.get_notes_owned_by(request).wait()?;
+
+        response
+            .into_inner()
+            .notes
+            .iter()
+            .map(|n| Note::from_slice(&n).map_err(Error::Serialization))
+            .collect()
+    }
+
+    /// Fetch the current anchor of the state.
+    fn fetch_anchor(&self) -> Result<BlsScalar, Self::Error> {
+        let mut client = StateClient::new(self.channel.clone());
+
+        let request = tonic::Request::new(GetAnchorRequest {});
+
+        let response = client.get_anchor(request).wait()?;
+
+        BlsScalar::from_slice(&response.into_inner().anchor)
+            .map_err(Error::Serialization)
+    }
+
+    /// Queries the node to find the opening for a specific note.
+    fn fetch_opening(
+        &self,
+        note: &Note,
+    ) -> Result<PoseidonBranch<POSEIDON_TREE_DEPTH>, Self::Error> {
+        let mut client = StateClient::new(self.channel.clone());
+
+        let request = tonic::Request::new(GetOpeningRequest {
+            note: note.to_bytes().to_vec(),
+        });
+
+        let response = client.get_opening(request).wait()?;
+        let response = response.into_inner();
+
+        let mut source = Source::new(&response.branch);
+        Ok(PoseidonBranch::decode(&mut source)?)
+    }
+
+    /// Queries the node the amount staked by a key and its expiration.
+    fn fetch_stake(&self, _pk: &PublicKey) -> Result<(u64, u64), Self::Error> {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TestProverClient {
+    channel: tonic::transport::Channel,
+}
+
+impl wallet::ProverClient for TestProverClient {
+    type Error = Error;
+    /// Requests that a node prove the given transaction and later propagates it
+    fn compute_proof_and_propagate(
+        &self,
+        utx: &UnprovenTransaction,
+    ) -> Result<(), Self::Error> {
+        let mut client = ProverClient::new(self.channel.clone());
+
+        let request = tonic::Request::new(ExecuteProverRequest {
+            utx: utx.to_var_bytes(),
+        });
+
+        let note = utx.inputs()[0].note();
+        let sk_r = SSK.sk_r(note.stealth_address());
+        let pkp: PublicKeyPair = sk_r.into();
+
+        if !utx.inputs()[0].signature().verify(&pkp, utx.hash()) {
+            panic!("Schnorr failed");
+        }
+
+        let response = client.prove_execute(request).wait()?;
+
+        let response = response.into_inner();
+
+        let tx_bytes = response.tx;
+        let tx =
+            Transaction::from_slice(&tx_bytes).map_err(Error::Serialization)?;
+        let tx_hash = tx.hash();
+
+        let tx = Some(TransactionProto {
+            version: 1,
+            r#type: 1,
+            payload: tx_bytes,
+        });
+
+        let request = tonic::Request::new(PreverifyRequest { tx });
+
+        let mut client = StateClient::new(self.channel.clone());
+
+        let response = client.preverify(request).wait()?;
+
+        let response = response.into_inner();
+
+        assert_eq!(
+            response.tx_hash,
+            tx_hash.to_bytes().to_vec(),
+            "Hash mismatch"
+        );
+
+        Ok(())
+    }
+
+    /// Requests an STCT proof.
+    fn request_stct_proof(
+        &self,
+        _fee: &Fee,
+        _crossover: &Crossover,
+        _value: u64,
+        _blinder: JubJubScalar,
+        _address: BlsScalar,
+        _signature: Signature,
+    ) -> Result<Proof, Self::Error> {
+        unimplemented!();
+    }
+
+    /// Request a WFCT proof.
+    fn request_wfct_proof(
+        &self,
+        _commitment: JubJubAffine,
+        _value: u64,
+        _blinder: JubJubScalar,
+    ) -> Result<Proof, Self::Error> {
+        unimplemented!();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn whatever() -> Result<()> {
+    let rusk = STATE_LOCK.lock();
+
+    let (channel, incoming) = setup().await;
+
+    let keys = KeysServer::new(RuskKeys::default());
+    let state = StateServer::new(rusk.clone());
+    let prover = ProverServer::new(RuskProver::default());
+
+    drop(rusk);
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(keys)
+            .add_service(state)
+            .add_service(prover)
+            .serve_with_incoming(incoming)
+            .await
+    });
+
+    let wallet = wallet::Wallet::new(
+        TestStore,
+        TestStateClient {
+            channel: channel.clone(),
+        },
+        TestProverClient { channel },
+    );
+
+    let psk = SSK.public_spend_key();
+    let receiver = wallet
+        .public_spend_key(1)
+        .expect("Failed to get public spend key");
+
+    let mut rng = StdRng::seed_from_u64(0xdead);
+    let nonce = BlsScalar::random(&mut rng);
+
+    println!("Balance before key 0: {:?}", wallet.get_balance(0));
+    println!("Balance before key 1: {:?}", wallet.get_balance(1));
+
+    wallet
+        .transfer(&mut rng, 0, &psk, &receiver, 1_000, 1_000_000_000, 1, nonce)
+        .expect("Failed to transfer");
+
+    println!("Balance after key 0: {:?}", wallet.get_balance(0));
+    println!("Balance after key 1: {:?}", wallet.get_balance(1));
+
+    Ok(())
+}

--- a/schema/transaction.proto
+++ b/schema/transaction.proto
@@ -36,18 +36,5 @@ message Transaction {
 
 message ExecutedTransaction {
     Transaction tx = 1;
-    bytes tx_hash = 3;
-}
-
-message TransactionRequest {
-    bytes contract_address = 1;
-    uint32 op_code = 2;
-    bytes arguments = 3;
-    Fee fee = 4;
-}
-
-service TransactionService {
-    // A generic method to create a transaction which requires
-    // no special fields (no crossover, outputs, or specific proofs).
-    rpc NewTransaction(TransactionRequest) returns (Transaction) {}
+    bytes tx_hash = 2;
 }


### PR DESCRIPTION
- rusk: Fix typo on check the number of coinbase txs
- transfer-contract: canonicalize Note in `mint`
- rusk: Add `transactions` tests to cover all our gRPC services (but kadkast)
    - Add `Block` trait with `Future` auto trait in `tests/common`

      This simplify the code in our tests when we're deailing with async
      code.

- rusk: Fix issues in `RuskProver`
    - Update the code to be compatible with `dusk-wallet-core 0.8`
    - Remove cache for `ProverKey` in `RuskProver`
    - Change the circuit in `RuskProver` to be instantiated as  `ExecuteCircuit::default()`
    - Change the `set_fee` in `RuskProver` to be called only if there is no
      `Crossover`.

- rusk: Update `dusk-wallet-core` from `0.6` to `0.8.0-rc`

-  Remove unused message and service for transaction
- Fix a typo for `tx_hash` in `ExecutedTransaction`
- rusk-abi: Add `TRANSCRIPT_LABEL` to verify
- transfer-contract: Remove unused `dusk_abi::ContractId`

See Also: #466

Co-authored-by: Eduardo Leegwater Simões <eduardo@dusk.network>