### PR TITLE
recovery: add forcing the state to build/download

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -47,6 +47,7 @@ jobs:
           RUSK_PROFILE_PATH="/var/opt/build-cache"
           RUSK_KEEP_KEYS="1"
           RUSK_BUILD_STATE="1"
+          RUSK_FORCE_STATE="1"
           make -j test
       - name: "Clippy check release"
         uses: actions-rs/clippy-check@v1

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-recovery"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 autobins = false
 description = "Tool to restore Rusk to factory settings"

--- a/rusk-recovery/src/bin/state.rs
+++ b/rusk-recovery/src/bin/state.rs
@@ -29,6 +29,10 @@ struct Cli {
     #[clap(short = 'w', long, env = "RUSK_BUILD_STATE")]
     build: bool,
 
+    /// Forces a build/download even if the state is in the profile path.
+    #[clap(short = 'f', long, env = "RUSK_FORCE_STATE")]
+    force: bool,
+
     /// Sets different levels of verbosity
     #[clap(short, long, parse(from_occurrences))]
     verbose: usize,
@@ -37,7 +41,7 @@ struct Cli {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Cli::parse();
     task::run(
-        || rusk_recovery_tools::state::exec(args.build),
+        || rusk_recovery_tools::state::exec(args.build, args.force),
         args.profile,
         args.verbose,
     )

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -136,15 +136,16 @@ where
     Ok(state_id)
 }
 
-pub fn exec(build: bool) -> Result<(), Box<dyn Error>> {
+pub fn exec(build: bool, force: bool) -> Result<(), Box<dyn Error>> {
     let theme = Theme::default();
 
     info!("{} Network state", theme.action("Checking"));
     let state_path = rusk_profile::get_rusk_state_dir()?;
     let id_path = rusk_profile::get_rusk_state_id_path()?;
 
-    // if the state already exists in the expected path stop.
-    if state_path.exists() && id_path.exists() {
+    // if we're not forcing a rebuild/download and the state already exists in
+    // the expected path, stop early.
+    if !force && state_path.exists() && id_path.exists() {
         info!("{} existing state", theme.info("Found"));
 
         let _ = NetworkStateId::read(&id_path)?;


### PR DESCRIPTION
A `force` flag is added, allowing one to always build or download the
state regardless of the existing state in the profile directory. The
flag is added in the CI for good measure.

Resolves: #518