### PR TITLE
wallet: change default gas price to 0.001 Dusk

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2022-02-09
+
+### Changed
+- Default `gas_price` from 0 to 0.001 Dusk [#539]
+
 ## [0.2.0] - 2022-02-04
 
 ### Added
@@ -62,3 +67,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#505]: https://github.com/dusk-network/rusk/issues/505
 [#507]: https://github.com/dusk-network/rusk/issues/507
 [#520]: https://github.com/dusk-network/rusk/issues/520
+[#539]: https://github.com/dusk-network/rusk/issues/539

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]

--- a/rusk-wallet/src/lib/mod.rs
+++ b/rusk-wallet/src/lib/mod.rs
@@ -14,6 +14,9 @@ pub mod wallet;
 pub const SEED_SIZE: usize = 64;
 pub const ONE_MILLION: f64 = 1_000_000.0;
 
+/// The default gas price is 0.001 Dusk
+pub(crate) const DEFAULT_GAS_PRICE: u64 = 1_000;
+
 /// Convert from Dusk to uDusk
 pub fn to_udusk(dusk: f64) -> u64 {
     (dusk * ONE_MILLION) as u64

--- a/rusk-wallet/src/lib/prompt.rs
+++ b/rusk-wallet/src/lib/prompt.rs
@@ -11,7 +11,7 @@ use blake3::Hash;
 use requestty::Question;
 
 use crate::lib::crypto::MnemSeed;
-use crate::lib::to_udusk;
+use crate::lib::{to_udusk, DEFAULT_GAS_PRICE};
 use crate::{CliCommand, WalletCfg};
 
 /// Request the user to authenticate with a password
@@ -262,7 +262,7 @@ pub(crate) fn command(offline: bool) -> Option<CliCommand> {
                 let rcvr = request_rcvr_addr();
                 let amt = request_token_amt("transfer");
                 let gas_limit = request_gas_limit();
-                let gas_price = Some(0);
+                let gas_price = Some(DEFAULT_GAS_PRICE);
                 Some(Transfer {
                     key,
                     rcvr,
@@ -277,7 +277,7 @@ pub(crate) fn command(offline: bool) -> Option<CliCommand> {
                 let stake_key = request_key_index("stake");
                 let amt = request_token_amt("stake");
                 let gas_limit = request_gas_limit();
-                let gas_price = Some(0);
+                let gas_price = Some(DEFAULT_GAS_PRICE);
                 Some(Stake {
                     key,
                     stake_key,
@@ -291,7 +291,7 @@ pub(crate) fn command(offline: bool) -> Option<CliCommand> {
                 let key = request_key_index("spend");
                 let stake_key = request_key_index("stake");
                 let gas_limit = request_gas_limit();
-                let gas_price = Some(0);
+                let gas_price = Some(DEFAULT_GAS_PRICE);
                 Some(ExtendStake {
                     key,
                     stake_key,
@@ -304,7 +304,7 @@ pub(crate) fn command(offline: bool) -> Option<CliCommand> {
                 let key = request_key_index("spend");
                 let stake_key = request_key_index("stake");
                 let gas_limit = request_gas_limit();
-                let gas_price = Some(0);
+                let gas_price = Some(DEFAULT_GAS_PRICE);
                 Some(WithdrawStake {
                     key,
                     stake_key,

--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -18,7 +18,7 @@ use crate::lib::clients::{Prover, State};
 use crate::lib::crypto::encrypt;
 use crate::lib::store::LocalStore;
 use crate::lib::to_dusk;
-use crate::lib::{prompt, SEED_SIZE};
+use crate::lib::{prompt, DEFAULT_GAS_PRICE, SEED_SIZE};
 use crate::{CliCommand, Error};
 
 mod base64 {
@@ -135,7 +135,7 @@ impl CliWallet {
                         &dest_addr,
                         amt,
                         gas_limit,
-                        gas_price.unwrap_or(0),
+                        gas_price.unwrap_or(DEFAULT_GAS_PRICE),
                         BlsScalar::zero(),
                     )?;
                     println!("> Transfer sent!");
@@ -163,7 +163,7 @@ impl CliWallet {
                         &my_addr,
                         amt,
                         gas_limit,
-                        gas_price.unwrap_or(0),
+                        gas_price.unwrap_or(DEFAULT_GAS_PRICE),
                     )?;
                     println!("> Stake success!");
                     Ok(())
@@ -188,7 +188,7 @@ impl CliWallet {
                         stake_key,
                         &my_addr,
                         gas_limit,
-                        gas_price.unwrap_or(0),
+                        gas_price.unwrap_or(DEFAULT_GAS_PRICE),
                     )?;
                     println!("> Stake extension success!");
                     Ok(())
@@ -213,7 +213,7 @@ impl CliWallet {
                         stake_key,
                         &my_addr,
                         gas_limit,
-                        gas_price.unwrap_or(0),
+                        gas_price.unwrap_or(DEFAULT_GAS_PRICE),
                     )?;
                     println!("> Stake withdrawal success!");
                     Ok(())

--- a/rusk-wallet/src/main.rs
+++ b/rusk-wallet/src/main.rs
@@ -41,7 +41,7 @@ pub(crate) const RUSK_SOCKET: &str = "/tmp/rusk_listener";
 #[derive(Parser)]
 #[clap(name = "Dusk Wallet CLI")]
 #[clap(author = "Dusk Network B.V.")]
-#[clap(version = "0.2.0")]
+#[clap(version = "0.2.1")]
 #[clap(about = "Easily manage your Dusk", long_about = None)]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 //#[clap(global_setting(AppSettings::SubcommandRequiredElseHelp))]


### PR DESCRIPTION
The default gas_price being zero makes it such that a change note is
not generated by default, ensuring the execute proof doesn't pass
verification. Since by default this shouldn't be the case we should
change it to a normal value - the choice here being 1 Dusk.

Resolves: #539
See also: #535

Follow-up of #540 