### PR TITLE
Achieve reproducible build for contracts 

### DIFF
--- a/contracts/stake/Makefile
+++ b/contracts/stake/Makefile
@@ -14,7 +14,8 @@ utils: ## Build the WASM files of the test utils
 	$(MAKE) -C ../../ $@
 
 wasm: ## Build the WASM files
-	@cargo rustc \
+	@RUSTFLAGS="$(RUSTFLAGS) --remap-path-prefix $(HOME)=" \
+		cargo rustc \
 		--release \
 		--target wasm32-unknown-unknown \
 		-- -C link-args=-s

--- a/contracts/transfer/Makefile
+++ b/contracts/transfer/Makefile
@@ -14,7 +14,8 @@ utils: ## Build the WASM files of the test utils
 	$(MAKE) -C ../../ $@
 
 wasm: ## Build the WASM files
-	@cargo rustc \
+	@RUSTFLAGS="$(RUSTFLAGS) --remap-path-prefix $(HOME)=" \
+		cargo rustc \
 		--release \
 		--target wasm32-unknown-unknown \
 		-- -C link-args=-s


### PR DESCRIPTION
This ensures reproducible builds of the genesis contracts by:

- Including a `Cargo.toml` in the repository, ensuring a tracking of dependencies.
- Setting `--remap-path-prefix` to strip system path info from binaries,
  in both a local build using `source .env`, and the CI environment.
- Failing the CI if the contract bytecode doesn't equal the included
  `wasm.sum` file. This ensures changes of bytecode are tracked.

Resolves: #509