### PR TITLE
wallet: fix denominations and ask for gas price

### DIFF
--- a/rusk-wallet/src/lib/mod.rs
+++ b/rusk-wallet/src/lib/mod.rs
@@ -11,19 +11,25 @@ pub mod prompt;
 pub mod store;
 pub mod wallet;
 
-pub const SEED_SIZE: usize = 64;
-pub const ONE_MILLION: f64 = 1_000_000.0;
+// Types that define Dusk's denomination.
+pub type Dusk = f64;
+pub type MicroDusk = u64;
 
-/// The default gas price is 0.001 Dusk
-pub(crate) const DEFAULT_GAS_PRICE: u64 = 1_000;
+pub const SEED_SIZE: usize = 64;
+
+pub const ONE_MILLION: Dusk = 1_000_000.0;
+
+pub(crate) const DEFAULT_GAS_LIMIT: u64 = 100000;
+
+pub(crate) const DEFAULT_GAS_PRICE: Dusk = 0.000001;
 
 /// Convert from Dusk to uDusk
-pub fn to_udusk(dusk: f64) -> u64 {
-    (dusk * ONE_MILLION) as u64
+pub fn to_udusk(dusk: Dusk) -> MicroDusk {
+    (dusk * ONE_MILLION) as MicroDusk
 }
 
 /// Convert from uDusk to Dusk
-pub fn to_dusk(udusk: u64) -> f64 {
-    let udusk = udusk as f64;
+pub fn to_dusk(udusk: MicroDusk) -> Dusk {
+    let udusk = udusk as Dusk;
     udusk / ONE_MILLION
 }

--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -17,8 +17,8 @@ use dusk_wallet_core::{Store, Wallet};
 use crate::lib::clients::{Prover, State};
 use crate::lib::crypto::encrypt;
 use crate::lib::store::LocalStore;
-use crate::lib::to_dusk;
 use crate::lib::{prompt, DEFAULT_GAS_PRICE, SEED_SIZE};
+use crate::lib::{to_dusk, to_udusk};
 use crate::{CliCommand, Error};
 
 mod base64 {
@@ -127,7 +127,10 @@ impl CliWallet {
                     let dest_addr =
                         dusk_pki::PublicSpendKey::from_bytes(&addr_bytes)?;
                     let my_addr = wallet.public_spend_key(key)?;
+
                     let mut rng = StdRng::from_entropy();
+                    let ref_id = BlsScalar::random(&mut rng);
+
                     wallet.transfer(
                         &mut rng,
                         key,
@@ -135,8 +138,9 @@ impl CliWallet {
                         &dest_addr,
                         amt,
                         gas_limit,
-                        gas_price.unwrap_or(DEFAULT_GAS_PRICE),
-                        BlsScalar::zero(),
+                        gas_price
+                            .unwrap_or_else(|| to_udusk(DEFAULT_GAS_PRICE)),
+                        ref_id,
                     )?;
                     println!("> Transfer sent!");
                     Ok(())
@@ -163,7 +167,8 @@ impl CliWallet {
                         &my_addr,
                         amt,
                         gas_limit,
-                        gas_price.unwrap_or(DEFAULT_GAS_PRICE),
+                        gas_price
+                            .unwrap_or_else(|| to_udusk(DEFAULT_GAS_PRICE)),
                     )?;
                     println!("> Stake success!");
                     Ok(())
@@ -213,7 +218,8 @@ impl CliWallet {
                         stake_key,
                         &my_addr,
                         gas_limit,
-                        gas_price.unwrap_or(DEFAULT_GAS_PRICE),
+                        gas_price
+                            .unwrap_or_else(|| to_udusk(DEFAULT_GAS_PRICE)),
                     )?;
                     println!("> Stake withdrawal success!");
                     Ok(())


### PR DESCRIPTION
The denominations are normalized to always be asked in Dusk from the
user, and converted to μDusk when used internally. Some sane - aka pass
verification - defaults are added.

Gas price is asked from the user as well. The gas price, gas limit and
transfer amount have a lower limit of 1 μDusk, since anything lower is
floored.