### PR TITLE
Wallet: Enhance `export` command

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2022-02-17
+
+### Changed
+- Default to current wallet directory for exported keys [#574]
+- Add an additional plain text file with the base58-encoded public key [#574]
+
+## [0.3.0] - 2022-02-17
+
+### Removed
+- Stake expiration [#566]
+
 ## [0.2.4] - 2022-02-15
 
 ### Added
@@ -91,4 +102,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#539]: https://github.com/dusk-network/rusk/issues/539
 [#547]: https://github.com/dusk-network/rusk/issues/547
 [#554]: https://github.com/dusk-network/rusk/issues/554
+[#566]: https://github.com/dusk-network/rusk/issues/566
 [#569]: https://github.com/dusk-network/rusk/issues/569
+[#574]: https://github.com/dusk-network/rusk/issues/574

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [dependencies]

--- a/rusk-wallet/README.md
+++ b/rusk-wallet/README.md
@@ -34,6 +34,7 @@ SUBCOMMANDS:
     export            Export BLS provisioner key pair
     interactive       Run in interactive mode (default)
     help              Print this message or the help of the given subcommand(s)
+```
 
 ## Good to know
 

--- a/rusk-wallet/src/lib/store.rs
+++ b/rusk-wallet/src/lib/store.rs
@@ -139,6 +139,17 @@ impl LocalStore {
 
         Some(String::from(name))
     }
+
+    /// Returns current directory for this store
+    pub fn dir(&self) -> Option<String> {
+        let mut p = self.path.clone();
+        if p.pop() {
+            let dir = p.as_os_str().to_str()?;
+            Some(String::from(dir))
+        } else {
+            None
+        }
+    }
 }
 
 impl fmt::Debug for LocalStore {

--- a/rusk-wallet/src/main.rs
+++ b/rusk-wallet/src/main.rs
@@ -41,7 +41,7 @@ pub(crate) const RUSK_SOCKET: &str = "/tmp/rusk_listener";
 #[derive(Parser)]
 #[clap(name = "Dusk Wallet CLI")]
 #[clap(author = "Dusk Network B.V.")]
-#[clap(version = "0.2.4")]
+#[clap(version = "0.3.1")]
 #[clap(about = "A user-friendly, reliable command line interface to the Dusk wallet!", long_about = None)]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 //#[clap(global_setting(AppSettings::SubcommandRequiredElseHelp))]


### PR DESCRIPTION
**Enhance `export` command**
- Default to current wallet directory for exported keys.
- Add an additional plain text file with the base58-encoded public key.

Resolves: #574