### PR TITLE
Download the state by default

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -46,7 +46,7 @@ jobs:
       - run: >
           RUSK_PROFILE_PATH="/var/opt/build-cache"
           RUSK_KEEP_KEYS="1"
-          RUSK_OVERWRITE_STATE="1"
+          RUSK_BUILD_STATE="1"
           make -j test
       - name: "Clippy check release"
         uses: actions-rs/clippy-check@v1

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-recovery"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 autobins = false
 description = "Tool to restore Rusk to factory settings"
@@ -47,6 +47,8 @@ thiserror = "1.0"
 console = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.2.0", features = ["fmt"] }
+http_req = "0.8"
+zip = "0.5"
 
 [features]
 state = []

--- a/rusk-recovery/Makefile
+++ b/rusk-recovery/Makefile
@@ -5,7 +5,7 @@ keys: ## Build circuit keys
 	cargo run --release --bin rusk-recovery-keys --features keys
 
 state: ## Build network state
-	cargo run --release --bin rusk-recovery-state --features state -- -w
+	cargo run --release --bin rusk-recovery-state --features state
 
 test: ## Run Rusk tests
 	@cargo test \
@@ -14,4 +14,4 @@ test: ## Run Rusk tests
 		-- --nocapture \
 		--test-threads 1
 
-.PHONY: keys test help
+.PHONY: keys state test help

--- a/rusk-recovery/src/bin/state.rs
+++ b/rusk-recovery/src/bin/state.rs
@@ -25,9 +25,9 @@ struct Cli {
     )]
     profile: PathBuf,
 
-    /// Overwrite the current state if exists
-    #[clap(short = 'w', long, env = "RUSK_OVERWRITE_STATE")]
-    overwrite: bool,
+    /// Builds the state from scratch instead of downloading it.
+    #[clap(short = 'w', long, env = "RUSK_BUILD_STATE")]
+    build: bool,
 
     /// Sets different levels of verbosity
     #[clap(short, long, parse(from_occurrences))]
@@ -37,7 +37,7 @@ struct Cli {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Cli::parse();
     task::run(
-        || rusk_recovery_tools::state::exec(args.overwrite),
+        || rusk_recovery_tools::state::exec(args.build),
         args.profile,
         args.verbose,
     )

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -7,24 +7,25 @@
 use crate::provisioners::PROVISIONERS;
 use crate::theme::Theme;
 
+use http_req::request;
 use microkelvin::{Backend, BackendCtor, DiskBackend};
 use phoenix_core::Note;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use rusk_abi;
 use rusk_vm::{Contract, NetworkState, NetworkStateId};
 use stake_contract::{Stake, StakeContract, MINIMUM_STAKE};
+use std::error::Error;
+use std::io::{Cursor, Read};
 use std::{fs, io};
-use tracing::{error, info};
+use tracing::info;
+use tracing::log::error;
 use transfer_contract::TransferContract;
+use zip::ZipArchive;
 
 /// Initial amount of the note inserted in the state.
 const GENESIS_DUSK: u64 = 1_000_000_000; // 1000 Dusk.
 /// The number of blocks after which the genesis stake expires.
 const GENESIS_EXPIRATION: u64 = 1_000_000;
-
-const EXPECTED_ROOT: &str =
-    "09978bbf8037095dd849e21a95333538d7fec205733028b8aa78d0009e03901a";
 
 fn diskbackend() -> BackendCtor<DiskBackend> {
     BackendCtor::new(|| {
@@ -85,7 +86,7 @@ fn genesis_stake() -> StakeContract {
 
 pub fn deploy<B>(
     ctor: &BackendCtor<B>,
-) -> Result<NetworkStateId, Box<dyn std::error::Error>>
+) -> Result<NetworkStateId, Box<dyn Error>>
 where
     B: 'static + Backend,
 {
@@ -125,58 +126,121 @@ where
 
     info!("{} network state", theme.action("Storing"));
 
-    let root = hex::encode(network.root());
-
-    if root != EXPECTED_ROOT {
-        error!("{} expected state root failed", theme.action("Checking"));
-        error!("{} {}", theme.error("Expected"), EXPECTED_ROOT);
-        error!("{} {}", theme.error("Computed"), root);
-        return Err("state root mismatch".into());
-    }
-
-    info!("{} {}", theme.action("Root"), root);
+    info!("{} {}", theme.action("Root"), hex::encode(network.root()));
 
     let state_id = network.persist(ctor).expect("Error in persistence");
 
     Ok(state_id)
 }
 
-pub fn exec(overwrite: bool) -> Result<(), Box<dyn std::error::Error>> {
+pub fn exec(build: bool) -> Result<(), Box<dyn Error>> {
     let theme = Theme::default();
 
     info!("{} Network state", theme.action("Checking"));
     let state_path = rusk_profile::get_rusk_state_dir()?;
     let id_path = rusk_profile::get_rusk_state_id_path()?;
 
-    let has_state = state_path.exists() && id_path.exists();
+    // if the state already exists in the expected path stop.
+    if state_path.exists() && id_path.exists() {
+        info!("{} existing state", theme.info("Found"));
 
-    if has_state {
-        if overwrite {
-            info!("{} previous network state", theme.info("Found"));
-        } else {
-            info!("{} previous network state", theme.info("Keep"));
-            return Ok(());
-        }
-    } else {
-        info!("{} previous network state", theme.info("Missing"));
+        let _ = NetworkStateId::read(&id_path)?;
+
+        info!(
+            "{} state id at {}",
+            theme.success("Checked"),
+            id_path.display()
+        );
+        return Ok(());
     }
 
-    let state_id =
-        deploy(&diskbackend()).expect("Failed to deploy network state");
+    if build {
+        info!("{} new state", theme.info("Building"));
+        let state_id =
+            deploy(&diskbackend()).expect("Failed to deploy network state");
+
+        info!("{} persisted id", theme.success("Storing"));
+        state_id.write(&id_path)?;
+    } else {
+        info!("{} state from previous build", theme.info("Downloading"));
+
+        if let Err(err) = download_state() {
+            error!("{} downloading state", theme.error("Failed"));
+            return Err(err);
+        }
+    }
+
+    if !state_path.exists() {
+        error!(
+            "{} network state at {}",
+            theme.error("Missing"),
+            state_path.display()
+        );
+        return Err("Missing state at expected path".into());
+    }
+
+    if !id_path.exists() {
+        error!(
+            "{} persisted id at {}",
+            theme.error("Missing"),
+            id_path.display()
+        );
+        return Err("Missing persisted id at expected path".into());
+    }
 
     info!(
         "{} network state at {}",
-        theme.info("Stored"),
+        theme.success("Stored"),
         state_path.display()
     );
-    info!("{} persisted id", theme.action("Storing"));
-    state_id.write(&id_path)?;
-
     info!(
         "{} persisted id at {}",
-        theme.info("Stored"),
+        theme.success("Stored"),
         id_path.display()
     );
+
+    Ok(())
+}
+
+const STATE_URL: &str =
+    "https://dusk-infra.ams3.digitaloceanspaces.com/keys/rusk-state.zip";
+
+/// Downloads the state into the rusk profile directory.
+fn download_state() -> Result<(), Box<dyn Error>> {
+    let theme = Theme::default();
+
+    let mut buffer = vec![];
+    let response = request::get(STATE_URL, &mut buffer)?;
+
+    // only accept success codes.
+    if !response.status_code().is_success() {
+        return Err(format!(
+            "State download error: HTTP {}",
+            response.status_code()
+        )
+        .into());
+    }
+
+    info!("{} state archive into", theme.info("Unzipping"));
+
+    let reader = Cursor::new(buffer);
+    let mut zip = ZipArchive::new(reader)?;
+
+    let mut profile_path = rusk_profile::get_rusk_profile_dir()?;
+    profile_path.pop();
+
+    for i in 0..zip.len() {
+        let mut entry = zip.by_index(i)?;
+        let entry_path = profile_path.join(entry.name());
+
+        if entry.is_dir() {
+            let _ = fs::create_dir_all(entry_path);
+        } else {
+            let mut buffer = Vec::with_capacity(entry.size() as usize);
+            entry.read_to_end(&mut buffer)?;
+            let _ = fs::write(entry_path, buffer)?;
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This is accomplished by:
    
- Changing the `RUSK_OVERWRITE_STATE` flag to `RUSK_BUILD_STATE` and
  building the state only on the condition of it being present.
    
- Adding code to download and unpack the state zip from DigitalOcean
  into `RUSK_PROFILE_PATH` - where the state is expected to be.
    
- Removing the code to check the state root against a known value.
    
See also: #509

ci: add always building the state
    
The state should always be built in the CI, therefore the
`RUSK_BUILD_STATE` variable is hardcoded and the now obsolete
`RUSK_OVERWRITE_STATE` removed.

