### PR TITLE
Add working stake test

### DIFF
--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -42,7 +42,7 @@ canonical_derive = "0.6"
 dusk-bytes = "0.1"
 dusk-bls12_381 = "0.8"
 dusk-bls12_381-sign = "0.1.0-rc"
-clap = { version = "3.0", features = ["cargo", "env", "derive"] }
+clap = { version = "3.1", features = ["cargo", "env", "derive"] }
 thiserror = "1.0"
 console = "0.12"
 tracing = "0.1"

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.5"
 edition = "2021"
 
 [dependencies]
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1", features = ["derive"] }
 tokio = { version = "1.15", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -23,7 +23,7 @@ bs58 = "0.4"
 rand = "0.8"
 aes = "0.7"
 
-dusk-wallet-core = "0.10.0-rc"
+dusk-wallet-core = "0.11.0-rc"
 canonical = "0.6"
 dusk-bytes = "0.1"
 dusk-pki = "0.9.0-rc"

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.2.5"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/rusk-wallet/src/lib/clients.rs
+++ b/rusk-wallet/src/lib/clients.rs
@@ -13,7 +13,7 @@ use dusk_plonk::prelude::Proof;
 use dusk_poseidon::tree::PoseidonBranch;
 use dusk_schnorr::Signature;
 use dusk_wallet_core::{
-    ProverClient, StateClient, Transaction, UnprovenTransaction,
+    ProverClient, StakeInfo, StateClient, Transaction, UnprovenTransaction,
     POSEIDON_TREE_DEPTH,
 };
 use phoenix_core::{Crossover, Fee, Note};
@@ -301,7 +301,7 @@ impl StateClient for State {
     }
 
     /// Queries the node for the amount staked by a key.
-    fn fetch_stake(&self, pk: &PublicKey) -> Result<(u64, u64), Self::Error> {
+    fn fetch_stake(&self, pk: &PublicKey) -> Result<StakeInfo, Self::Error> {
         let msg = GetStakeRequest {
             pk: pk.to_bytes().to_vec(),
         };
@@ -314,7 +314,17 @@ impl StateClient for State {
         })?
         .into_inner();
 
-        // TODO return a proper value here
-        Ok((res.value, 0))
+        Ok(StakeInfo {
+            value: res.value,
+            eligibility: res.eligibility,
+            created_at: res.created_at,
+        })
+    }
+
+    fn fetch_block_height(&self) -> Result<u64, Self::Error> {
+        // FIXME a value of zero entails that someone is only able to stake and
+        //  withdraw only once for a particular key. This should be fixed once
+        //  there is a way to query the node for the current block height.
+        Ok(0)
     }
 }

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -38,7 +38,7 @@ dusk-bls12_381-sign = { version = "0.1.0-rc", features = ["canon"] }
 dusk-jubjub = { version = "0.10", features = ["canon"] }
 dusk-pki = "0.9.0-rc"
 dusk-bytes = "0.1"
-dusk-wallet-core = "0.10.0-rc"
+dusk-wallet-core = "0.11.0-rc"
 dusk-abi = "0.10"
 rusk-vm = { version = "0.10.0-rc", features = ["persistence"] }
 phoenix-core = "0.15.0-rc"

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1.15", features = ["rt-multi-thread", "time", "fs", "macros
 async-stream = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", features = ["fmt", "env-filter"] }
-clap = { version = "3.0", features = ["env"] }
+clap = { version = "3.1", features = ["env"] }
 prost = "0.9"
 futures = "0.3"
 anyhow = "1.0"

--- a/rusk/src/bin/config.rs
+++ b/rusk/src/bin/config.rs
@@ -8,7 +8,7 @@ pub mod grpc;
 pub mod kadcast;
 pub mod wallet;
 
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 use serde::{Deserialize, Serialize};
 
 use self::{grpc::GrpcConfig, kadcast::KadcastConfig, wallet::WalletConfig};
@@ -61,11 +61,11 @@ impl From<ArgMatches> for Config {
 }
 
 impl Config {
-    pub fn inject_args(app: App<'_>) -> App<'_> {
-        let app = KadcastConfig::inject_args(app);
-        let app = GrpcConfig::inject_args(app);
-        let app = WalletConfig::inject_args(app);
-        app.arg(
+    pub fn inject_args(command: Command<'_>) -> Command<'_> {
+        let command = KadcastConfig::inject_args(command);
+        let command = GrpcConfig::inject_args(command);
+        let command = WalletConfig::inject_args(command);
+        command.arg(
             Arg::new("log-level")
                 .long("log-level")
                 .value_name("LOG")

--- a/rusk/src/bin/config/grpc.rs
+++ b/rusk/src/bin/config/grpc.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -49,37 +49,40 @@ impl GrpcConfig {
             self.socket = socket.into();
         }
     }
-    pub fn inject_args(app: App<'_>) -> App<'_> {
-        app.arg(
-            Arg::new("socket")
-                .short('s')
-                .long("socket")
-                .value_name("socket")
-                .help("Path for setting up the UDS ")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new("ipc_method")
-                .long("ipc_method")
-                .value_name("ipc_method")
-                .possible_values(&["uds", "tcp_ip"])
-                .help("Inter-Process communication protocol you want to use ")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new("port")
-                .short('p')
-                .long("port")
-                .value_name("port")
-                .help("Port you want to use ")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new("host")
-                .short('h')
-                .long("host")
-                .value_name("host")
-                .takes_value(true),
-        )
+    pub fn inject_args(command: Command<'_>) -> Command<'_> {
+        command
+            .arg(
+                Arg::new("socket")
+                    .short('s')
+                    .long("socket")
+                    .value_name("socket")
+                    .help("Path for setting up the UDS ")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::new("ipc_method")
+                    .long("ipc_method")
+                    .value_name("ipc_method")
+                    .possible_values(&["uds", "tcp_ip"])
+                    .help(
+                        "Inter-Process communication protocol you want to use ",
+                    )
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::new("port")
+                    .short('p')
+                    .long("port")
+                    .value_name("port")
+                    .help("Port you want to use ")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::new("host")
+                    .short('h')
+                    .long("host")
+                    .value_name("host")
+                    .takes_value(true),
+            )
     }
 }

--- a/rusk/src/bin/config/kadcast.rs
+++ b/rusk/src/bin/config/kadcast.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 use kadcast::config::Config;
 use serde::{Deserialize, Serialize};
 
@@ -36,8 +36,8 @@ impl KadcastConfig {
         self.0.auto_propagate = matches.is_present("kadcast_autobroadcast");
     }
 
-    pub fn inject_args(app: App<'_>) -> App<'_> {
-        app.arg(
+    pub fn inject_args(command: Command<'_>) -> Command<'_> {
+        command.arg(
             Arg::new("kadcast_public_address")
                 .long("kadcast_public_address")
                 .long_help("This is the address where other peer can contact you. 

--- a/rusk/src/bin/config/wallet.rs
+++ b/rusk/src/bin/config/wallet.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 use dusk_bytes::DeserializableSlice;
 use dusk_pki::PublicSpendKey;
 use serde::{Deserialize, Serialize};
@@ -39,8 +39,8 @@ impl WalletConfig {
         }
     }
 
-    pub fn inject_args(app: App<'_>) -> App<'_> {
-        app.arg(
+    pub fn inject_args(command: Command<'_>) -> Command<'_> {
+        command.arg(
             Arg::new("generator")
                 .long("generator")
                 .value_name("Generator Key")

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -10,7 +10,7 @@ mod services;
 mod unix;
 mod version;
 
-use clap::{App, Arg};
+use clap::{Arg, Command};
 use rusk::services::network::KadcastDispatcher;
 use rusk::services::network::NetworkServer;
 use rusk::services::pki::{KeysServer, RuskKeys};
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let crate_info = get_version_info!();
     let crate_name = &crate_info.crate_name.to_string();
     let version = show_version(crate_info);
-    let app = App::new(crate_name)
+    let command = Command::new(crate_name)
         .version(version.as_str())
         .author("Dusk Network B.V. All Rights Reserved.")
         .about("Rusk Server node.")
@@ -50,8 +50,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .takes_value(true)
                 .required(false),
         );
-    let app = Config::inject_args(app);
-    let config = Config::from(app.get_matches());
+    let command = Config::inject_args(command);
+    let config = Config::from(command.get_matches());
 
     // Match tracing desired level.
     let log = match &config.log_level[..] {

--- a/rusk/tests/services/mod.rs
+++ b/rusk/tests/services/mod.rs
@@ -6,5 +6,6 @@
 
 pub mod pki_service;
 pub mod prover_service;
+pub mod stake;
 pub mod state_service;
-pub mod transactions;
+pub mod transfer;

--- a/rusk/tests/services/prover_service.rs
+++ b/rusk/tests/services/prover_service.rs
@@ -13,8 +13,8 @@ use dusk_plonk::prelude::*;
 use dusk_poseidon::tree::PoseidonBranch;
 use dusk_schnorr::Signature;
 use dusk_wallet_core::{
-    ProverClient as WalletProverClient, StateClient, Store, Transaction,
-    UnprovenTransaction, Wallet, POSEIDON_TREE_DEPTH,
+    ProverClient as WalletProverClient, StakeInfo, StateClient, Store,
+    Transaction, UnprovenTransaction, Wallet, POSEIDON_TREE_DEPTH,
 };
 use parking_lot::Mutex;
 use phoenix_core::{Crossover, Fee};
@@ -200,7 +200,7 @@ impl StateClient for TestStateClient {
         Ok(self.opening.clone())
     }
 
-    fn fetch_stake(&self, _pk: &PublicKey) -> Result<(u64, u64), Self::Error> {
+    fn fetch_stake(&self, _pk: &PublicKey) -> Result<StakeInfo, Self::Error> {
         unimplemented!();
     }
 
@@ -209,6 +209,10 @@ impl StateClient for TestStateClient {
         _nullifiers: &[BlsScalar],
     ) -> Result<Vec<BlsScalar>, Self::Error> {
         Ok(self.nullifiers.clone())
+    }
+
+    fn fetch_block_height(&self) -> Result<u64, Self::Error> {
+        unimplemented!()
     }
 }
 

--- a/rusk/tests/services/stake.rs
+++ b/rusk/tests/services/stake.rs
@@ -1,0 +1,605 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::common::*;
+use canonical::{Canon, Source};
+use dusk_bls12_381_sign::{PublicKey, SecretKey};
+use dusk_pki::{SecretSpendKey, ViewKey};
+use dusk_schnorr::Signature;
+use parking_lot::Mutex;
+use rusk::services::network::{KadcastDispatcher, NetworkServer};
+use rusk::services::prover::{
+    ExecuteProverRequest, StctProverRequest, WfctProverRequest,
+};
+use rusk::services::rusk_proto::network_client::NetworkClient;
+use rusk::services::rusk_proto::prover_client::ProverClient;
+use rusk::services::rusk_proto::state_client::StateClient;
+use rusk::services::rusk_proto::{
+    PropagateMessage, Transaction as TransactionProto,
+};
+use rusk::services::state::{
+    ExecuteStateTransitionRequest, FindExistingNullifiersRequest,
+    GetAnchorRequest, GetNotesOwnedByRequest, GetOpeningRequest,
+    GetStakeRequest, PreverifyRequest, StateTransitionRequest,
+    VerifyStateTransitionRequest,
+};
+use stake_contract::Stake;
+
+use dusk_bytes::{DeserializableSlice, Serializable, Write};
+
+use once_cell::sync::Lazy;
+use rand::prelude::*;
+use rand::rngs::StdRng;
+use rusk::error::Error;
+use rusk::{Result, Rusk};
+
+use microkelvin::{BackendCtor, DiskBackend};
+
+use tracing::info;
+
+use tonic::transport::Server;
+
+use rusk::services::prover::{ProverServer, RuskProver};
+use rusk::services::state::StateServer;
+
+use dusk_wallet_core::{
+    self as wallet, StakeInfo, Store, Transaction, UnprovenTransaction,
+};
+
+use phoenix_core::{Crossover, Fee, Note};
+
+use dusk_bls12_381::BlsScalar;
+use dusk_jubjub::{JubJubAffine, JubJubScalar};
+use dusk_plonk::proof_system::Proof;
+
+use dusk_poseidon::tree::PoseidonBranch;
+use rusk_abi::POSEIDON_TREE_DEPTH;
+
+const BLOCK_HEIGHT: u64 = 1;
+const BLOCK_GAS_LIMIT: u64 = 100_000_000_000;
+const INITIAL_BALANCE: u64 = 10_000_000_000;
+const MAX_NOTES: u64 = 10;
+const GAS_LIMIT: u64 = 5_000_000_000;
+
+// Function used to creates a temporary diskbackend for Rusk
+fn testbackend() -> BackendCtor<DiskBackend> {
+    BackendCtor::new(DiskBackend::ephemeral)
+}
+
+// Creates the Rusk initial state for the tests below
+fn initial_state() -> Result<Rusk> {
+    let state_id = rusk_recovery_tools::state::deploy(&testbackend())?;
+
+    let mut rusk = Rusk::builder(testbackend).id(state_id).build()?;
+
+    let state = rusk.state()?;
+    let transfer = state.transfer_contract()?;
+
+    assert!(
+        transfer.get_note(0)?.is_some(),
+        "Expect to have one note at the genesis state",
+    );
+
+    assert!(
+        transfer.get_note(1)?.is_none(),
+        "Expect to have ONLY one note at the genesis state",
+    );
+
+    generate_notes(&mut rusk)?;
+    generate_stake(&mut rusk)?;
+
+    let transfer = state.transfer_contract()?;
+
+    assert!(transfer.get_note(1)?.is_some(), "Expect to have more notes",);
+    assert!(
+        transfer.get_note(MAX_NOTES + 1)?.is_none(),
+        "Expect to have only {} notes",
+        MAX_NOTES
+    );
+
+    rusk.state()?.finalize();
+
+    Ok(rusk)
+}
+
+static STATE_LOCK: Lazy<Mutex<Rusk>> = Lazy::new(|| {
+    let rusk = initial_state().expect("Failed to create initial state");
+    Mutex::new(rusk)
+});
+
+static SSK: Lazy<SecretSpendKey> = Lazy::new(|| {
+    info!("Generating SecretSpendKey");
+    TestStore.retrieve_ssk(0).expect("Should not fail in test")
+});
+
+static SK: Lazy<SecretKey> = Lazy::new(|| {
+    info!("Generating BLS SecretKey");
+    TestStore.retrieve_sk(0).expect("Should not fail in test")
+});
+
+fn generate_notes(rusk: &mut Rusk) -> Result<()> {
+    info!("Generating a note");
+    let mut rng = StdRng::seed_from_u64(0xdead);
+
+    let psk = SSK.public_spend_key();
+
+    let note = Note::transparent(&mut rng, &psk, INITIAL_BALANCE);
+
+    let mut rusk_state = rusk.state()?;
+    let mut transfer = rusk_state.transfer_contract()?;
+
+    for _ in 0..MAX_NOTES {
+        transfer.push_note(BLOCK_HEIGHT, note)?;
+    }
+
+    transfer.update_root()?;
+
+    info!("Updating the new transfer contract state");
+    unsafe {
+        rusk_state
+            .set_contract_state(&rusk_abi::transfer_contract(), &transfer)?;
+    }
+
+    rusk_state.finalize();
+
+    Ok(())
+}
+
+fn generate_stake(rusk: &mut Rusk) -> Result<()> {
+    info!("Generating a stake");
+
+    let pk = PublicKey::from(&*SK);
+
+    let mut rusk_state = rusk.state()?;
+    let mut stake = rusk_state.stake_contract()?;
+
+    stake.push_stake(pk, Stake::with_eligibility(1_000_000_000, 0, 0), 0)?;
+
+    info!("Updating the new stake contract state");
+    unsafe {
+        rusk_state.set_contract_state(&rusk_abi::stake_contract(), &stake)?;
+    }
+
+    rusk_state.finalize();
+
+    Ok(())
+}
+
+/// Stakes an amount Dusk and produces a block with this single transaction,
+/// checking the stake is set successfully. It then proceeds to withdraw the
+/// stake and checking it is correctly withdrawn.
+fn wallet_stake(
+    wallet: &wallet::Wallet<TestStore, TestStateClient, TestProverClient>,
+    channel: tonic::transport::Channel,
+    amount: u64,
+) {
+    // Sender psk
+    let psk = SSK.public_spend_key();
+
+    let mut rng = StdRng::seed_from_u64(0xdead);
+
+    wallet.get_stake(0).expect("stake to not be found");
+
+    let tx = wallet
+        .stake(&mut rng, 0, 1, &psk, amount, GAS_LIMIT, 1)
+        .expect("Failed to stake");
+    generator_procedure(channel.clone(), &tx)
+        .expect("generator procedure to succeed");
+
+    let stake = wallet.get_stake(1).expect("stake to be found");
+
+    assert_eq!(stake.value, amount);
+
+    let _ = wallet.get_stake(0).expect("stake to be found");
+
+    let tx = wallet
+        .withdraw_stake(&mut rng, 0, 0, &psk, GAS_LIMIT, 1)
+        .expect("Failed to withdraw stake");
+    generator_procedure(channel, &tx).expect("generator procedure to succeed");
+
+    wallet.get_stake(0).expect_err("stake is still in state");
+}
+
+/// Executes the procedure a block generator will go through to generate a block
+/// including a single transfer transaction, checking the outputs are as
+/// expected.
+fn generator_procedure(
+    channel: tonic::transport::Channel,
+    tx: &Transaction,
+) -> Result<()> {
+    let tx_hash = tx.hash();
+    let tx_bytes = tx.to_var_bytes();
+
+    let tx = TransactionProto {
+        version: 1,
+        r#type: 1,
+        payload: tx_bytes,
+    };
+
+    let mut client = StateClient::new(channel);
+
+    let response = client
+        .preverify(PreverifyRequest {
+            tx: Some(tx.clone()),
+        })
+        .wait()?
+        .into_inner();
+
+    assert_eq!(
+        response.tx_hash,
+        tx_hash.to_bytes().to_vec(),
+        "Hash mismatch"
+    );
+
+    info!("First call to execute_state_transition");
+
+    let response = client
+        .execute_state_transition(ExecuteStateTransitionRequest {
+            txs: vec![tx],
+            block_height: BLOCK_HEIGHT,
+            block_gas_limit: BLOCK_GAS_LIMIT,
+        })
+        .wait()?
+        .into_inner();
+
+    assert_eq!(response.txs.len(), 2, "Should have two tx");
+
+    let transfer_txs: Vec<_> = response
+        .txs
+        .iter()
+        .filter(|etx| etx.tx.as_ref().unwrap().r#type == 1)
+        .collect();
+
+    let coinbase_txs: Vec<_> = response
+        .txs
+        .iter()
+        .filter(|etx| etx.tx.as_ref().unwrap().r#type == 0)
+        .collect();
+
+    assert_eq!(transfer_txs.len(), 1, "Only one transfer tx");
+    assert_eq!(coinbase_txs.len(), 1, "One coinbase tx");
+
+    assert_eq!(
+        transfer_txs[0].tx_hash,
+        tx_hash.to_bytes().to_vec(),
+        "Hash mismatch"
+    );
+
+    let execute_state_root = response.state_root.clone();
+
+    info!(
+        "execute_state_transition new root: {:?}",
+        hex::encode(&execute_state_root)
+    );
+
+    let mut txs = vec![];
+    txs.extend(transfer_txs);
+    txs.extend(coinbase_txs);
+
+    let txs: Vec<_> = txs
+        .iter()
+        .map(|tx| tx.tx.as_ref().unwrap())
+        .cloned()
+        .collect();
+
+    client
+        .verify_state_transition(VerifyStateTransitionRequest {
+            txs: txs.clone(),
+            block_height: BLOCK_HEIGHT,
+            block_gas_limit: BLOCK_GAS_LIMIT,
+        })
+        .wait()?;
+
+    let response = client
+        .accept(StateTransitionRequest {
+            txs,
+            block_height: BLOCK_HEIGHT,
+            block_gas_limit: BLOCK_GAS_LIMIT,
+            state_root: execute_state_root.clone(),
+        })
+        .wait()?
+        .into_inner();
+
+    assert_eq!(response.txs.len(), 1, "Should have one tx");
+
+    let accept_state_root = response.state_root;
+    info!("accept new root: {:?}", hex::encode(&accept_state_root));
+
+    assert_eq!(
+        accept_state_root, execute_state_root,
+        "Root should be equal"
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct TestStore;
+
+impl wallet::Store for TestStore {
+    type Error = ();
+
+    fn get_seed(&self) -> Result<[u8; 64], Self::Error> {
+        Ok([0; 64])
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TestStateClient {
+    channel: tonic::transport::Channel,
+}
+
+impl wallet::StateClient for TestStateClient {
+    type Error = Error;
+
+    /// Find notes for a view key, starting from the given block height.
+    fn fetch_notes(
+        &self,
+        height: u64,
+        vk: &ViewKey,
+    ) -> Result<Vec<Note>, Self::Error> {
+        let mut client = StateClient::new(self.channel.clone());
+
+        let request = tonic::Request::new(GetNotesOwnedByRequest {
+            height,
+            vk: vk.to_bytes().to_vec(),
+        });
+
+        let response = client.get_notes_owned_by(request).wait()?;
+
+        response
+            .into_inner()
+            .notes
+            .iter()
+            .map(|n| Note::from_slice(n).map_err(Error::Serialization))
+            .collect()
+    }
+
+    /// Fetch the current anchor of the state.
+    fn fetch_anchor(&self) -> Result<BlsScalar, Self::Error> {
+        let mut client = StateClient::new(self.channel.clone());
+
+        let request = tonic::Request::new(GetAnchorRequest {});
+
+        let response = client.get_anchor(request).wait()?;
+
+        BlsScalar::from_slice(&response.into_inner().anchor)
+            .map_err(Error::Serialization)
+    }
+
+    /// Queries the node to find the opening for a specific note.
+    fn fetch_opening(
+        &self,
+        note: &Note,
+    ) -> Result<PoseidonBranch<POSEIDON_TREE_DEPTH>, Self::Error> {
+        let mut client = StateClient::new(self.channel.clone());
+
+        let request = tonic::Request::new(GetOpeningRequest {
+            note: note.to_bytes().to_vec(),
+        });
+
+        let response = client.get_opening(request).wait()?;
+        let response = response.into_inner();
+
+        let mut source = Source::new(&response.branch);
+        Ok(PoseidonBranch::decode(&mut source)?)
+    }
+
+    fn fetch_existing_nullifiers(
+        &self,
+        nullifiers: &[BlsScalar],
+    ) -> Result<Vec<BlsScalar>, Self::Error> {
+        let mut client = StateClient::new(self.channel.clone());
+
+        let request = FindExistingNullifiersRequest {
+            nullifiers: nullifiers
+                .iter()
+                .map(|n| n.to_bytes().to_vec())
+                .collect(),
+        };
+
+        let response = client
+            .find_existing_nullifiers(request)
+            .wait()?
+            .into_inner();
+
+        let nullifiers = response
+            .nullifiers
+            .into_iter()
+            .map(|n| BlsScalar::from_slice(&n).map_err(Error::Serialization))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(nullifiers)
+    }
+
+    /// Queries the node the amount staked by a key and its expiration.
+    fn fetch_stake(&self, pk: &PublicKey) -> Result<StakeInfo, Self::Error> {
+        let mut client = StateClient::new(self.channel.clone());
+
+        let request = GetStakeRequest {
+            pk: pk.to_bytes().to_vec(),
+        };
+
+        let response = client.get_stake(request).wait()?.into_inner();
+
+        Ok(StakeInfo {
+            value: response.value,
+            eligibility: response.eligibility,
+            created_at: response.created_at,
+        })
+    }
+
+    fn fetch_block_height(&self) -> Result<u64, Self::Error> {
+        Ok(BLOCK_HEIGHT)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TestProverClient {
+    channel: tonic::transport::Channel,
+}
+
+impl wallet::ProverClient for TestProverClient {
+    type Error = Error;
+    /// Requests that a node prove the given transaction and later propagates it
+    fn compute_proof_and_propagate(
+        &self,
+        utx: &UnprovenTransaction,
+    ) -> Result<Transaction, Self::Error> {
+        let mut client = ProverClient::new(self.channel.clone());
+
+        let response = client
+            .prove_execute(ExecuteProverRequest {
+                utx: utx.to_var_bytes(),
+            })
+            .wait()?
+            .into_inner();
+
+        let proof =
+            Proof::from_slice(&response.proof).map_err(Error::Serialization)?;
+        let tx = utx.clone().prove(proof);
+
+        let propagate_request = tonic::Request::new(PropagateMessage {
+            message: tx.to_var_bytes(),
+        });
+
+        let mut network_client = NetworkClient::new(self.channel.clone());
+        let _ = network_client.propagate(propagate_request).wait()?;
+
+        Ok(tx)
+    }
+
+    /// Requests an STCT proof.
+    #[allow(unused_must_use)]
+    fn request_stct_proof(
+        &self,
+        fee: &Fee,
+        crossover: &Crossover,
+        value: u64,
+        blinder: JubJubScalar,
+        address: BlsScalar,
+        signature: Signature,
+    ) -> Result<Proof, Self::Error> {
+        let size = Fee::SIZE
+            + Crossover::SIZE
+            + u64::SIZE
+            + JubJubScalar::SIZE
+            + BlsScalar::SIZE
+            + Signature::SIZE;
+
+        let mut circuit_inputs = vec![0; size];
+        let mut writer = &mut circuit_inputs[..];
+
+        writer.write(&fee.to_bytes());
+        writer.write(&crossover.to_bytes());
+        writer.write(&value.to_bytes());
+        writer.write(&blinder.to_bytes());
+        writer.write(&address.to_bytes());
+        writer.write(&signature.to_bytes());
+
+        let mut client = ProverClient::new(self.channel.clone());
+
+        let response = client
+            .prove_stct(StctProverRequest { circuit_inputs })
+            .wait()?
+            .into_inner();
+
+        let proof =
+            Proof::from_slice(&response.proof).map_err(Error::Serialization)?;
+        Ok(proof)
+    }
+
+    /// Request a WFCT proof.
+    #[allow(unused_must_use)]
+    fn request_wfct_proof(
+        &self,
+        commitment: JubJubAffine,
+        value: u64,
+        blinder: JubJubScalar,
+    ) -> Result<Proof, Self::Error> {
+        let size = JubJubAffine::SIZE + u64::SIZE + JubJubScalar::SIZE;
+
+        let mut circuit_inputs = vec![0; size];
+        let mut writer = &mut circuit_inputs[..];
+
+        writer.write(&commitment.to_bytes());
+        writer.write(&value.to_bytes());
+        writer.write(&blinder.to_bytes());
+
+        let mut client = ProverClient::new(self.channel.clone());
+
+        let response = client
+            .prove_wfct(WfctProverRequest { circuit_inputs })
+            .wait()?
+            .into_inner();
+
+        let proof =
+            Proof::from_slice(&response.proof).map_err(Error::Serialization)?;
+        Ok(proof)
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn stake() -> Result<()> {
+    // Setup the logger and gRPC channels
+    let (channel, incoming) = setup().await;
+
+    // Get the Rusk's instance to pass to the `StateServer`
+    let rusk = STATE_LOCK.lock();
+
+    let state = StateServer::new(rusk.clone());
+    let prover = ProverServer::new(RuskProver::default());
+    let dispatcher = KadcastDispatcher::default();
+    let mut kadcast_recv = dispatcher.subscribe();
+    let network = NetworkServer::new(dispatcher);
+
+    // Drop the Rusk instance so it can be re-acquired later on
+    drop(rusk);
+
+    // Build and Spawn the server
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(state)
+            .add_service(prover)
+            .add_service(network)
+            .serve_with_incoming(incoming)
+            .await
+    });
+
+    // Create a wallet
+    let wallet = wallet::Wallet::new(
+        TestStore,
+        TestStateClient {
+            channel: channel.clone(),
+        },
+        TestProverClient {
+            channel: channel.clone(),
+        },
+    );
+
+    let rusk = STATE_LOCK.lock();
+    let state = rusk.state()?;
+    let original_root = state.root();
+
+    info!("Original Root: {:?}", hex::encode(original_root));
+
+    // Perform some staking actions.
+    wallet_stake(&wallet, channel, 1_000_000_000);
+
+    // Check the state's root is changed from the original one
+    let new_root = state.root();
+    info!(
+        "New root after the 1st transfer: {:?}",
+        hex::encode(new_root)
+    );
+    assert_ne!(original_root, new_root, "Root should have changed");
+
+    let recv = kadcast_recv.try_recv();
+    let (_, _, h) = recv.expect("Transaction has not been locally propagated");
+    assert_eq!(h, 0, "Transaction locally propagated with wrong height");
+
+    Ok(())
+}

--- a/rusk/tests/services/transfer.rs
+++ b/rusk/tests/services/transfer.rs
@@ -43,7 +43,7 @@ use rusk::services::prover::{ProverServer, RuskProver};
 use rusk::services::state::StateServer;
 
 use dusk_wallet_core::{
-    self as wallet, Store, Transaction, UnprovenTransaction,
+    self as wallet, StakeInfo, Store, Transaction, UnprovenTransaction,
 };
 
 use phoenix_core::{Crossover, Fee, Note};
@@ -441,8 +441,11 @@ impl wallet::StateClient for TestStateClient {
         Ok(nullifiers)
     }
 
-    /// Queries the node the amount staked by a key.
-    fn fetch_stake(&self, _pk: &PublicKey) -> Result<(u64, u64), Self::Error> {
+    fn fetch_stake(&self, _pk: &PublicKey) -> Result<StakeInfo, Self::Error> {
+        unimplemented!()
+    }
+
+    fn fetch_block_height(&self) -> Result<u64, Self::Error> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
rusk: upgrade to `dusk-wallet-core` `0.11.0`
    
- Add test performing a stake and stake withdrawal transaction and
  passing them through the normal block generator procedure.

Resolves: #560

---
wallet: upgrade to `dusk-wallet-core` `0.11.0`

---
wallet: bump version to `0.3.0`