### PR TITLE
rusk-wallet: Add configuration item to specify the prover URL

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2022-03-01
+
+## Added
+- Optional configuration item to specify the prover URL [#612]
+
 ## [0.5.1] - 2022-02-26
 
 ## Added
@@ -131,3 +136,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#600]: https://github.com/dusk-network/rusk/issues/600
 [#602]: https://github.com/dusk-network/rusk/issues/602
 [#606]: https://github.com/dusk-network/rusk/issues/606
+[#612]: https://github.com/dusk-network/rusk/issues/612

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 [dependencies]

--- a/rusk-wallet/README.md
+++ b/rusk-wallet/README.md
@@ -14,6 +14,8 @@ OPTIONS:
                                        directory
     -a, --rusk-addr <RUSK_ADDR>        Rusk address [default: 127.0.0.1]
     -p, --rusk-port <RUSK_PORT>        Rusk port [default: 8585]
+        --prover-addr <PROVER_ADDR>    Prover service address [default: `rusk_addr`]
+        --prover-port <PROVER_PORT>    Prover service port [default: `rusk_port`]
     -i, --ipc-method <IPC_METHOD>      IPC method for communication with rusk [uds, tcp_ip]
                                        [default: uds]
     -s, --socket-path <SOCKET_PATH>    Path for setting up the unix domain socket [default: /tmp/

--- a/rusk-wallet/src/lib/prompt.rs
+++ b/rusk-wallet/src/lib/prompt.rs
@@ -441,7 +441,7 @@ fn request_rcvr_addr() -> String {
 
 /// Utility function to check if an address is valid
 fn is_valid_addr(addr: &str) -> bool {
-    bs58::decode(addr).into_vec().is_ok() && !addr.is_empty()
+    !addr.is_empty() && bs58::decode(addr).into_vec().is_ok()
 }
 
 /// Checks for a valid dusk denomination


### PR DESCRIPTION
Parameter is optional and defaults to Rusk address as one would expect.

Separation of the Prover service is only supported in TCP mode until there is a solid reason to support it in UDS as well. After all, the point here is targeting a different machine with different hardware altogether.

For debugging purposes in a local environment, the user can still use TCP, which on loopback interfaces and `localhost` addresses is highly optimized by the OS anyways.

Resolves #612 