### PR TITLE
wallet: Release `0.2.4`

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.2.4] - 2022-02-15
+
+### Added
+- Allow for headless wallet creation [#569]
 
 ### Changed
 - TX output in wallet instead of within client impl
@@ -88,3 +91,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#539]: https://github.com/dusk-network/rusk/issues/539
 [#547]: https://github.com/dusk-network/rusk/issues/547
 [#554]: https://github.com/dusk-network/rusk/issues/554
+[#569]: https://github.com/dusk-network/rusk/issues/569

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 
 [dependencies]

--- a/rusk-wallet/README.md
+++ b/rusk-wallet/README.md
@@ -18,6 +18,8 @@ OPTIONS:
                                        [default: uds]
     -s, --socket-path <SOCKET_PATH>    Path for setting up the unix domain socket [default: /tmp/
                                        rusk_listener]
+        --skip-recovery                Skip wallet recovery phrase (useful for headless wallet
+                                       creation)
     -h, --help                         Print help information
     -V, --version                      Print version information
 
@@ -32,7 +34,6 @@ SUBCOMMANDS:
     export            Export BLS provisioner key pair
     interactive       Run in interactive mode (default)
     help              Print this message or the help of the given subcommand(s)
-```
 
 ## Good to know
 
@@ -81,3 +82,8 @@ cargo r --release -- stake --help
 ```
 
 By default, you will always be prompted to enter the wallet password. To prevent this behavior, you can provide the password using the `RUSK_WALLET_PWD` environment variable. This is useful in CI or any other headless environment.
+
+Please note that `RUSK_WALLET_PWD` is effectively used for:
+- Wallet decryption (in all commands that use a wallet)
+- Wallet encryption (in `create`)
+- BLS key encryption (in `export`)

--- a/rusk-wallet/src/lib/prompt.rs
+++ b/rusk-wallet/src/lib/prompt.rs
@@ -36,34 +36,41 @@ pub(crate) fn request_auth(msg: &str) -> Hash {
 
 /// Request the user to create a wallet password
 pub(crate) fn create_password() -> Hash {
-    let mut pwd = String::from("");
+    let pwd = match env::var("RUSK_WALLET_PWD") {
+        Ok(p) => p,
+        Err(_) => {
+            let mut pwd = String::from("");
 
-    let mut pwds_match = false;
-    while !pwds_match {
-        // enter password
-        let q = Question::password("password")
-            .message("Enter a strong password for your wallet:")
-            .mask('*')
-            .build();
-        let a = requestty::prompt_one(q).expect("password");
-        let pwd1 = a.as_string().unwrap_or("").to_string();
+            let mut pwds_match = false;
+            while !pwds_match {
+                // enter password
+                let q = Question::password("password")
+                    .message("Enter a strong password for your wallet:")
+                    .mask('*')
+                    .build();
+                let a = requestty::prompt_one(q).expect("password");
+                let pwd1 = a.as_string().unwrap_or("").to_string();
 
-        // confirm password
-        let q = Question::password("password")
-            .message("Please confirm your password:")
-            .mask('*')
-            .build();
-        let a = requestty::prompt_one(q).expect("password confirmation");
-        let pwd2 = a.as_string().unwrap_or("").to_string();
+                // confirm password
+                let q = Question::password("password")
+                    .message("Please confirm your password:")
+                    .mask('*')
+                    .build();
+                let a =
+                    requestty::prompt_one(q).expect("password confirmation");
+                let pwd2 = a.as_string().unwrap_or("").to_string();
 
-        // check match
-        pwds_match = pwd1 == pwd2;
-        if pwds_match {
-            pwd = pwd1.to_string()
-        } else {
-            println!("Passwords don't match, please try again.");
+                // check match
+                pwds_match = pwd1 == pwd2;
+                if pwds_match {
+                    pwd = pwd1.to_string()
+                } else {
+                    println!("Passwords don't match, please try again.");
+                }
+            }
+            pwd
         }
-    }
+    };
 
     let pwd = blake3::hash(pwd.as_bytes());
     pwd


### PR DESCRIPTION
***Allow for headless wallet creation***

- Adds support for `RUSK_WALLET_PWD` env variable in wallet creation.
- Adds `--skip-recover` flag to prevent the user from being prompted to confirm the safe backup of recovery phrase.

Resolves: #569

---

***Add transaction outputs***

- TX outputs are now in their proper place

See also: https://github.com/dusk-network/wallet-core/pull/43