### PR TITLE
wallet: Add "headless" mode and fix Export in multi-wallet scenarios

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.1.2] - 2022-01-31
+
+### Added
+- Enable headless mode [#495]
 - Introduce interactive mode by default [#492]
+- Add Export command for BLS PubKeys [#505]
 
 ## [0.1.1] - 2022-01-27
 
@@ -34,3 +40,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#482]: https://github.com/dusk-network/rusk/issues/482
 [#479]: https://github.com/dusk-network/rusk/issues/479
 [#492]: https://github.com/dusk-network/rusk/issues/492
+[#495]: https://github.com/dusk-network/rusk/issues/495
+[#505]: https://github.com/dusk-network/rusk/issues/505

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/rusk-wallet/src/lib/store.rs
+++ b/rusk-wallet/src/lib/store.rs
@@ -73,6 +73,15 @@ impl LocalStore {
         fs::write(&self.path, enc_seed)?;
         Ok(())
     }
+
+    /// Returns the filename of this store
+    pub fn name(&self) -> Option<String> {
+        // extract the name
+        let p = &self.path;
+        let name = p.file_stem()?.to_str()?;
+
+        Some(String::from(name))
+    }
 }
 
 impl fmt::Debug for LocalStore {

--- a/rusk-wallet/src/main.rs
+++ b/rusk-wallet/src/main.rs
@@ -36,7 +36,7 @@ pub(crate) const DATA_DIR: &str = ".dusk";
 #[derive(Parser)]
 #[clap(name = "Dusk Wallet CLI")]
 #[clap(author = "Dusk Network B.V.")]
-#[clap(version = "0.1.1")]
+#[clap(version = "0.1.2")]
 #[clap(about = "Easily manage your Dusk", long_about = None)]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 //#[clap(global_setting(AppSettings::SubcommandRequiredElseHelp))]
@@ -239,7 +239,7 @@ async fn main() -> Result<(), Error> {
         let mut pb = PathBuf::new();
         pb.push(cfg.data_dir);
         pb.push(cfg.wallet_name);
-        pb = pb.with_extension("dat");
+        pb.set_extension("dat");
         pb
     };
 


### PR DESCRIPTION
Wallet password is optionally retrieved from environment variable `RUSK_WALLET_PWD`.

When this env var is set, the CLI will not ask for interactive user authentication when performing operations that require it.

Added wallet name to the exported key file as well. In multi-wallet scenarios, exported keys were overwritten without this.

Changed to using `serde` for file encoding as suggested by @herr-seppia 

Bumped to `0.1.2`

Resolves: #495 