### PR TITLE
Upgrade `dusk-wallet-core` to latest version

### DIFF
--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.8"
 aes = "0.7"
 hex = "0.4"
 
-dusk-wallet-core = "0.12.0-rc"
+dusk-wallet-core = "0.13.0-rc"
 canonical = "0.7"
 dusk-bytes = "0.1"
 dusk-pki ="0.10.0-rc"

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.6.0-rc.1"
+version = "0.6.1-rc.0"
 edition = "2021"
 
 [dependencies]

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -39,7 +39,7 @@ dusk-bls12_381-sign = { version = "0.3.0-rc", features = ["canon"] }
 dusk-jubjub = { version = "0.11", features = ["canon"] }
 dusk-pki ="0.10.0-rc"
 dusk-bytes = "0.1"
-dusk-wallet-core = "0.12.0-rc"
+dusk-wallet-core = "0.13.0-rc"
 dusk-abi = "0.11"
 rusk-vm = "0.12.0-rc"
 phoenix-core = "0.16.0-rc"

--- a/rusk/tests/services/multi_transfer.rs
+++ b/rusk/tests/services/multi_transfer.rs
@@ -172,12 +172,18 @@ fn wallet_transfer(
     let mut rng = StdRng::seed_from_u64(0xdead);
     let nonce = BlsScalar::random(&mut rng);
 
-    let initial_balance_0 =
-        wallet.get_balance(0).expect("Failed to get the balance");
-    let initial_balance_1 =
-        wallet.get_balance(1).expect("Failed to get the balance");
-    let initial_balance_2 =
-        wallet.get_balance(2).expect("Failed to get the balance");
+    let initial_balance_0 = wallet
+        .get_balance(0)
+        .expect("Failed to get the balance")
+        .value;
+    let initial_balance_1 = wallet
+        .get_balance(1)
+        .expect("Failed to get the balance")
+        .value;
+    let initial_balance_2 = wallet
+        .get_balance(2)
+        .expect("Failed to get the balance")
+        .value;
 
     // Check the senders initial balance is correct
     assert_eq!(
@@ -195,7 +201,10 @@ fn wallet_transfer(
 
     // Check the receiver initial balance is zero
     assert_eq!(
-        wallet.get_balance(3).expect("Failed to get the balance"),
+        wallet
+            .get_balance(3)
+            .expect("Failed to get the balance")
+            .value,
         0,
         "Wrong initial balance for the receiver"
     );
@@ -223,18 +232,25 @@ fn wallet_transfer(
 
     // Check the receiver's balance is changed accordingly
     assert_eq!(
-        wallet.get_balance(3).expect("Failed to get the balance"),
+        wallet
+            .get_balance(3)
+            .expect("Failed to get the balance")
+            .value,
         2 * amount,
         "Wrong resulting balance for the receiver"
     );
 
-    let final_balance_0 =
-        wallet.get_balance(0).expect("Failed to get the balance");
+    let final_balance_0 = wallet
+        .get_balance(0)
+        .expect("Failed to get the balance")
+        .value;
     let fee_0 = txs[0].fee();
     let fee_0 = fee_0.gas_limit * fee_0.gas_price;
 
-    let final_balance_1 =
-        wallet.get_balance(1).expect("Failed to get the balance");
+    let final_balance_1 = wallet
+        .get_balance(1)
+        .expect("Failed to get the balance")
+        .value;
     let fee_1 = txs[1].fee();
     let fee_1 = fee_1.gas_limit * fee_1.gas_price;
 
@@ -268,7 +284,10 @@ fn wallet_transfer(
 
     // Check the discarded transaction didn't change the balance
     assert_eq!(
-        wallet.get_balance(2).expect("Failed to get the balance"),
+        wallet
+            .get_balance(2)
+            .expect("Failed to get the balance")
+            .value,
         initial_balance_2,
         "Wrong resulting balance for discarded TX sender"
     );

--- a/rusk/tests/services/transfer.rs
+++ b/rusk/tests/services/transfer.rs
@@ -165,8 +165,10 @@ fn wallet_transfer(
     let nonce = BlsScalar::random(&mut rng);
 
     // Store the sender initial balance
-    let sender_initial_balance =
-        wallet.get_balance(0).expect("Failed to get the balance");
+    let sender_initial_balance = wallet
+        .get_balance(0)
+        .expect("Failed to get the balance")
+        .value;
 
     // Check the sender's initial balance is correct
     assert_eq!(
@@ -177,7 +179,10 @@ fn wallet_transfer(
 
     // Check the receiver initial balance is zero
     assert_eq!(
-        wallet.get_balance(1).expect("Failed to get the balance"),
+        wallet
+            .get_balance(1)
+            .expect("Failed to get the balance")
+            .value,
         0,
         "Wrong initial balance for the receiver"
     );
@@ -200,14 +205,19 @@ fn wallet_transfer(
 
     // Check the receiver's balance is changed accordingly
     assert_eq!(
-        wallet.get_balance(1).expect("Failed to get the balance"),
+        wallet
+            .get_balance(1)
+            .expect("Failed to get the balance")
+            .value,
         amount,
         "Wrong resulting balance for the receiver"
     );
 
     // Check the sender's balance is changed accordingly
-    let sender_final_balance =
-        wallet.get_balance(0).expect("Failed to get the balance");
+    let sender_final_balance = wallet
+        .get_balance(0)
+        .expect("Failed to get the balance")
+        .value;
     let fee = tx.fee();
     let fee = fee.gas_limit * fee.gas_price;
 


### PR DESCRIPTION
The new version adds the `spendable` field to the balance calculation,
which determines the maximum amount a user can spend in a single
transaction, due to there being a maximum number of input notes.
    
Resolves #636