### PR TITLE
Change denomination to nDusk

### DIFF
--- a/contracts/stake/Cargo.toml
+++ b/contracts/stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stake-contract"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/contracts/stake/src/lib.rs
+++ b/contracts/stake/src/lib.rs
@@ -19,6 +19,8 @@ pub use stake::Stake;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 
+use rusk_abi::dusk::*;
+
 pub type BlockHeight = u64;
 
 /// Epoch used for stake operations
@@ -27,8 +29,8 @@ pub const EPOCH: u64 = 2160;
 /// Maturity of the stake
 pub const MATURITY: u64 = 2 * EPOCH;
 
-/// The minimum amount of (micro)Dusk one can stake.
-pub const MINIMUM_STAKE: u64 = 1_000_000_000;
+/// The minimum amount of Dusk one can stake.
+pub const MINIMUM_STAKE: Dusk = dusk(1_000.0);
 
 pub const TX_STAKE: u8 = 0x00;
 pub const TX_WITHDRAW: u8 = 0x01;

--- a/contracts/stake/tests/stake.rs
+++ b/contracts/stake/tests/stake.rs
@@ -7,13 +7,14 @@
 use dusk_bls12_381_sign::{PublicKey, SecretKey};
 use dusk_pki::Ownable;
 use phoenix_core::Note;
+use rusk_abi::dusk::*;
 use stake_contract::{Stake, StakeContract, MINIMUM_STAKE};
 use transfer_circuits::SendToContractTransparentCircuit;
 use transfer_wrapper::TransferWrapper;
 
 #[test]
 fn stake() {
-    let genesis_value = 50_000_000_000;
+    let genesis_value = dusk(50_000.0);
     let mut wrapper = TransferWrapper::new(0xbeef, genesis_value);
 
     let (genesis_ssk, unspent_note) = wrapper.genesis_identifier();

--- a/contracts/transfer/src/wasm/internal.rs
+++ b/contracts/transfer/src/wasm/internal.rs
@@ -12,6 +12,7 @@ use dusk_bls12_381::BlsScalar;
 use dusk_bytes::Serializable;
 use dusk_pki::{PublicKey, StealthAddress};
 use phoenix_core::{Crossover, Fee, Message, Note};
+use rusk_abi::dusk::*;
 use rusk_abi::PublicInput;
 
 impl TransferContract {
@@ -34,11 +35,9 @@ impl TransferContract {
         Ok(())
     }
 
-    /// Minimum accepted price per unit of gas
-    ///
-    /// The gas is always calculated in micro-dusk
-    pub(crate) const fn minimum_gas_price() -> u64 {
-        1
+    /// Minimum accepted price per unit of gas.
+    pub(crate) const fn minimum_gas_price() -> Dusk {
+        LUX
     }
 
     pub(crate) fn root_exists(&self, root: &BlsScalar) -> Result<bool, Error> {

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-abi"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 repository = "https://github.com/dusk-network/rusk"

--- a/rusk-abi/src/dusk.rs
+++ b/rusk-abi/src/dusk.rs
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Dusk denomination.
+
+const DUSK_UNIT: f64 = 1_000_000_000.0;
+
+/// The minimum increment of Dusk.
+pub const LUX: Dusk = dusk(1.0 / DUSK_UNIT);
+
+/// The Dusk denomination. Use the [`dusk`] function to convert from floating
+/// point format, and the [`from_dusk`] function to convert back to Dusk.
+///
+/// Values of Dusk should *never* be assigned directly. Instead they should use
+/// a call to the [`dusk`] function. If increments of the smallest denomination
+/// are desired, the [`LUX`] constant can be used.
+pub type Dusk = u64;
+
+/// Converts from floating point format to Dusk.
+pub const fn dusk(value: f64) -> Dusk {
+    (value * DUSK_UNIT) as Dusk
+}
+
+/// Converts from Dusk to floating point format.
+pub const fn from_dusk(dusk: Dusk) -> f64 {
+    dusk as f64 / DUSK_UNIT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_to_dusk() {
+        let value = 5f64;
+        let dusk_value = dusk(value);
+
+        assert_eq!(value, from_dusk(dusk_value));
+    }
+
+    #[test]
+    fn lux_is_one() {
+        assert_eq!(LUX, 1);
+    }
+}

--- a/rusk-abi/src/lib.rs
+++ b/rusk-abi/src/lib.rs
@@ -15,6 +15,7 @@
 #![warn(missing_docs)]
 #![no_std]
 #![deny(clippy::all)]
+#![feature(const_fn_floating_point_arithmetic)]
 
 pub use dusk_abi::ContractId;
 use dusk_bls12_381::BlsScalar;
@@ -47,6 +48,7 @@ pub fn contract_to_scalar(contract_id: &ContractId) -> BlsScalar {
     )
 }
 
+pub mod dusk;
 #[doc(hidden)]
 pub mod hash;
 

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-recovery"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 autobins = false
 description = "Tool to restore Rusk to factory settings"

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -12,6 +12,7 @@ use microkelvin::{Backend, BackendCtor, DiskBackend};
 use phoenix_core::Note;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rusk_abi::dusk::*;
 use rusk_vm::{Contract, NetworkState, NetworkStateId};
 use stake_contract::{Stake, StakeContract, MINIMUM_STAKE};
 use std::error::Error;
@@ -22,8 +23,8 @@ use tracing::log::error;
 use transfer_contract::TransferContract;
 use zip::ZipArchive;
 
-/// Initial amount of the note inserted in the state.
-const GENESIS_DUSK: u64 = 1_000_000_000; // 1000 Dusk.
+/// Amount of the note inserted in the genesis state.
+const GENESIS_DUSK: Dusk = dusk(1_000.0);
 
 fn diskbackend() -> BackendCtor<DiskBackend> {
     BackendCtor::new(|| {

--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2022-02-17
+
+## Changed
+- Use the Dusk denomination from `rusk-abi` [#582]
+
 ## [0.3.1] - 2022-02-17
 
 ### Changed
@@ -91,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementation of `State` and `Prover` traits from `wallet-core`
 
 
+[#582]: https://github.com/dusk-network/rusk/issues/582
 [#482]: https://github.com/dusk-network/rusk/issues/482
 [#479]: https://github.com/dusk-network/rusk/issues/479
 [#492]: https://github.com/dusk-network/rusk/issues/492

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -34,5 +34,7 @@ dusk-plonk = { version = "^0.9", default-features = false }
 dusk-jubjub = { version = "^0.10", default-features = false }
 dusk-bls12_381-sign = { version = "0.1.0-rc", default-features = false, features = [ "canon" ] }
 
+rusk-abi = { path = "../rusk-abi" }
+
 [build-dependencies]
 tonic-build = "0.6"

--- a/rusk-wallet/src/lib/mod.rs
+++ b/rusk-wallet/src/lib/mod.rs
@@ -11,27 +11,12 @@ pub mod prompt;
 pub mod store;
 pub mod wallet;
 
-// Types that define Dusk's denomination.
-pub type Dusk = f64;
-pub type MicroDusk = u64;
+use rusk_abi::dusk::*;
 
 pub const SEED_SIZE: usize = 64;
 
-pub const ONE_MILLION: Dusk = 1_000_000.0;
+pub(crate) const MAX_CONVERTIBLE: f64 = f64::MAX / dusk(1.0) as f64;
+pub(crate) const MIN_CONVERTIBLE: f64 = from_dusk(LUX);
 
-pub(crate) const DEFAULT_GAS_LIMIT: u64 = 100_000;
-pub(crate) const DEFAULT_GAS_PRICE: Dusk = ONE_MICRO_DUSK;
-
-pub(crate) const MAX_CONVERTIBLE_DUSK: Dusk = Dusk::MAX / ONE_MILLION;
-pub(crate) const ONE_MICRO_DUSK: Dusk = 1_f64 / ONE_MILLION;
-
-/// Convert from Dusk to uDusk
-pub fn to_udusk(dusk: Dusk) -> MicroDusk {
-    (dusk * ONE_MILLION) as MicroDusk
-}
-
-/// Convert from uDusk to Dusk
-pub fn to_dusk(udusk: MicroDusk) -> Dusk {
-    let udusk = udusk as Dusk;
-    udusk / ONE_MILLION
-}
+pub(crate) const DEFAULT_GAS_LIMIT: u64 = 500_000_000;
+pub(crate) const DEFAULT_GAS_PRICE: f64 = from_dusk(LUX);

--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -14,11 +14,12 @@ use serde::Serialize;
 use dusk_bytes::Serializable;
 use dusk_jubjub::BlsScalar;
 use dusk_wallet_core::{Store, Wallet};
+use rusk_abi::dusk::*;
 
 use crate::lib::clients::{Prover, State};
 use crate::lib::crypto::encrypt;
 use crate::lib::store::LocalStore;
-use crate::lib::{prompt, to_dusk, to_udusk, DEFAULT_GAS_PRICE, SEED_SIZE};
+use crate::lib::{prompt, DEFAULT_GAS_PRICE, SEED_SIZE};
 use crate::{CliCommand, Error};
 
 mod base64 {
@@ -94,7 +95,7 @@ impl CliWallet {
                     };
 
                     // prepare command
-                    let cmd = prompt::prepare_command(pcmd, to_dusk(balance));
+                    let cmd = prompt::prepare_command(pcmd, from_dusk(balance));
                     // run command
                     self.run(cmd)?;
                     // wait for a second
@@ -118,7 +119,7 @@ impl CliWallet {
                     println!(
                         "> Balance for key {} is: {} Dusk",
                         key,
-                        to_dusk(balance)
+                        from_dusk(balance)
                     );
                     Ok(())
                 } else {
@@ -158,6 +159,8 @@ impl CliWallet {
                     let mut rng = StdRng::from_entropy();
                     let ref_id = BlsScalar::random(&mut rng);
 
+                    let default_price = dusk(DEFAULT_GAS_PRICE);
+
                     let tx = wallet.transfer(
                         &mut rng,
                         key,
@@ -165,8 +168,7 @@ impl CliWallet {
                         &dest_addr,
                         amt,
                         gas_limit,
-                        gas_price
-                            .unwrap_or_else(|| to_udusk(DEFAULT_GAS_PRICE)),
+                        gas_price.unwrap_or(default_price),
                         ref_id,
                     )?;
 
@@ -191,6 +193,8 @@ impl CliWallet {
                     let my_addr = wallet.public_spend_key(key)?;
                     let mut rng = StdRng::from_entropy();
 
+                    let default_price = dusk(DEFAULT_GAS_PRICE);
+
                     let tx = wallet.stake(
                         &mut rng,
                         key,
@@ -198,8 +202,7 @@ impl CliWallet {
                         &my_addr,
                         amt,
                         gas_limit,
-                        gas_price
-                            .unwrap_or_else(|| to_udusk(DEFAULT_GAS_PRICE)),
+                        gas_price.unwrap_or(default_price),
                     )?;
 
                     let txh = bs58::encode(&tx.hash().to_bytes()).into_string();
@@ -222,14 +225,15 @@ impl CliWallet {
                     let my_addr = wallet.public_spend_key(key)?;
                     let mut rng = StdRng::from_entropy();
 
+                    let default_price = dusk(DEFAULT_GAS_PRICE);
+
                     let tx = wallet.withdraw_stake(
                         &mut rng,
                         key,
                         stake_key,
                         &my_addr,
                         gas_limit,
-                        gas_price
-                            .unwrap_or_else(|| to_udusk(DEFAULT_GAS_PRICE)),
+                        gas_price.unwrap_or(default_price),
                     )?;
 
                     let txh = bs58::encode(&tx.hash().to_bytes()).into_string();

--- a/rusk/src/lib/state.rs
+++ b/rusk/src/lib/state.rs
@@ -16,7 +16,8 @@ use dusk_poseidon::tree::PoseidonBranch;
 use dusk_wallet_core::Transaction;
 use parking_lot::Mutex;
 use phoenix_core::Note;
-use rusk_abi::{self, POSEIDON_TREE_DEPTH};
+use rusk_abi::dusk::*;
+use rusk_abi::POSEIDON_TREE_DEPTH;
 use rusk_vm::{ContractId, GasMeter, NetworkState};
 use stake_contract::{Stake, StakeContract};
 use std::sync::Arc;
@@ -275,14 +276,14 @@ const fn coinbase_value(block_height: u64, gas_spent: u64) -> (u64, u64) {
 /// This implements the emission schedule described in the economic paper.
 const fn emission_amount(block_height: u64) -> u64 {
     match block_height {
-        1..=12_500_000 => 16_000_000,
-        12_500_001..=18_750_000 => 12_800_000,
-        18_750_001..=25_000_000 => 9_600_000,
-        25_000_001..=31_250_000 => 8_000_000,
-        31_250_001..=37_500_000 => 6_400_000,
-        37_500_001..=43_750_000 => 4_800_000,
-        43_750_001..=50_000_000 => 3_200_000,
-        50_000_001..=62_500_000 => 1_600_000,
-        _ => 0,
+        1..=12_500_000 => dusk(16.0),
+        12_500_001..=18_750_000 => dusk(12.8),
+        18_750_001..=25_000_000 => dusk(9.6),
+        25_000_001..=31_250_000 => dusk(8.0),
+        31_250_001..=37_500_000 => dusk(6.4),
+        37_500_001..=43_750_000 => dusk(4.8),
+        43_750_001..=50_000_000 => dusk(3.2),
+        50_000_001..=62_500_000 => dusk(1.6),
+        _ => dusk(0.0),
     }
 }

--- a/rusk/tests/services/stake.rs
+++ b/rusk/tests/services/stake.rs
@@ -26,7 +26,7 @@ use rusk::services::state::{
     GetStakeRequest, PreverifyRequest, StateTransitionRequest,
     VerifyStateTransitionRequest,
 };
-use stake_contract::Stake;
+use stake_contract::{Stake, MINIMUM_STAKE};
 
 use dusk_bytes::{DeserializableSlice, Serializable, Write};
 
@@ -56,11 +56,12 @@ use dusk_jubjub::{JubJubAffine, JubJubScalar};
 use dusk_plonk::proof_system::Proof;
 
 use dusk_poseidon::tree::PoseidonBranch;
+use rusk_abi::dusk::*;
 use rusk_abi::POSEIDON_TREE_DEPTH;
 
 const BLOCK_HEIGHT: u64 = 1;
 const BLOCK_GAS_LIMIT: u64 = 100_000_000_000;
-const INITIAL_BALANCE: u64 = 10_000_000_000;
+const INITIAL_BALANCE: Dusk = dusk(10_000.0);
 const MAX_NOTES: u64 = 10;
 const GAS_LIMIT: u64 = 5_000_000_000;
 
@@ -156,7 +157,7 @@ fn generate_stake(rusk: &mut Rusk) -> Result<()> {
     let mut rusk_state = rusk.state()?;
     let mut stake = rusk_state.stake_contract()?;
 
-    stake.push_stake(pk, Stake::with_eligibility(1_000_000_000, 0, 0), 0)?;
+    stake.push_stake(pk, Stake::with_eligibility(MINIMUM_STAKE, 0, 0), 0)?;
 
     info!("Updating the new stake contract state");
     unsafe {
@@ -587,7 +588,7 @@ pub async fn stake() -> Result<()> {
     info!("Original Root: {:?}", hex::encode(original_root));
 
     // Perform some staking actions.
-    wallet_stake(&wallet, channel, 1_000_000_000);
+    wallet_stake(&wallet, channel, MINIMUM_STAKE);
 
     // Check the state's root is changed from the original one
     let new_root = state.root();


### PR DESCRIPTION
Changes the denomination to nDusk. This is a cross project change, but I try to centralize denomination "logic" in `rusk-abi`. If at some point we want to change this, that is where it would be done.

Resolves: #582