### PR TITLE
wallet: Add offline mode and improve overall UX

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -11,9 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Offline mode [#499] [#507]
+- Live validation to user interactive input
+- Improved navigation through interactive menus
+- "Pause" after command outputs for better readability
 
-### Changed
-- Notable UX improvements
+### Fixed
+- Bad UX when creating an already existing wallet with default name
 
 ## [0.1.2] - 2022-01-31
 

--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.3] - 2022-02-01
+
+### Added
+- Offline mode [#499] [#507]
+
+### Changed
+- Notable UX improvements
+
 ## [0.1.2] - 2022-01-31
 
 ### Added
@@ -41,4 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#479]: https://github.com/dusk-network/rusk/issues/479
 [#492]: https://github.com/dusk-network/rusk/issues/492
 [#495]: https://github.com/dusk-network/rusk/issues/495
+[#499]: https://github.com/dusk-network/rusk/issues/499
 [#505]: https://github.com/dusk-network/rusk/issues/505
+[#507]: https://github.com/dusk-network/rusk/issues/507

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]

--- a/rusk-wallet/src/lib/crypto.rs
+++ b/rusk-wallet/src/lib/crypto.rs
@@ -63,6 +63,12 @@ impl MnemSeed {
             Err(_) => Err(Error::InvalidMnemonicPhrase),
         }
     }
+
+    /// Returns true if a given mnemonic phrase is valid
+    pub fn is_valid(phrase: &str) -> bool {
+        Mnemonic::from_phrase(phrase, Language::English).is_ok()
+    }
+
 }
 
 /// Encrypts data using a password.

--- a/rusk-wallet/src/lib/crypto.rs
+++ b/rusk-wallet/src/lib/crypto.rs
@@ -68,7 +68,6 @@ impl MnemSeed {
     pub fn is_valid(phrase: &str) -> bool {
         Mnemonic::from_phrase(phrase, Language::English).is_ok()
     }
-
 }
 
 /// Encrypts data using a password.

--- a/rusk-wallet/src/lib/error.rs
+++ b/rusk-wallet/src/lib/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     Network(tonic::transport::Error),
     /// Connection error with rusk
     Connection(tonic::Status),
+    /// Command not available in offline mode
+    Offline,
     /// Wrong wallet password
     InvalidPassword,
     /// Bytes encoding errors
@@ -129,6 +131,9 @@ impl fmt::Display for Error {
             Error::Connection(err) => {
                 write!(f, "Connection error with rusk: {}", err)
             }
+            Error::Offline => {
+                write!(f, "Command not available in offline mode")
+            }
             Error::InvalidPassword => {
                 write!(f, "Wrong wallet password")
             }
@@ -181,6 +186,9 @@ impl fmt::Debug for Error {
             }
             Error::Connection(err) => {
                 write!(f, "Connection error with rusk: {}", err)
+            }
+            Error::Offline => {
+                write!(f, "Command not available in offline mode")
             }
             Error::InvalidPassword => {
                 write!(f, "Wrong wallet password")

--- a/rusk-wallet/src/lib/mod.rs
+++ b/rusk-wallet/src/lib/mod.rs
@@ -12,3 +12,15 @@ pub mod store;
 pub mod wallet;
 
 pub const SEED_SIZE: usize = 64;
+pub const ONE_MILLION: f64 = 1_000_000.0;
+
+/// Convert from Dusk to uDusk
+pub fn to_udusk(dusk: f64) -> u64 {
+    (dusk * ONE_MILLION) as u64
+}
+
+/// Convert from uDusk to Dusk
+pub fn to_dusk(udusk: u64) -> f64 {
+    let udusk = udusk as f64;
+    udusk / ONE_MILLION
+}

--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::fs;
+use std::{fs, thread, time::Duration};
 
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -41,23 +41,39 @@ struct BlsKeyPair {
 /// Interface to wallet_core lib
 pub(crate) struct CliWallet {
     store: LocalStore,
-    wallet: Wallet<LocalStore, State, Prover>,
+    wallet: Option<Wallet<LocalStore, State, Prover>>,
 }
 
 impl CliWallet {
+
     /// Creates a new CliWallet instance
     pub fn new(store: LocalStore, state: State, prover: Prover) -> Self {
         CliWallet {
             store: store.clone(),
-            wallet: Wallet::new(store, state, prover),
+            wallet: Some(Wallet::new(store, state, prover)),
+        }
+    }
+
+    /// Creates a new offline CliWallet instance
+    pub fn offline(store: LocalStore) -> Self {
+        CliWallet {
+            store: store.clone(),
+            wallet: None,
         }
     }
 
     /// Runs the CliWallet in interactive mode
     pub fn interactive(&self) -> Result<(), Error> {
+        let offline = !self.wallet.is_some();
         loop {
-            match prompt::command() {
-                Some(cmd) => self.run(cmd)?,
+            match prompt::command(offline) {
+                Some(cmd) => {
+                    // run command
+                    self.run(cmd)?;
+                    // wait for a second
+                    thread::sleep(Duration::from_millis(1000));
+                    println!("—")
+                }
                 None => return Ok(()),
             }
         }
@@ -70,20 +86,31 @@ impl CliWallet {
         match cmd {
             // Check your current balance
             Balance { key } => {
-                let balance = self.wallet.get_balance(key)?;
-                println!(
-                    "Balance for key {} is: {} Dusk ✅",
-                    key,
-                    balance / 1_000_000
-                );
+                if let Some(wallet) = &self.wallet {
+                    let balance = wallet.get_balance(key)?;
+                    println!(
+                        "> Balance for key {} is: {} Dusk",
+                        key,
+                        balance / 1_000_000
+                    );
+                    Ok(())
+                } else {
+                    Err(Error::Offline)
+                }
             }
 
             // Retrieve public spend key
             Address { key } => {
-                let pk = self.wallet.public_spend_key(key)?;
+                let pk = if let Some(wallet) = &self.wallet {
+                    wallet.public_spend_key(key)?
+                } else {
+                    let ssk = self.store.retrieve_ssk(key)?;
+                    ssk.public_spend_key()
+                };
                 let addr = pk.to_bytes();
                 let addr = bs58::encode(addr).into_string();
-                println!("Public address for key {} is: {:?} ✅", key, addr);
+                println!("> Public address for key {} is: {}", key, addr);
+                Ok(())
             }
 
             // Send Dusk through the network
@@ -94,23 +121,28 @@ impl CliWallet {
                 gas_limit,
                 gas_price,
             } => {
-                let mut addr_bytes = [0u8; SEED_SIZE];
-                addr_bytes.copy_from_slice(&bs58::decode(rcvr).into_vec()?);
-                let dest_addr =
-                    dusk_pki::PublicSpendKey::from_bytes(&addr_bytes)?;
-                let my_addr = self.wallet.public_spend_key(key)?;
-                let mut rng = StdRng::from_entropy();
-                self.wallet.transfer(
-                    &mut rng,
-                    key,
-                    &my_addr,
-                    &dest_addr,
-                    amt,
-                    gas_limit,
-                    gas_price.unwrap_or(0),
-                    BlsScalar::zero(),
-                )?;
-                println!("Transfer sent! ✅");
+                if let Some(wallet) = &self.wallet {
+                    let mut addr_bytes = [0u8; SEED_SIZE];
+                    addr_bytes.copy_from_slice(&bs58::decode(rcvr).into_vec()?);
+                    let dest_addr =
+                        dusk_pki::PublicSpendKey::from_bytes(&addr_bytes)?;
+                    let my_addr = wallet.public_spend_key(key)?;
+                    let mut rng = StdRng::from_entropy();
+                    wallet.transfer(
+                        &mut rng,
+                        key,
+                        &my_addr,
+                        &dest_addr,
+                        amt,
+                        gas_limit,
+                        gas_price.unwrap_or(0),
+                        BlsScalar::zero(),
+                    )?;
+                    println!("> Transfer sent!");
+                    Ok(())
+                } else {
+                    Err(Error::Offline)
+                }
             }
 
             // Start staking Dusk
@@ -121,18 +153,23 @@ impl CliWallet {
                 gas_limit,
                 gas_price,
             } => {
-                let my_addr = self.wallet.public_spend_key(key)?;
-                let mut rng = StdRng::from_entropy();
-                self.wallet.stake(
-                    &mut rng,
-                    key,
-                    stake_key,
-                    &my_addr,
-                    amt,
-                    gas_limit,
-                    gas_price.unwrap_or(0),
-                )?;
-                println!("Stake success! ✅");
+                if let Some(wallet) = &self.wallet {
+                    let my_addr = wallet.public_spend_key(key)?;
+                    let mut rng = StdRng::from_entropy();
+                    wallet.stake(
+                        &mut rng,
+                        key,
+                        stake_key,
+                        &my_addr,
+                        amt,
+                        gas_limit,
+                        gas_price.unwrap_or(0),
+                    )?;
+                    println!("> Stake success!");
+                    Ok(())
+                } else {
+                    Err(Error::Offline)
+                }
             }
 
             // Extend stake for a particular key
@@ -142,17 +179,22 @@ impl CliWallet {
                 gas_limit,
                 gas_price,
             } => {
-                let my_addr = self.wallet.public_spend_key(key)?;
-                let mut rng = StdRng::from_entropy();
-                self.wallet.extend_stake(
-                    &mut rng,
-                    key,
-                    stake_key,
-                    &my_addr,
-                    gas_limit,
-                    gas_price.unwrap_or(0),
-                )?;
-                println!("Stake extension success! ✅");
+                if let Some(wallet) = &self.wallet {
+                    let my_addr = wallet.public_spend_key(key)?;
+                    let mut rng = StdRng::from_entropy();
+                    wallet.extend_stake(
+                        &mut rng,
+                        key,
+                        stake_key,
+                        &my_addr,
+                        gas_limit,
+                        gas_price.unwrap_or(0),
+                    )?;
+                    println!("> Stake extension success!");
+                    Ok(())
+                } else {
+                    Err(Error::Offline)
+                }
             }
 
             // Withdraw a key's stake
@@ -162,23 +204,32 @@ impl CliWallet {
                 gas_limit,
                 gas_price,
             } => {
-                let my_addr = self.wallet.public_spend_key(key)?;
-                let mut rng = StdRng::from_entropy();
-                self.wallet.withdraw_stake(
-                    &mut rng,
-                    key,
-                    stake_key,
-                    &my_addr,
-                    gas_limit,
-                    gas_price.unwrap_or(0),
-                )?;
-                println!("Stake withdrawal success! ✅");
+                if let Some(wallet) = &self.wallet {
+                    let my_addr = wallet.public_spend_key(key)?;
+                    let mut rng = StdRng::from_entropy();
+                    wallet.withdraw_stake(
+                        &mut rng,
+                        key,
+                        stake_key,
+                        &my_addr,
+                        gas_limit,
+                        gas_price.unwrap_or(0),
+                    )?;
+                    println!("> Stake withdrawal success!");
+                    Ok(())
+                } else {
+                    Err(Error::Offline)
+                }
             }
 
             Export { key, plaintext } => {
                 // retrieve keys
                 let sk = self.store.retrieve_sk(key)?;
-                let pk = self.wallet.public_key(key)?;
+                let pk = if let Some(wallet) = &self.wallet {
+                    wallet.public_key(key)?
+                } else {
+                    From::from(&sk)
+                };
 
                 // create node-compatible json structure
                 let bls = BlsKeyPair {
@@ -194,12 +245,13 @@ impl CliWallet {
                     bytes = encrypt(&bytes, pwd)?;
                 }
 
-                // write to disk
+                // add wallet name to file
                 let filename = match self.store.name() {
                     Some(name) => format!("{}-{}", name, key),
                     None => key.to_string(),
                 };
 
+                // write to disk
                 let mut path = dirs::home_dir().expect("user home dir");
                 path.push(&filename);
                 path.set_extension("key");
@@ -207,15 +259,14 @@ impl CliWallet {
                 fs::write(&path, bytes)?;
 
                 println!(
-                    "Key pair exported to {} ✅",
+                    "> Key pair exported to {}",
                     path.as_os_str().to_str().unwrap()
-                )
+                );
+                Ok(())
             }
 
             // Do nothing
-            _ => {}
+            _ => Ok(())
         }
-
-        Ok(())
     }
 }

--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -171,7 +171,7 @@ impl CliWallet {
                     Err(Error::Offline)
                 }
             }
-
+/*
             // Extend stake for a particular key
             ExtendStake {
                 key,
@@ -196,7 +196,7 @@ impl CliWallet {
                     Err(Error::Offline)
                 }
             }
-
+*/
             // Withdraw a key's stake
             WithdrawStake {
                 key,

--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -17,6 +17,7 @@ use dusk_wallet_core::{Store, Wallet};
 use crate::lib::clients::{Prover, State};
 use crate::lib::crypto::encrypt;
 use crate::lib::store::LocalStore;
+use crate::lib::to_dusk;
 use crate::lib::{prompt, SEED_SIZE};
 use crate::{CliCommand, Error};
 
@@ -45,7 +46,6 @@ pub(crate) struct CliWallet {
 }
 
 impl CliWallet {
-
     /// Creates a new CliWallet instance
     pub fn new(store: LocalStore, state: State, prover: Prover) -> Self {
         CliWallet {
@@ -57,14 +57,14 @@ impl CliWallet {
     /// Creates a new offline CliWallet instance
     pub fn offline(store: LocalStore) -> Self {
         CliWallet {
-            store: store.clone(),
+            store,
             wallet: None,
         }
     }
 
     /// Runs the CliWallet in interactive mode
     pub fn interactive(&self) -> Result<(), Error> {
-        let offline = !self.wallet.is_some();
+        let offline = self.wallet.is_none();
         loop {
             match prompt::command(offline) {
                 Some(cmd) => {
@@ -91,7 +91,7 @@ impl CliWallet {
                     println!(
                         "> Balance for key {} is: {} Dusk",
                         key,
-                        balance / 1_000_000
+                        to_dusk(balance)
                     );
                     Ok(())
                 } else {
@@ -171,7 +171,7 @@ impl CliWallet {
                     Err(Error::Offline)
                 }
             }
-/*
+            /*
             // Extend stake for a particular key
             ExtendStake {
                 key,
@@ -196,7 +196,7 @@ impl CliWallet {
                     Err(Error::Offline)
                 }
             }
-*/
+            */
             // Withdraw a key's stake
             WithdrawStake {
                 key,
@@ -266,7 +266,7 @@ impl CliWallet {
             }
 
             // Do nothing
-            _ => Ok(())
+            _ => Ok(()),
         }
     }
 }

--- a/rusk-wallet/src/main.rs
+++ b/rusk-wallet/src/main.rs
@@ -135,7 +135,7 @@ enum CliCommand {
         #[clap(short = 'p', long)]
         gas_price: Option<u64>,
     },
-
+/*
     /// Extend stake for a particular key
     ExtendStake {
         /// Key index from which your Dusk was staked
@@ -154,7 +154,7 @@ enum CliCommand {
         #[clap(short = 'p', long)]
         gas_price: Option<u64>,
     },
-
+*/
     /// Withdraw a key's stake
     WithdrawStake {
         /// Key index from which your Dusk was staked

--- a/rusk-wallet/src/main.rs
+++ b/rusk-wallet/src/main.rs
@@ -12,9 +12,9 @@ mod lib;
 pub use lib::error::Error;
 
 use clap::{AppSettings, Parser, Subcommand};
-use tonic::transport::Channel;
 use std::fs;
 use std::path::{Path, PathBuf};
+use tonic::transport::Channel;
 
 use lib::clients::{Prover, State};
 use lib::crypto::MnemSeed;
@@ -37,7 +37,7 @@ pub(crate) const DATA_DIR: &str = ".dusk";
 #[derive(Parser)]
 #[clap(name = "Dusk Wallet CLI")]
 #[clap(author = "Dusk Network B.V.")]
-#[clap(version = "0.1.2")]
+#[clap(version = "0.1.3")]
 #[clap(about = "Easily manage your Dusk", long_about = None)]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 //#[clap(global_setting(AppSettings::SubcommandRequiredElseHelp))]
@@ -135,26 +135,26 @@ enum CliCommand {
         #[clap(short = 'p', long)]
         gas_price: Option<u64>,
     },
-/*
-    /// Extend stake for a particular key
-    ExtendStake {
-        /// Key index from which your Dusk was staked
-        #[clap(short, long)]
-        key: u64,
+    /*
+        /// Extend stake for a particular key
+        ExtendStake {
+            /// Key index from which your Dusk was staked
+            #[clap(short, long)]
+            key: u64,
 
-        /// Staking key index used for this stake
-        #[clap(short, long)]
-        stake_key: u64,
+            /// Staking key index used for this stake
+            #[clap(short, long)]
+            stake_key: u64,
 
-        /// Max amt of gas for this transaction
-        #[clap(short = 'l', long)]
-        gas_limit: u64,
+            /// Max amt of gas for this transaction
+            #[clap(short = 'l', long)]
+            gas_limit: u64,
 
-        /// Max price you're willing to pay for gas used
-        #[clap(short = 'p', long)]
-        gas_price: Option<u64>,
-    },
-*/
+            /// Max price you're willing to pay for gas used
+            #[clap(short = 'p', long)]
+            gas_price: Option<u64>,
+        },
+    */
     /// Withdraw a key's stake
     WithdrawStake {
         /// Key index from which your Dusk was staked
@@ -219,7 +219,6 @@ impl WalletCfg {
     }
 }
 
-
 /// Client connections to rusk Services
 struct Rusk {
     network: NetworkClient<Channel>,
@@ -228,9 +227,9 @@ struct Rusk {
 }
 
 /// Connect to rusk services
-async fn connect (addr: &str, port: &str) -> Result<Rusk, Error> {
+async fn connect(addr: &str, port: &str) -> Result<Rusk, Error> {
     let rusk_addr = format!("http://{}:{}", addr, port);
-    Ok(Rusk{
+    Ok(Rusk {
         network: NetworkClient::connect(rusk_addr.clone()).await?,
         state: StateClient::connect(rusk_addr.clone()).await?,
         prover: ProverClient::connect(rusk_addr).await?,
@@ -284,10 +283,8 @@ async fn main() -> Result<(), Error> {
             let prover = Prover::new(clients.prover, clients.network);
             let state = State::new(clients.state);
             CliWallet::new(store, state, prover)
-        },
-        Err(_) => {
-            CliWallet::offline(store)
         }
+        Err(_) => CliWallet::offline(store),
     };
 
     // run command(s)
@@ -365,7 +362,8 @@ fn interactive(path: PathBuf) -> Result<LocalStore, Error> {
     if !wallets.is_empty() {
         let wallet = prompt::select_wallet(&dir, wallets);
         if let Some(w) = wallet {
-            let pwd = prompt::request_auth("Please enter your wallet's password");
+            let pwd =
+                prompt::request_auth("Please enter your wallet's password");
             let store = LocalStore::from_file(w, pwd)?;
             Ok(store)
         } else {


### PR DESCRIPTION
Adds "Offline" mode to the wallet CLI - Commands that don't require Rusk can be executed.

Includes *notable* UX improvements:
- Add live validation to user interactive input
- Better navigation through interactive menus
- Fix bad UX when creating a wallet that already exists
- "Pause" after result to give user time to digest info
- _Disable "Extend stake" command_

Resolves: #499
Resolves: #507