### PR TITLE
wallet: fix interactive wallet selection

### DIFF
--- a/rusk-wallet/src/lib/store.rs
+++ b/rusk-wallet/src/lib/store.rs
@@ -51,6 +51,12 @@ impl LocalStore {
     /// Loads wallet file from file
     pub fn from_file(path: PathBuf, pwd: Hash) -> Result<LocalStore, Error> {
         // basic sanity check
+        let mut path = path;
+        if path.extension().is_none() {
+            path.set_extension("dat");
+        }
+
+        // make sure file exists
         if !path.is_file() {
             return Err(Error::WalletFileNotExists);
         }

--- a/rusk-wallet/src/main.rs
+++ b/rusk-wallet/src/main.rs
@@ -421,21 +421,24 @@ fn interactive(path: PathBuf) -> Result<LocalStore, Error> {
     }
 }
 
-/// Scan data directory and return a list of filenames
+/// Scan data directory and return a list of wallet names
 fn find_wallets(dir: &str) -> Result<Vec<String>, Error> {
-    // scan for wallets
     let dir = fs::read_dir(dir)?;
-    let names = dir
-        .map(|entry| {
-            entry
-                .ok()
-                .and_then(|e| {
-                    e.path()
-                        .file_name()
-                        .and_then(|name| name.to_str().map(String::from))
-                })
-                .unwrap()
+
+    let wallets = dir
+        .filter_map(|el| el.ok().map(|d| d.path()))
+        .filter(|path| path.is_file())
+        .filter(|path| match path.extension() {
+            Some(ext) => ext == "dat",
+            None => false,
         })
-        .collect::<Vec<String>>();
-    Ok(names)
+        .filter_map(|path| {
+            path.file_stem()
+                .map(|stem| stem.to_str())
+                .flatten()
+                .map(String::from)
+        })
+        .collect();
+
+    Ok(wallets)
 }


### PR DESCRIPTION
Prevents interactive wallet selection from displaying non .dat files.

**Note:** It is of course true that one can have a `.dat` file that is not an actual wallet and it will be displayed in the list. However:
1.  We already have the proper checks and errors for that.
2. Reading every file just to display a list seems a bit overkill.
2. Even if we did, files generated with CLI `v0.1` don't have the `magic` prefix that identifies them as a wallet, yet we still support reading them.

Resolves: #585