### PR TITLE
rusk-wallet: Remove balance prerequisite for GetBalance operation

### DIFF
--- a/rusk-wallet/src/lib/wallet.rs
+++ b/rusk-wallet/src/lib/wallet.rs
@@ -84,9 +84,6 @@ impl CliWallet {
                     prompt::hide_cursor()?;
                     let balance = if let Some(wallet) = &self.wallet {
                         match pcmd {
-                            PromptCommand::Balance(key) => {
-                                wallet.get_balance(key)?
-                            }
                             PromptCommand::Transfer(key) => {
                                 wallet.get_balance(key)?
                             }


### PR DESCRIPTION
Resolves #653