### PR TITLE
Change stake contract to new specification

### DIFF
--- a/contracts/stake/Cargo.toml
+++ b/contracts/stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stake-contract"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 
 [lib]

--- a/contracts/stake/src/contract/transaction.rs
+++ b/contracts/stake/src/contract/transaction.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{Error, Stake, StakeContract, TX_EXTEND, TX_STAKE, TX_WITHDRAW};
+use crate::{Error, Stake, StakeContract, TX_STAKE, TX_WITHDRAW};
 
 use dusk_abi::{ContractId, Transaction};
 use dusk_bls12_381_sign::{PublicKey, Signature};
@@ -72,23 +72,12 @@ impl StakeContract {
 
         let proof = prove(circuit)?;
 
-        let transaction = (TX_STAKE, pk, signature, value, proof);
+        let transaction =
+            (TX_STAKE, pk, signature, value, stake.created_at(), proof);
         let transaction = Transaction::from_canon(&transaction);
         let transaction = (id, transaction);
 
         Ok(transaction)
-    }
-
-    pub fn extend_transaction(
-        pk: PublicKey,
-        signature: Signature,
-    ) -> (ContractId, Transaction) {
-        let id = rusk_abi::stake_contract();
-
-        let transaction = (TX_EXTEND, pk, signature);
-        let transaction = Transaction::from_canon(&transaction);
-
-        (id, transaction)
     }
 
     pub fn withdraw_transaction(

--- a/contracts/stake/src/error.rs
+++ b/contracts/stake/src/error.rs
@@ -13,6 +13,7 @@ pub enum Error {
     StakeNotFound,
     StakeSerialization,
     StakeAlreadyExists,
+    InvalidCreatedAt,
     PlonkKeys,
     PlonkProver,
 }

--- a/contracts/stake/src/lib.rs
+++ b/contracts/stake/src/lib.rs
@@ -19,18 +19,16 @@ pub use stake::Stake;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 
+pub type BlockHeight = u64;
+
 /// Epoch used for stake operations
 pub const EPOCH: u64 = 2160;
 
 /// Maturity of the stake
 pub const MATURITY: u64 = 2 * EPOCH;
 
-/// Validity of the stake
-pub const VALIDITY: u64 = 56 * EPOCH;
-
 /// The minimum amount of (micro)Dusk one can stake.
 pub const MINIMUM_STAKE: u64 = 1_000_000_000;
 
 pub const TX_STAKE: u8 = 0x00;
-pub const TX_EXTEND: u8 = 0x01;
-pub const TX_WITHDRAW: u8 = 0x02;
+pub const TX_WITHDRAW: u8 = 0x01;

--- a/contracts/stake/src/wasm/bridge.rs
+++ b/contracts/stake/src/wasm/bridge.rs
@@ -46,21 +46,15 @@ fn t(bytes: &mut [u8; PAGE_SIZE]) {
 
     match tid {
         TX_STAKE => {
-            let (pk, signature, value, spend_proof): (
+            let (pk, signature, value, created_at, spend_proof): (
                 PublicKey,
                 Signature,
                 u64,
+                BlockHeight,
                 Vec<u8>,
             ) = Canon::decode(&mut source).expect("Failed to parse arguments");
 
-            contract.stake(pk, signature, value, spend_proof);
-        }
-
-        TX_EXTEND => {
-            let (pk, signature): (PublicKey, Signature) =
-                Canon::decode(&mut source).expect("Failed to parse arguments");
-
-            contract.extend(pk, signature);
+            contract.stake(pk, signature, value, created_at, spend_proof);
         }
 
         TX_WITHDRAW => {

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-recovery"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 autobins = false
 description = "Tool to restore Rusk to factory settings"

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -24,8 +24,6 @@ use zip::ZipArchive;
 
 /// Initial amount of the note inserted in the state.
 const GENESIS_DUSK: u64 = 1_000_000_000; // 1000 Dusk.
-/// The number of blocks after which the genesis stake expires.
-const GENESIS_EXPIRATION: u64 = 1_000_000;
 
 fn diskbackend() -> BackendCtor<DiskBackend> {
     BackendCtor::new(|| {
@@ -73,7 +71,7 @@ fn genesis_transfer() -> TransferContract {
 fn genesis_stake() -> StakeContract {
     let mut stake_contract = StakeContract::default();
 
-    let stake = Stake::new(MINIMUM_STAKE, 0, GENESIS_EXPIRATION);
+    let stake = Stake::with_eligibility(MINIMUM_STAKE, 0, 0);
 
     for provisioner in PROVISIONERS.iter() {
         stake_contract

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -77,7 +77,7 @@ fn genesis_stake() -> StakeContract {
 
     for provisioner in PROVISIONERS.iter() {
         stake_contract
-            .push_stake(*provisioner, stake)
+            .push_stake(*provisioner, stake, 0)
             .expect("Genesis stake to be pushed to the stake");
     }
 

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 [dependencies]

--- a/rusk-wallet/src/lib/clients.rs
+++ b/rusk-wallet/src/lib/clients.rs
@@ -300,7 +300,7 @@ impl StateClient for State {
         Ok(branch)
     }
 
-    /// Queries the node the amount staked by a key and its expiration.
+    /// Queries the node for the amount staked by a key.
     fn fetch_stake(&self, pk: &PublicKey) -> Result<(u64, u64), Self::Error> {
         let msg = GetStakeRequest {
             pk: pk.to_bytes().to_vec(),
@@ -314,6 +314,7 @@ impl StateClient for State {
         })?
         .into_inner();
 
-        Ok((res.stake, res.expiration))
+        // TODO return a proper value here
+        Ok((res.value, 0))
     }
 }

--- a/rusk/src/lib/services/state.rs
+++ b/rusk/src/lib/services/state.rs
@@ -352,9 +352,9 @@ impl State for Rusk {
                 let public_key_bls = key.to_bytes().to_vec();
 
                 let stake = StakeProto {
-                    start_height: stake.eligibility(),
-                    end_height: stake.expiration(),
-                    amount: stake.value(),
+                    value: stake.value(),
+                    created_at: stake.created_at(),
+                    eligibility: stake.eligibility(),
                 };
 
                 Provisioner {
@@ -451,8 +451,11 @@ impl State for Rusk {
 
         let stake = self.state()?.fetch_stake(&pk)?;
 
-        let (stake, expiration) = (stake.value(), stake.expiration());
-        Ok(Response::new(GetStakeResponse { stake, expiration }))
+        Ok(Response::new(GetStakeResponse {
+            value: stake.value(),
+            created_at: stake.created_at(),
+            eligibility: stake.eligibility(),
+        }))
     }
 
     async fn find_existing_nullifiers(

--- a/rusk/tests/services/state_service.rs
+++ b/rusk/tests/services/state_service.rs
@@ -121,9 +121,9 @@ fn generate_stake(rusk: &mut Rusk) -> Result<(BlsPublicKey, Stake)> {
     let mut rusk_state = rusk.state()?;
     let mut stake_contract = rusk_state.stake_contract()?;
 
-    let stake = Stake::new(0xdead, 0xdead, 0xbeef);
+    let stake = Stake::with_eligibility(0xdead, 0, 0);
 
-    stake_contract.push_stake(pk, stake)?;
+    stake_contract.push_stake(pk, stake, 0)?;
 
     info!("Updating the new stake contract state");
 
@@ -283,8 +283,9 @@ pub async fn test_fetch_stake() -> Result<()> {
 
     let response = client.get_stake(request).await?.into_inner();
 
-    assert_eq!(stake.value(), response.stake);
-    assert_eq!(stake.expiration(), response.expiration);
+    assert_eq!(stake.value(), response.value);
+    assert_eq!(stake.created_at(), response.created_at);
+    assert_eq!(stake.eligibility(), response.eligibility);
 
     Ok(())
 }

--- a/rusk/tests/services/transactions.rs
+++ b/rusk/tests/services/transactions.rs
@@ -441,7 +441,7 @@ impl wallet::StateClient for TestStateClient {
         Ok(nullifiers)
     }
 
-    /// Queries the node the amount staked by a key and its expiration.
+    /// Queries the node the amount staked by a key.
     fn fetch_stake(&self, _pk: &PublicKey) -> Result<(u64, u64), Self::Error> {
         unimplemented!()
     }
@@ -567,7 +567,7 @@ pub async fn wallet_grpc() -> Result<()> {
     info!("Root after reset: {:?}", hex::encode(state.root()));
     assert_eq!(original_root, state.root(), "Root be the same again");
 
-    wallet_transfer(&wallet, channel.clone(), 1_000);
+    wallet_transfer(&wallet, channel, 1_000);
 
     // Check the state's root is back to the original one
     info!(

--- a/schema/stake.proto
+++ b/schema/stake.proto
@@ -4,9 +4,9 @@ package rusk;
 import "transaction.proto";
 
 message Stake {
-    fixed64 amount = 1;
-    fixed64 start_height = 2;
-    fixed64 end_height = 3;
+    fixed64 value = 1;
+    fixed64 created_at = 2;
+    fixed64 eligibility = 3;
 }
 
 message StakeTransactionRequest {

--- a/schema/state.proto
+++ b/schema/state.proto
@@ -88,8 +88,9 @@ message GetStakeRequest {
 }
 
 message GetStakeResponse {
-    fixed64 stake = 1;
-    fixed64 expiration = 2;
+    fixed64 value = 1;
+    fixed64 created_at = 2;
+    fixed64 eligibility = 3;
 }
 
 message FindExistingNullifiersRequest {


### PR DESCRIPTION
 stake: change contract to new specification

- Expiration is deprecated, and all associated functionality is removed.
- The messages to sign are changed, with the notable addition of
  `created_at` - meant to be similar but not equal to the block height.
  This is done since it is effectively impossible to sign and prove the
  transaction in the timespan of a single block.
    
Resolves: #566 