### PR TITLE
wallet: Add `Export` command 

### DIFF
--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -6,9 +6,12 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.0", features = ["derive"] }
 tokio = { version = "1.15", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 block-modes = "0.8"
 tiny-bip39 = "0.8"
 requestty = "0.3"
+base64 = "0.13"
 crypto = "0.3"
 whoami = "1.2"
 blake3 = "1.3"

--- a/rusk-wallet/src/lib/error.rs
+++ b/rusk-wallet/src/lib/error.rs
@@ -34,6 +34,8 @@ pub enum Error {
     Canon(canonical::CanonError),
     /// Filesystem errors
     IO(io::Error),
+    /// JSON serialization errors
+    JSON(serde_json::Error),
     /// Wallet Core lib errors
     WalletCore(Box<CoreError>),
     /// User graceful exit
@@ -94,6 +96,12 @@ impl From<block_modes::BlockModeError> for Error {
     }
 }
 
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        Self::JSON(e)
+    }
+}
+
 impl std::error::Error for Error {}
 
 impl fmt::Display for Error {
@@ -135,6 +143,9 @@ impl fmt::Display for Error {
             }
             Error::IO(err) => {
                 write!(f, "Filesystem errors: {}", err)
+            }
+            Error::JSON(err) => {
+                write!(f, "JSON serialization error: {}", err)
             }
             Error::WalletCore(err) => {
                 write!(f, "Wallet Core lib errors: {:?}", err)
@@ -185,6 +196,9 @@ impl fmt::Debug for Error {
             }
             Error::IO(err) => {
                 write!(f, "Filesystem errors: {}", err)
+            }
+            Error::JSON(err) => {
+                write!(f, "JSON serialization error: {}", err)
             }
             Error::WalletCore(err) => {
                 write!(f, "Wallet Core lib errors: {:?}", err)

--- a/rusk-wallet/src/lib/mod.rs
+++ b/rusk-wallet/src/lib/mod.rs
@@ -10,3 +10,5 @@ pub mod error;
 pub mod prompt;
 pub mod store;
 pub mod wallet;
+
+pub const SEED_SIZE: usize = 64;

--- a/rusk-wallet/src/lib/prompt.rs
+++ b/rusk-wallet/src/lib/prompt.rs
@@ -12,9 +12,9 @@ use requestty::Question;
 use crate::CliCommand;
 
 /// Request the user to authenticate with a password
-pub(crate) fn request_auth() -> Hash {
+pub(crate) fn request_auth(msg: &str) -> Hash {
     let q = Question::password("password")
-        .message("Please enter your wallet's password:")
+        .message(format!("{}:", msg))
         .mask('*')
         .build();
     let a = requestty::prompt_one(q).unwrap();
@@ -79,6 +79,16 @@ pub(crate) fn confirm_recovery_phrase(phrase: String) {
     }
 }
 
+/// Confirm if file must be encrypted
+pub(crate) fn confirm_encryption() -> bool {
+    // let the user confirm if they want the file encrypted
+    let q = requestty::Question::confirm("encrypt")
+        .message("Encrypt the exported key pair file?")
+        .build();
+    let a = requestty::prompt_one(q).unwrap();
+    a.as_bool().unwrap()
+}
+
 /// Request the user to input the recovery phrase
 pub(crate) fn request_recovery_phrase() -> String {
     // let the user input the recovery phrase
@@ -138,6 +148,7 @@ pub(crate) fn command() -> Option<CliCommand> {
             "Stake Dusk",
             "Extend stake for a particular key",
             "Withdraw a key's stake",
+            "Export provisioner BLS key pair",
         ])
         .default_separator()
         .choice("Exit")
@@ -188,7 +199,7 @@ pub(crate) fn command() -> Option<CliCommand> {
             })
         }
         // Extend stake
-        5 => {
+        4 => {
             let key = request_key_index("spend");
             let stake_key = request_key_index("stake");
             let gas_limit = request_gas_limit();
@@ -201,7 +212,7 @@ pub(crate) fn command() -> Option<CliCommand> {
             })
         }
         // Withdraw stake
-        6 => {
+        5 => {
             let key = request_key_index("spend");
             let stake_key = request_key_index("stake");
             let gas_limit = request_gas_limit();
@@ -211,6 +222,16 @@ pub(crate) fn command() -> Option<CliCommand> {
                 stake_key,
                 gas_limit,
                 gas_price,
+            })
+        }
+        // Export BLS Key Pair
+        6 => {
+            let key = request_key_index("stake");
+            let encrypt = confirm_encryption();
+            //let pwd = prompt::request_auth();
+            Some(Export {
+                key,
+                plaintext: !encrypt,
             })
         }
         _ => None,

--- a/rusk-wallet/src/lib/store.rs
+++ b/rusk-wallet/src/lib/store.rs
@@ -10,27 +10,31 @@ use std::{fmt, fs};
 use blake3::Hash;
 use dusk_wallet_core::Store;
 
-use crate::lib::crypto::EncryptedSeed;
+use crate::lib::crypto::{decrypt, encrypt};
+use crate::lib::SEED_SIZE;
 use crate::Error;
 
 /// Stores all the user's settings and keystore in the file system
 pub struct LocalStore {
     path: PathBuf,
-    seed: [u8; 64],
+    seed: [u8; SEED_SIZE],
 }
 
 impl Store for LocalStore {
     type Error = Error;
 
     /// Retrieves the seed used to derive keys.
-    fn get_seed(&self) -> Result<[u8; 64], Self::Error> {
+    fn get_seed(&self) -> Result<[u8; SEED_SIZE], Self::Error> {
         Ok(self.seed)
     }
 }
 
 impl LocalStore {
     /// Creates a new store
-    pub fn new(path: PathBuf, seed: [u8; 64]) -> Result<LocalStore, Error> {
+    pub fn new(
+        path: PathBuf,
+        seed: [u8; SEED_SIZE],
+    ) -> Result<LocalStore, Error> {
         // create the local store
         let store = LocalStore { path, seed };
 
@@ -46,14 +50,14 @@ impl LocalStore {
 
         // attempt to load and decode wallet
         let bytes = fs::read(&path)?;
-        if bytes.len() != EncryptedSeed::SIZE {
+        let bytes = decrypt(&bytes, pwd)?;
+
+        if bytes.len() != SEED_SIZE {
             return Err(Error::WalletFileCorrupted);
         }
-        let mut seed_bytes = [0u8; EncryptedSeed::SIZE];
-        seed_bytes.copy_from_slice(&bytes);
 
-        let seed = EncryptedSeed::from_bytes(&seed_bytes);
-        let seed = seed.decrypt(pwd)?;
+        let mut seed = [0u8; SEED_SIZE];
+        seed.copy_from_slice(&bytes);
 
         // create and return
         Ok(LocalStore { path, seed })
@@ -62,11 +66,10 @@ impl LocalStore {
     /// Saves wallet to a file
     pub fn save(&self, pwd: Hash) -> Result<(), Error> {
         // encrypt seed
-        let mut seed = EncryptedSeed::from_seed(self.seed);
-        seed.encrypt(pwd)?;
+        let enc_seed = encrypt(&self.seed, pwd)?;
 
         // write file
-        fs::write(&self.path, &seed.to_bytes())?;
+        fs::write(&self.path, enc_seed)?;
         Ok(())
     }
 }

--- a/rusk-wallet/src/lib/store.rs
+++ b/rusk-wallet/src/lib/store.rs
@@ -15,6 +15,7 @@ use crate::lib::SEED_SIZE;
 use crate::Error;
 
 /// Stores all the user's settings and keystore in the file system
+#[derive(Clone)]
 pub struct LocalStore {
     path: PathBuf,
     seed: [u8; SEED_SIZE],

--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -12,8 +12,8 @@ use dusk_jubjub::BlsScalar;
 use dusk_wallet_core::Wallet;
 
 use crate::lib::clients::{Prover, State};
-use crate::lib::prompt;
 use crate::lib::store::LocalStore;
+use crate::lib::{prompt, SEED_SIZE};
 use crate::{CliCommand, Error};
 
 /// Interface to wallet_core lib
@@ -70,7 +70,7 @@ impl CliWallet {
                 gas_limit,
                 gas_price,
             } => {
-                let mut addr_bytes = [0u8; 64];
+                let mut addr_bytes = [0u8; SEED_SIZE];
                 addr_bytes.copy_from_slice(&bs58::decode(rcvr).into_vec()?);
                 let dest_addr =
                     dusk_pki::PublicSpendKey::from_bytes(&addr_bytes)?;

--- a/rusk-wallet/src/main.rs
+++ b/rusk-wallet/src/main.rs
@@ -173,6 +173,17 @@ enum CliCommand {
         gas_price: Option<u64>,
     },
 
+    /// Export BLS provisioner key pair
+    Export {
+        /// Key index from which your Dusk was staked
+        #[clap(short, long)]
+        key: u64,
+
+        /// Don't encrypt the output file
+        #[clap(long)]
+        plaintext: bool,
+    },
+
     /// Run in interactive mode (default)
     Interactive,
 }
@@ -234,7 +245,7 @@ async fn main() -> Result<(), Error> {
 
     // request auth for wallet (if required)
     let pwd = if cmd.uses_wallet() {
-        prompt::request_auth()
+        prompt::request_auth("Please enter your wallet's password")
     } else {
         blake3::hash("".as_bytes())
     };
@@ -330,7 +341,7 @@ fn interactive(path: PathBuf) -> Result<LocalStore, Error> {
     // let the user choose one
     if !wallets.is_empty() {
         let path = prompt::select_wallet(&dir, wallets);
-        let pwd = prompt::request_auth();
+        let pwd = prompt::request_auth("Please enter your wallet's password");
         let store = LocalStore::from_file(path, pwd)?;
         Ok(store)
     }


### PR DESCRIPTION
Introduce `Export` command to export BLS key-pair into a file.

Refactored `crypto` module to allow for variable sized data encryption. 