### PR TITLE
Get ActiveNodes through Network service

### DIFF
--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -42,7 +42,7 @@ dusk-wallet-core = "0.10.0-rc"
 dusk-abi = "0.10"
 rusk-vm = { version = "0.10.0-rc", features = ["persistence"] }
 phoenix-core = "0.15.0-rc"
-kadcast = "0.4.0-rc"
+kadcast = "0.4.0-rc.5"
 canonical = "0.6"
 canonical_derive = "0.6"
 

--- a/schema/network.proto
+++ b/schema/network.proto
@@ -25,6 +25,14 @@ message SendMessage {
     string target_address = 2;
 }
 
+message AliveNodesRequest {
+    uint32 max_nodes = 1;
+}
+
+message AliveNodesResponse {
+    repeated string address = 1;
+}
+
 message Null {};
 
 service Network {
@@ -40,4 +48,7 @@ service Network {
 
     // Send a message to a specific target in the network
     rpc Send(SendMessage) returns (Null) {}
+
+    // Retrieve network nodes considered alive
+    rpc AliveNodes(AliveNodesRequest) returns (AliveNodesResponse) {}
 }


### PR DESCRIPTION
- Add `AliveNodes` to network.proto 
- rusk: Add gRPC to retrieve active nodes in the network
- Update minimum version of kadcast dependency to `0.4.0-rc.5`

Resolves #571