### PR TITLE
wallet: change default `gas_price` to 0.001 Dusk

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2022-02-08
+
+### Changed 
+- Default `gas_price` from 0 to 0.001 Dusk [#539]
+
 ## [0.2.0] - 2022-02-04
 
 ### Added
@@ -53,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementation of `Store` trait from `wallet-core`
 - Implementation of `State` and `Prover` traits from `wallet-core`
 
-
+[#539]: https://github.com/dusk-network/rusk/issues/539
 [#482]: https://github.com/dusk-network/rusk/issues/482
 [#479]: https://github.com/dusk-network/rusk/issues/479
 [#492]: https://github.com/dusk-network/rusk/issues/492

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]

--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -30,6 +30,9 @@ mod base64 {
     }
 }
 
+/// The default gas price is 0.001 Dusk.
+const DEFAULT_GAS_PRICE: u64 = 1_000;
+
 /// Bls key pair helper structure
 #[derive(Serialize)]
 struct BlsKeyPair {
@@ -135,7 +138,7 @@ impl CliWallet {
                         &dest_addr,
                         amt,
                         gas_limit,
-                        gas_price.unwrap_or(0),
+                        gas_price.unwrap_or(DEFAULT_GAS_PRICE),
                         BlsScalar::zero(),
                     )?;
                     println!("> Transfer sent!");
@@ -163,7 +166,7 @@ impl CliWallet {
                         &my_addr,
                         amt,
                         gas_limit,
-                        gas_price.unwrap_or(0),
+                        gas_price.unwrap_or(DEFAULT_GAS_PRICE),
                     )?;
                     println!("> Stake success!");
                     Ok(())
@@ -213,7 +216,7 @@ impl CliWallet {
                         stake_key,
                         &my_addr,
                         gas_limit,
-                        gas_price.unwrap_or(0),
+                        gas_price.unwrap_or(DEFAULT_GAS_PRICE),
                     )?;
                     println!("> Stake withdrawal success!");
                     Ok(())


### PR DESCRIPTION
The default `gas_price` being zero makes it such that a change note is
not generated by default, ensuring the execute proof doesn't pass
verification. Since by default this shouldn't be the case we should
change it to a normal value - the choice here being 1 Dusk.

Resolves: #539
See also: #535