### PR TITLE
E2E Rusk test

### DIFF
--- a/contracts/transfer/Cargo.toml
+++ b/contracts/transfer/Cargo.toml
@@ -25,7 +25,7 @@ dusk-plonk = "0.9"
 lazy_static = "1.4"
 rand = "0.8"
 rusk-profile = { path = "../../rusk-profile" }
-rusk-vm = "0.8.0-rc"
+rusk-vm = "0.10.0-rc"
 transfer-circuits = { path = "../../circuits/transfer", features = ["builder"] }
 
 [dev-dependencies]

--- a/contracts/transfer/src/transfer.rs
+++ b/contracts/transfer/src/transfer.rs
@@ -177,7 +177,6 @@ impl TryFrom<Note> for TransferContract {
 #[cfg(test)]
 mod test_transfer {
     use super::*;
-    use alloc::vec;
 
     #[test]
     fn find_existing_nullifiers() -> Result<(), Error> {

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -27,7 +27,7 @@ canonical_derive = "0.6"
 dusk-plonk = { version = "0.9", default-features = false, features = ["canon"] }
 
 [dev-dependencies]
-rusk-vm = "0.8.0-rc"
+rusk-vm = "0.10.0-rc"
 dusk-bytes = "0.1"
 host_fn = { path = "tests/contracts/host_fn" }
 rand_core = { version = "0.6", features = ["std"] }

--- a/rusk-abi/tests/lib.rs
+++ b/rusk-abi/tests/lib.rs
@@ -81,7 +81,7 @@ mod module_tests {
 
         let mut network = NetworkState::default();
         let rusk_mod = RuskModule::new(&PUB_PARAMS);
-        network.register_host_module(rusk_mod);
+        NetworkState::register_host_module(rusk_mod);
 
         let contract_id = network.deploy(contract).unwrap();
 
@@ -126,7 +126,7 @@ mod module_tests {
 
         let mut network = NetworkState::default();
         let rusk_mod = RuskModule::new(&PUB_PARAMS);
-        network.register_host_module(rusk_mod);
+        NetworkState::register_host_module(rusk_mod);
 
         let contract_id = network.deploy(contract).unwrap();
 
@@ -160,7 +160,7 @@ mod module_tests {
 
         let rusk_mod = RuskModule::new(&PUB_PARAMS);
         let mut network = NetworkState::default();
-        network.register_host_module(rusk_mod);
+        NetworkState::register_host_module(rusk_mod);
 
         let contract_id = network.deploy(contract).unwrap();
 
@@ -214,7 +214,7 @@ mod module_tests {
 
         let rusk_mod = RuskModule::new(&PUB_PARAMS);
         let mut network = NetworkState::default();
-        network.register_host_module(rusk_mod);
+        NetworkState::register_host_module(rusk_mod);
 
         let contract_id = network.deploy(contract).unwrap();
 
@@ -336,7 +336,7 @@ mod module_tests {
 
         let rusk_mod = RuskModule::new(&PUB_PARAMS);
         let mut network = NetworkState::default();
-        network.register_host_module(rusk_mod);
+        NetworkState::register_host_module(rusk_mod);
 
         let contract_id = network.deploy(contract).unwrap();
 
@@ -377,7 +377,7 @@ mod module_tests {
 
         let rusk_mod = RuskModule::new(&PUB_PARAMS);
         let mut network = NetworkState::default();
-        network.register_host_module(rusk_mod);
+        NetworkState::register_host_module(rusk_mod);
 
         let contract_id = network.deploy(contract).unwrap();
 
@@ -407,7 +407,7 @@ mod module_tests {
 
         let rusk_mod = RuskModule::new(&PUB_PARAMS);
         let mut network = NetworkState::default();
-        network.register_host_module(rusk_mod);
+        NetworkState::register_host_module(rusk_mod);
 
         let contract_id = network.deploy(contract).unwrap();
 

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -33,7 +33,7 @@ transfer-circuits = { path = "../circuits/transfer", features=["builder"] }
 transfer-contract = { path = "../contracts/transfer", default-features = false }
 stake-contract = { path = "../contracts/stake", default-features = false }
 microkelvin = { version = "0.10", features = ["persistence"] }
-rusk-vm = { version = "0.8.0-rc", features = ["persistence"] }
+rusk-vm = { version = "0.10.0-rc", features = ["persistence"] }
 rusk-profile = { path = "../rusk-profile" }
 rusk-abi = { path = "../rusk-abi" }
 lazy_static = "1.4"

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -126,6 +126,9 @@ where
 
     info!("{} network state", theme.action("Storing"));
 
+    network.commit();
+    network.push();
+
     info!("{} {}", theme.action("Root"), hex::encode(network.root()));
 
     let state_id = network.persist(ctor).expect("Error in persistence");

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -38,9 +38,9 @@ dusk-bls12_381-sign = { version = "0.1.0-rc", features = ["canon"] }
 dusk-jubjub = { version = "0.10", features = ["canon"] }
 dusk-pki = "0.9.0-rc"
 dusk-bytes = "0.1"
-dusk-wallet-core = "0.8.0-rc"
+dusk-wallet-core = "0.9.0-rc"
 dusk-abi = "0.10"
-rusk-vm = { version = "0.8.0-rc", features = ["persistence"] }
+rusk-vm = { version = "0.10.0-rc", features = ["persistence"] }
 phoenix-core = "0.15.0-rc"
 kadcast = "0.4.0-rc"
 canonical = "0.6"
@@ -60,7 +60,7 @@ tower = "0.4"
 test-context = "0.1"
 async-trait = "0.1"
 tempfile = "3.2"
-
+hex = "0.4"
 
 [build-dependencies]
 tonic-build = "0.6"

--- a/rusk/src/lib/error.rs
+++ b/rusk/src/lib/error.rs
@@ -43,9 +43,17 @@ pub enum Error {
     StakeNotFound(PublicKey),
     /// Bad coinbase value (got, expected).
     CoinbaseValue(u64, u64),
+    /// Other
+    Other(Box<dyn std::error::Error>),
 }
 
 impl std::error::Error for Error {}
+
+impl From<Box<dyn std::error::Error>> for Error {
+    fn from(err: Box<dyn std::error::Error>) -> Self {
+        Error::Other(err)
+    }
+}
 
 impl From<rusk_vm::VMError> for Error {
     fn from(err: rusk_vm::VMError) -> Self {
@@ -138,6 +146,7 @@ impl fmt::Display for Error {
                 got, expected
             ),
             Error::Phoenix(err) => write!(f, "Phoenix error: {}", err),
+            Error::Other(err) => write!(f, "Other error: {}", err),
         }
     }
 }

--- a/rusk/tests/common/mod.rs
+++ b/rusk/tests/common/mod.rs
@@ -43,11 +43,10 @@ pub fn logger() {
     // not the other way around.
     let directive = std::env::var("RUST_LOG")
         .unwrap_or_else(|_| "rusk=info,tests=info".to_string());
-    let filter = EnvFilter::new(directive);
 
+    let filter = EnvFilter::new(directive);
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
 }
-
 pub async fn setup() -> (
     Channel,
     async_stream::AsyncStream<

--- a/rusk/tests/rusk-state.rs
+++ b/rusk/tests/rusk-state.rs
@@ -1,0 +1,159 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+pub mod common;
+use crate::common::*;
+use dusk_pki::SecretSpendKey;
+use rand::prelude::*;
+use rand::rngs::StdRng;
+use rusk::{Result, Rusk, RuskState};
+
+use microkelvin::{BackendCtor, DiskBackend};
+
+use tracing::info;
+
+use phoenix_core::Note;
+
+const BLOCK_HEIGHT: u64 = 1;
+const INITIAL_BALANCE: u64 = 10_000_000_000;
+
+// Function used to creates a temporary diskbackend for Rusk
+fn testbackend() -> BackendCtor<DiskBackend> {
+    BackendCtor::new(DiskBackend::ephemeral)
+}
+
+// Creates the Rusk initial state for the tests below
+fn initial_state() -> Result<Rusk> {
+    let state_id = rusk_recovery_tools::state::deploy(&testbackend())?;
+
+    let rusk = Rusk::builder(testbackend).id(state_id).build()?;
+
+    let mut state = rusk.state()?;
+    let transfer = state.transfer_contract()?;
+
+    assert!(
+        transfer.get_note(0)?.is_some(),
+        "Expect to have one note at the genesis state",
+    );
+
+    assert!(
+        transfer.get_note(1)?.is_none(),
+        "Expect to have ONLY one note at the genesis state",
+    );
+
+    state.accept();
+    state.finalize();
+
+    Ok(rusk)
+}
+
+fn push_note(rusk_state: &mut RuskState) -> Result<()> {
+    info!("Generating a note");
+    let mut rng = StdRng::seed_from_u64(0xdead);
+
+    let ssk = SecretSpendKey::random(&mut rng);
+    let psk = ssk.public_spend_key();
+
+    let note = Note::transparent(&mut rng, &psk, INITIAL_BALANCE);
+
+    let mut transfer = rusk_state.transfer_contract()?;
+
+    transfer.push_note(BLOCK_HEIGHT, note)?;
+
+    transfer.update_root()?;
+
+    info!("Updating the new transfer contract state");
+    unsafe {
+        rusk_state
+            .set_contract_state(&rusk_abi::transfer_contract(), &transfer)?;
+    };
+
+    Ok(())
+}
+
+pub fn rusk_state_accepted() -> Result<()> {
+    // Setup the logger
+    logger();
+
+    let rusk = initial_state()?;
+
+    let mut state = rusk.state()?;
+    push_note(&mut state)?;
+
+    let transfer = state.transfer_contract()?;
+
+    assert!(transfer.get_note(1)?.is_some(), "Note added");
+
+    state.accept();
+    state.revert();
+
+    let transfer = state.transfer_contract()?;
+    assert!(transfer.get_note(1)?.is_none(), "Note removed");
+    Ok(())
+}
+
+pub fn rusk_state_finalized() -> Result<()> {
+    // Setup the logger
+    logger();
+
+    let rusk = initial_state()?;
+
+    let mut state = rusk.state()?;
+    push_note(&mut state)?;
+
+    let transfer = state.transfer_contract()?;
+
+    assert!(transfer.get_note(1)?.is_some(), "Note added");
+
+    state.finalize();
+    state.revert();
+
+    assert!(transfer.get_note(1)?.is_some(), "Note still present");
+    Ok(())
+}
+
+pub fn rusk_state_ephemeral() -> Result<()> {
+    // Setup the logger
+    logger();
+
+    let rusk = initial_state()?;
+
+    // The state is dropped at the end of the block, all changes that are not
+    // accepted / finalized are lost
+    {
+        let mut state = rusk.state()?;
+
+        push_note(&mut state)?;
+        state.finalize();
+
+        push_note(&mut state)?;
+        state.accept();
+
+        push_note(&mut state)?;
+
+        let transfer = state.transfer_contract()?;
+
+        assert!(transfer.get_note(1)?.is_some(), "Note added");
+        assert!(transfer.get_note(2)?.is_some(), "Note added");
+        assert!(transfer.get_note(3)?.is_some(), "Note added");
+    }
+
+    let mut state = rusk.state()?;
+    let transfer = state.transfer_contract()?;
+
+    assert!(transfer.get_note(1)?.is_some(), "Note still present");
+    assert!(transfer.get_note(2)?.is_some(), "Note still present");
+    assert!(transfer.get_note(3)?.is_none(), "Note removed");
+
+    state.revert();
+    let transfer = state.transfer_contract()?;
+
+    assert!(transfer.get_note(1)?.is_some(), "Note still present");
+    assert!(transfer.get_note(2)?.is_none(), "Note removed");
+    assert!(transfer.get_note(3)?.is_none(), "Note removed");
+
+    Ok(())
+}

--- a/rusk/tests/services/prover_service.rs
+++ b/rusk/tests/services/prover_service.rs
@@ -43,7 +43,7 @@ fn mock_wallet<Rng: RngCore + CryptoRng>(
     let opening = Default::default();
 
     let node = TestWalletProverClient::new(client);
-    let state = TestStateClient::new(notes, anchor, opening);
+    let state = TestStateClient::new(notes, anchor, opening, vec![]);
 
     Wallet::new(store, state, node)
 }
@@ -152,6 +152,7 @@ pub struct TestStateClient {
     notes: Vec<Note>,
     anchor: BlsScalar,
     opening: PoseidonBranch<POSEIDON_TREE_DEPTH>,
+    nullifiers: Vec<BlsScalar>,
 }
 
 impl TestStateClient {
@@ -159,11 +160,13 @@ impl TestStateClient {
         notes: Vec<Note>,
         anchor: BlsScalar,
         opening: PoseidonBranch<POSEIDON_TREE_DEPTH>,
+        nullifiers: Vec<BlsScalar>,
     ) -> Self {
         Self {
             notes,
             anchor,
             opening,
+            nullifiers,
         }
     }
 }
@@ -192,6 +195,13 @@ impl StateClient for TestStateClient {
 
     fn fetch_stake(&self, _pk: &PublicKey) -> Result<(u64, u64), Self::Error> {
         unimplemented!();
+    }
+
+    fn fetch_existing_nullifiers(
+        &self,
+        _nullifiers: &[BlsScalar],
+    ) -> Result<Vec<BlsScalar>, Self::Error> {
+        Ok(self.nullifiers.clone())
     }
 }
 

--- a/rusk/tests/services/state_service.rs
+++ b/rusk/tests/services/state_service.rs
@@ -108,7 +108,7 @@ fn generate_note(rusk: &mut Rusk) -> Result<Option<Note>> {
         rusk_state
             .set_contract_state(&rusk_abi::transfer_contract(), &transfer)?;
     }
-    rusk.persist(&mut rusk_state)?;
+    rusk_state.finalize();
 
     fetch_note(rusk)
 }
@@ -132,7 +132,7 @@ fn generate_stake(rusk: &mut Rusk) -> Result<(BlsPublicKey, Stake)> {
             .set_contract_state(&rusk_abi::stake_contract(), &stake_contract)?;
     }
 
-    rusk.persist(&mut rusk_state)?;
+    rusk_state.finalize();
 
     Ok((pk, stake))
 }

--- a/schema/state.proto
+++ b/schema/state.proto
@@ -94,6 +94,14 @@ message GetStakeResponse {
     fixed64 expiration = 2;
 }
 
+message FindExistingNullifiersRequest {
+    repeated bytes nullifiers = 1;
+}
+
+message FindExistingNullifiersResponse {
+    repeated bytes nullifiers = 1;
+}
+
 service State {
     rpc Echo(EchoRequest) returns (EchoResponse) {}
     rpc Preverify(PreverifyRequest) returns (PreverifyResponse) {}
@@ -107,4 +115,5 @@ service State {
     rpc GetAnchor(GetAnchorRequest) returns (GetAnchorResponse) {}
     rpc GetOpening(GetOpeningRequest) returns (GetOpeningResponse) {}
     rpc GetStake(GetStakeRequest) returns (GetStakeResponse) {}
+    rpc FindExistingNullifiers(FindExistingNullifiersRequest) returns (FindExistingNullifiersResponse) {}
 }

--- a/test-utils/transfer-wrapper/Cargo.toml
+++ b/test-utils/transfer-wrapper/Cargo.toml
@@ -25,4 +25,4 @@ transfer-circuits = { path = "../../circuits/transfer", features = ["builder"] }
 transfer-contract = { path = "../../contracts/transfer" }
 rusk-profile = { path = "../../rusk-profile" }
 dusk-plonk = "0.9"
-rusk-vm = "0.8.0-rc"
+rusk-vm = "0.10.0-rc"

--- a/test-utils/transfer-wrapper/src/wrapper.rs
+++ b/test-utils/transfer-wrapper/src/wrapper.rs
@@ -45,7 +45,7 @@ impl TransferWrapper {
         let mut network = NetworkState::new();
 
         let rusk_mod = RuskModule::new(&*PP);
-        network.register_host_module(rusk_mod);
+        NetworkState::register_host_module(rusk_mod);
 
         let genesis_ssk = SecretSpendKey::random(&mut rng);
         let genesis_psk = genesis_ssk.public_spend_key();


### PR DESCRIPTION
- transfer-contract: Update `rusk-vm` from `0.8.0-rc` to `0.10.0-rc`

- rusk-abi: Update `rusk-vm` from `0.8.0-rc` to `0.10.0-rc`

- rusk-recovery: Update `rusk-vm` from `0.8.0-rc` to `0.10.0-rc`

- Add `FindExistingNullifiers` gRPC service to the schema

- test-utils: Update rusk-vm from `0.8.0-rc` to `0.10.0-rc`

- rusk: Update dependencies

  - Update `dusk-wallet-core` from `0.8.0-rc` to `0.9.0-rc`
  - Update `rusk-vm` from `0.8.0-rc` to `0.10.0-rc`
  - Add `hex` version `0.4`


- rusk: Add a `Error::Other` for any `std::error::Error` type

- rusk: Change `Rusk` to keep a shared ref of `NetworkState`

  Now `NetworkState` is thread safe, so there is no need to keep just the
  `NetworkStateId` and `restore` from disk every call.


- rusk: `RuskState` refactoring

  - Change `RuskState` to hold an `Arc` `Mutex` of `NetworkState`
  - Add `accept` method to `RuskState`
  - Add `finalize` method to `RuskState`
  - Add `revert` method to `RuskState`
  - Add `execute` method to `RuskState`
  - Add `any_nullifier_exists` method to `RuskState`
  - Add `find_existing_nullifiers` method to `RuskState`
  - Add implementation of `Drop` trait to `RuskState`
  - Change `coinbase_value` and `emission_amount` to be `const` functions
  
    Once an instance of `RuskState` is dropped, it will automatically
    discard any changes that aren't either finalized or accepted.
  
  - Change `contract_state` method to mirroring the `set_contract_state` one

- rusk: refactor state service

  - Add `find_existing_nullifiers` service
  - Change the code to be compatible with the new `RuskState`

- rusk: Update tests

  - Add tests for new `RuskState` implementation
  - Change `wallet_grpc` to reflect better the actual workflow
  - Update tests for the state service
  - Update tests for the prover service

Resolves: #466
Resolves:  #512