### PR TITLE
Change ExecuteProverResponse to contain the proof

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- TX output in wallet instead of within client impl
+
 ## [0.2.3] - 2022-02-10
 
 ### Added

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -23,7 +23,7 @@ bs58 = "0.4"
 rand = "0.8"
 aes = "0.7"
 
-dusk-wallet-core = "0.9.0-rc"
+dusk-wallet-core = "0.10.0-rc"
 canonical = "0.6"
 dusk-bytes = "0.1"
 dusk-pki = "0.9.0-rc"

--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -158,7 +158,7 @@ impl CliWallet {
                     let mut rng = StdRng::from_entropy();
                     let ref_id = BlsScalar::random(&mut rng);
 
-                    wallet.transfer(
+                    let tx = wallet.transfer(
                         &mut rng,
                         key,
                         &my_addr,
@@ -169,7 +169,10 @@ impl CliWallet {
                             .unwrap_or_else(|| to_udusk(DEFAULT_GAS_PRICE)),
                         ref_id,
                     )?;
-                    println!("> Transfer sent!");
+
+                    let txh = bs58::encode(&tx.hash().to_bytes()).into_string();
+                    println!("> Transaction sent: {}", txh);
+
                     Ok(())
                 } else {
                     Err(Error::Offline)
@@ -187,7 +190,8 @@ impl CliWallet {
                 if let Some(wallet) = &self.wallet {
                     let my_addr = wallet.public_spend_key(key)?;
                     let mut rng = StdRng::from_entropy();
-                    wallet.stake(
+
+                    let tx = wallet.stake(
                         &mut rng,
                         key,
                         stake_key,
@@ -197,7 +201,10 @@ impl CliWallet {
                         gas_price
                             .unwrap_or_else(|| to_udusk(DEFAULT_GAS_PRICE)),
                     )?;
-                    println!("> Stake success!");
+
+                    let txh = bs58::encode(&tx.hash().to_bytes()).into_string();
+                    println!("> Stake transaction sent: {}", txh);
+
                     Ok(())
                 } else {
                     Err(Error::Offline)
@@ -214,7 +221,8 @@ impl CliWallet {
                 if let Some(wallet) = &self.wallet {
                     let my_addr = wallet.public_spend_key(key)?;
                     let mut rng = StdRng::from_entropy();
-                    wallet.withdraw_stake(
+
+                    let tx = wallet.withdraw_stake(
                         &mut rng,
                         key,
                         stake_key,
@@ -223,7 +231,10 @@ impl CliWallet {
                         gas_price
                             .unwrap_or_else(|| to_udusk(DEFAULT_GAS_PRICE)),
                     )?;
-                    println!("> Stake withdrawal success!");
+
+                    let txh = bs58::encode(&tx.hash().to_bytes()).into_string();
+                    println!("> Stake withdrawal transaction sent: {}", txh);
+
                     Ok(())
                 } else {
                     Err(Error::Offline)

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -38,7 +38,7 @@ dusk-bls12_381-sign = { version = "0.1.0-rc", features = ["canon"] }
 dusk-jubjub = { version = "0.10", features = ["canon"] }
 dusk-pki = "0.9.0-rc"
 dusk-bytes = "0.1"
-dusk-wallet-core = "0.9.0-rc"
+dusk-wallet-core = "0.10.0-rc"
 dusk-abi = "0.10"
 rusk-vm = { version = "0.10.0-rc", features = ["persistence"] }
 phoenix-core = "0.15.0-rc"

--- a/rusk/src/lib/services/prover/execute.rs
+++ b/rusk/src/lib/services/prover/execute.rs
@@ -70,7 +70,8 @@ impl RuskProver {
             ))
         })?;
 
-        let tx = utx.prove(proof).to_var_bytes();
-        Ok(Response::new(ExecuteProverResponse { tx }))
+        Ok(Response::new(ExecuteProverResponse {
+            proof: proof.to_bytes().to_vec(),
+        }))
     }
 }

--- a/schema/prover.proto
+++ b/schema/prover.proto
@@ -7,9 +7,9 @@ message ExecuteProverRequest {
 }
 
 
-// A serialized `Transaction` from the `dusk-wallet-core` crate.
+// A Plonk proof for the Execute circuit.
 message ExecuteProverResponse {
-    bytes tx = 1;
+    bytes proof = 1;
 }
 
 // Request a proof for the STCT circuit.


### PR DESCRIPTION
rusk: upgrade to wallet-core `0.10.0-rc.0`

- Change to return proof from `prove_execute` instead of the full tx
- Refactor `wallet_grpc` test to generate blocks outside of `TestProverClient`

Resolves: #556

---
wallet: upgrade to wallet-core `0.10.0-rc.0`

- Change to print transaction hash in main process
- Adapt ProverClient to return tx in `compute_proof_and_propagate`, and take the proof from upstream instead of the full tx

Resolves: #557
Co-authored-by: Abel Elbaile <abel@dusk.network>

---
schema: change ProveExecute to return proof

See also: #556