### PR TITLE
rusk: reduce number of coinbase transactions to 1

### DIFF
--- a/rusk/tests/services/transactions.rs
+++ b/rusk/tests/services/transactions.rs
@@ -394,7 +394,7 @@ impl wallet::ProverClient for TestProverClient {
             }
         };
 
-        assert_eq!(response.txs.len(), 3, "Should have three tx");
+        assert_eq!(response.txs.len(), 2, "Should have two tx");
 
         let transfer_txs: Vec<_> = response
             .txs
@@ -409,7 +409,7 @@ impl wallet::ProverClient for TestProverClient {
             .collect();
 
         assert_eq!(transfer_txs.len(), 1, "Only one transfer tx");
-        assert_eq!(coinbase_txs.len(), 2, "Two coinbase txs");
+        assert_eq!(coinbase_txs.len(), 1, "One coinbase tx");
 
         assert_eq!(
             transfer_txs[0].tx_hash,


### PR DESCRIPTION
The new coinbase transaction contains both the note for Dusk and the
note for the block generator serialized in sequence. The transaction
hash is calculated using `rusk_abi::Hasher` instead of the significantly
more expensive `dusk_poseidon::sponge::hash`. This is in line with how
normal transfer transactions are hashed.

Resolves: #529