### PR TITLE
rusk-wallet: Better error mgmt, path handling and UX

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 - Export consensus public key as binary
-- Interactive mode allows for directory and wallet file overriding
-- Rusk error messages are displayed without metadata
-- Paths are now mostly managed using `PathBuf`
+- Interactive mode allows for directory and wallet file overriding [#630]
+- Client errors implemented, Rusk error messages displayed without metadata [#629]
+- Transactions from wallets with no balance are halted immediately [#631]
 
 ## [0.5.2] - 2022-03-01
 
@@ -149,3 +149,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#619]: https://github.com/dusk-network/rusk/issues/619
 [#629]: https://github.com/dusk-network/rusk/issues/629
 [#630]: https://github.com/dusk-network/rusk/issues/630
+[#631]: https://github.com/dusk-network/rusk/issues/631

--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 - Export consensus public key as binary
+- Interactive mode allows for directory and wallet file overriding
+- Rusk error messages are displayed without metadata
+- Paths are now mostly managed using `PathBuf`
 
 ## [0.5.2] - 2022-03-01
 
@@ -144,3 +147,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#606]: https://github.com/dusk-network/rusk/issues/606
 [#612]: https://github.com/dusk-network/rusk/issues/612
 [#619]: https://github.com/dusk-network/rusk/issues/619
+[#629]: https://github.com/dusk-network/rusk/issues/629
+[#630]: https://github.com/dusk-network/rusk/issues/630

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 edition = "2021"
 
 [dependencies]
@@ -11,6 +11,7 @@ serde_json = "1.0"
 block-modes = "0.8"
 tiny-bip39 = "0.8"
 crossterm = "0.22"
+rand_core = "0.6"
 requestty = "0.3"
 base64 = "0.13"
 crypto = "0.3"

--- a/rusk-wallet/src/lib/clients.rs
+++ b/rusk-wallet/src/lib/clients.rs
@@ -34,7 +34,7 @@ use crate::rusk_proto::{
     Transaction as TransactionProto, WfctProverRequest,
 };
 
-use crate::Error;
+use crate::{ProverError, StateError};
 
 const STCT_INPUT_SIZE: usize = Fee::SIZE
     + Crossover::SIZE
@@ -70,7 +70,7 @@ impl Prover {
 
 impl ProverClient for Prover {
     /// Error returned by the prover client.
-    type Error = Error;
+    type Error = ProverError;
 
     /// Requests that a node prove the given transaction and later propagates it
     fn compute_proof_and_propagate(
@@ -92,7 +92,8 @@ impl ProverClient for Prover {
         prompt::status("Proof success!");
 
         prompt::status("Attempt to preverify tx...");
-        let proof = Proof::from_slice(&proof_bytes).map_err(Error::Bytes)?;
+        let proof =
+            Proof::from_slice(&proof_bytes).map_err(ProverError::Bytes)?;
         let tx = utx.clone().prove(proof);
         let tx_bytes = tx.to_var_bytes();
         let tx_proto = TransactionProto {
@@ -216,7 +217,7 @@ impl State {
 /// Types that are clients of the state API.
 impl StateClient for State {
     /// Error returned by the node client.
-    type Error = Error;
+    type Error = StateError;
 
     /// Find notes for a view key, starting from the given block height.
     fn fetch_notes(

--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -5,7 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use std::env;
-use std::path::PathBuf;
 use std::{fs, thread, time::Duration};
 
 use rand::rngs::StdRng;
@@ -316,21 +315,10 @@ impl CliWallet {
                 };
 
                 // output directory
-                let dir = match self.store.dir() {
-                    Some(dir) => dir,
-                    None => {
-                        let home = dirs::home_dir().expect("user home dir");
-                        let home = home
-                            .as_os_str()
-                            .to_str()
-                            .ok_or(Error::WalletFileNotExists)?;
-                        String::from(home)
-                    }
-                };
-
-                // construct path
-                let mut path = PathBuf::new();
-                path.push(&dir);
+                let mut path = self
+                    .store
+                    .dir()
+                    .unwrap_or_else(LocalStore::default_data_dir);
                 path.push(&filename);
                 path.set_extension("key");
 

--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -100,7 +100,7 @@ impl CliWallet {
 
                     // prepare command
                     if let Some(cmd) =
-                        prompt::prepare_command(pcmd, from_dusk(balance))
+                        prompt::prepare_command(pcmd, from_dusk(balance))?
                     {
                         // run command
                         if let Some(txh) = self.run(cmd)? {


### PR DESCRIPTION
#### Error types for all clients have been explicitly defined. 
This allowed us to:
1. Remove the `Box<_>` "hack" for the wallet core errors that carried the generics implementation with them.
2. Implement better error messages in an elegant, organized manner.

Resolves: #629

---

#### Defaults for `data_dir` and `wallet_name` are handled manually.
We're no longer leaving these defaults in Clap derives, because that prevents us from determining if the user actually passed in those arguments or not. We instead handle the defaults manually. As a result, the `LocalStore` is now in charge of everything related to the file system.
This allowed us to:
1. Understand when the user is overriding the wallet file.
2. Actually use `data_dir` for interactive wallet chooser.

*Note:* For wallet creation in interactive mode, we're still using the default path. This can be easily adjusted in the near future.

Resolves: #630 

---

#### Transactions from wallets with no balance are halted immediately in interactive mode.
We won't even let the user fill in the transaction data once we identify there's no balance on the chosen address.

Resolves: #631 