### PR TITLE
Persist on demand rather than automatically

### DIFF
--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -29,6 +29,7 @@ blake2 = "0.10"
 toml = "0.5"
 serde = "1.0"
 bs58 = "0.4"
+hex = "0.4"
 
 dusk-schnorr = "0.9.0-rc"
 dusk-poseidon = { version = "0.23.0-rc", features = ["canon"] }

--- a/schema/state.proto
+++ b/schema/state.proto
@@ -107,6 +107,12 @@ message RevertResponse {
     bytes state_root = 1;
 }
 
+message PersistRequest {
+    bytes state_root = 1;
+}
+
+message PersistResponse {}
+
 service State {
     rpc Echo(EchoRequest) returns (EchoResponse) {}
     rpc Preverify(PreverifyRequest) returns (PreverifyResponse) {}
@@ -115,6 +121,7 @@ service State {
     rpc Accept(StateTransitionRequest) returns (StateTransitionResponse) {}
     rpc Finalize(StateTransitionRequest) returns (StateTransitionResponse) {}
     rpc Revert(RevertRequest) returns (RevertResponse) {}
+    rpc Persist(PersistRequest) returns (PersistResponse) {}
     rpc GetProvisioners(GetProvisionersRequest) returns (GetProvisionersResponse) {}
     rpc GetStateRoot(GetStateRootRequest) returns (GetStateRootResponse) {}
     rpc GetNotesOwnedBy(GetNotesOwnedByRequest) returns (GetNotesOwnedByResponse) {}


### PR DESCRIPTION
rusk: persist on command rather than automatically
    
- Remove `state.persist()` call on `accept`, `finalize`, and `revert`
- Add persist RPC that takes the state root, and calls
  `state.persist()` if the current root matches
    
Resolves: #572
