### PR TITLE
rusk-wallet: major refactor in path handling and user flow

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- `data_dir` can be properly overriden [#656]
+
 ## Added
 - Settings can be loaded from a config file [#637]
+- Create config file if not exists [#647]
+- Notify user when defaulting configuration [#655]
 
 ## Changed
 - Export consensus public key as binary
@@ -154,3 +159,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#630]: https://github.com/dusk-network/rusk/issues/630
 [#631]: https://github.com/dusk-network/rusk/issues/631
 [#637]: https://github.com/dusk-network/rusk/issues/637
+[#647]: https://github.com/dusk-network/rusk/issues/647
+[#655]: https://github.com/dusk-network/rusk/issues/655
+[#656]: https://github.com/dusk-network/rusk/issues/656

--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Interactive mode allows for directory and wallet file overriding [#630]
 - Client errors implemented, Rusk error messages displayed without metadata [#629]
 - Transactions from wallets with no balance are halted immediately [#631]
+- Rusk and prover connections decoupled [#659]
+
 
 ## [0.5.2] - 2022-03-01
 
@@ -162,3 +164,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#647]: https://github.com/dusk-network/rusk/issues/647
 [#655]: https://github.com/dusk-network/rusk/issues/655
 [#656]: https://github.com/dusk-network/rusk/issues/656
+[#659]: https://github.com/dusk-network/rusk/issues/659

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.6.2-rc.0"
+version = "0.7.0-rc.0"
 edition = "2021"
 
 [dependencies]

--- a/rusk-wallet/README.md
+++ b/rusk-wallet/README.md
@@ -24,7 +24,7 @@ OPTIONS:
             Rusk address: socket path or fully quallified URL
 
     -p  --prover-addr <PROVER_ADDR>
-            Prover service address [default: `rusk-addr`]
+            Prover service address
 
         --skip-recovery <SKIP_RECOVERY>
             Skip wallet recovery phrase (useful for headless wallet creation)

--- a/rusk-wallet/config.toml
+++ b/rusk-wallet/config.toml
@@ -4,8 +4,8 @@
 # Connection to Rusk
 [rusk]
 ipc_method = "tcp_ip"
-rusk_addr = "https://127.0.0.1:8585"
-prover_addr = "https://provers.dusk.network:8585"
+rusk_addr = "http://127.0.0.1:8585"
+prover_addr = "http://127.0.0.1:8585"
 
 # Dusk explorer
 [explorer]

--- a/rusk-wallet/src/lib/config.rs
+++ b/rusk-wallet/src/lib/config.rs
@@ -159,8 +159,7 @@ impl Config {
             self.rusk.ipc_method = ipc_method;
         }
         if let Some(rusk_addr) = args.rusk_addr {
-            self.rusk.rusk_addr = rusk_addr.clone();
-            self.rusk.prover_addr = rusk_addr;
+            self.rusk.rusk_addr = rusk_addr
         }
         if let Some(prover_addr) = args.prover_addr {
             self.rusk.prover_addr = prover_addr;

--- a/rusk-wallet/src/lib/config.rs
+++ b/rusk-wallet/src/lib/config.rs
@@ -4,9 +4,12 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::{env, fs, path::PathBuf};
-
-use crate::{LocalStore, WalletArgs};
+use crate::{Error, LocalStore, WalletArgs};
+use serde::Serialize;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
 
 /// Default IPC method for Rusk connections
 pub(crate) const IPC_DEFAULT: &str = "uds";
@@ -48,12 +51,12 @@ mod parser {
 
     /// Attempts to parse the content of a file into config values
     pub fn parse(content: &str) -> Result<ParsedConfig, Error> {
-        toml::from_str(content).map_err(Error::TOML)
+        toml::from_str(content).map_err(Error::ConfigRead)
     }
 }
 
 /// Config holds the settings for the CLI wallet
-#[derive(Debug)]
+#[derive(Serialize)]
 pub(crate) struct Config {
     /// Wallet configuration
     pub wallet: WalletConfig,
@@ -64,7 +67,7 @@ pub(crate) struct Config {
 }
 
 /// Wallet and store configuration
-#[derive(Debug)]
+#[derive(Serialize)]
 pub(crate) struct WalletConfig {
     /// Directory to store user data
     pub data_dir: PathBuf,
@@ -77,7 +80,7 @@ pub(crate) struct WalletConfig {
 }
 
 /// Connection details to Rusk and Prover clusters
-#[derive(Debug)]
+#[derive(Serialize)]
 pub(crate) struct RuskConfig {
     /// IPC method for communication with rusk
     pub ipc_method: String,
@@ -88,7 +91,7 @@ pub(crate) struct RuskConfig {
 }
 
 /// Dusk Explorer access information
-#[derive(Debug)]
+#[derive(Serialize)]
 pub(crate) struct ExplorerConfig {
     /// Base url for transactions
     pub tx_url: Option<String>,
@@ -96,16 +99,19 @@ pub(crate) struct ExplorerConfig {
 
 impl Config {
     /// Attempt to load configuration from file
-    pub fn load() -> Option<Config> {
+    pub fn load(data_dir: &Path) -> Option<Config> {
         // search in default data dir and current working directory
-        let paths =
-            vec![env::current_dir().ok()?, LocalStore::default_data_dir()]
-                .iter_mut()
-                .map(|p| {
-                    p.push("config");
-                    p.with_extension("toml")
-                })
-                .collect::<Vec<PathBuf>>();
+        let paths = vec![
+            env::current_dir().ok()?,
+            data_dir.to_path_buf(),
+            LocalStore::default_data_dir(),
+        ]
+        .iter_mut()
+        .map(|p| {
+            p.push("config");
+            p.with_extension("toml")
+        })
+        .collect::<Vec<PathBuf>>();
 
         for p in paths.iter() {
             // attempt to read the file
@@ -123,6 +129,18 @@ impl Config {
         }
 
         None
+    }
+
+    /// Saves current configuration
+    pub fn save(&self) -> Result<PathBuf, Error> {
+        let str = toml::to_string(self)?;
+        let path = {
+            let mut p = self.wallet.data_dir.clone();
+            p.push("config");
+            p.with_extension("toml")
+        };
+        fs::write(&path, &str)?;
+        Ok(path)
     }
 
     /// Arguments that have been explicitly passed into this
@@ -153,10 +171,10 @@ impl Config {
     }
 
     /// Default settings
-    pub fn default() -> Config {
+    pub fn default(data_dir: &Path) -> Config {
         Config {
             wallet: WalletConfig {
-                data_dir: LocalStore::default_data_dir(),
+                data_dir: data_dir.to_path_buf(),
                 name: LocalStore::default_wallet_name(),
                 file: None,
                 skip_recovery: false,

--- a/rusk-wallet/src/lib/error.rs
+++ b/rusk-wallet/src/lib/error.rs
@@ -31,7 +31,9 @@ pub enum Error {
     /// JSON serialization errors
     JSON(serde_json::Error),
     /// TOML deserialization errors
-    TOML(toml::de::Error),
+    ConfigRead(toml::de::Error),
+    /// TOML serialization errors
+    ConfigWrite(toml::ser::Error),
     /// Bytes encoding errors
     Bytes(dusk_bytes::Error),
     /// Base58 errors
@@ -49,8 +51,6 @@ pub enum Error {
     NoteCombinationProblem,
     /// Not enough gas to perform this transaction
     NotEnoughGas,
-    /// User graceful exit
-    UserExit,
 }
 
 impl From<serde_json::Error> for Error {
@@ -61,7 +61,13 @@ impl From<serde_json::Error> for Error {
 
 impl From<toml::de::Error> for Error {
     fn from(e: toml::de::Error) -> Self {
-        Self::TOML(e)
+        Self::ConfigRead(e)
+    }
+}
+
+impl From<toml::ser::Error> for Error {
+    fn from(e: toml::ser::Error) -> Self {
+        Self::ConfigWrite(e)
     }
 }
 
@@ -136,7 +142,8 @@ impl fmt::Display for Error {
             Error::Offline => write!(f, "\rThis command cannot be performed while offline. Please configure a valid Rusk instance and try again."),
             Error::IO(err) => write!(f, "\rAn IO error occurred:\n{}", err),
             Error::JSON(err) => write!(f, "\rA serialization error occurred:\n{}", err),
-            Error::TOML(err) => write!(f, "\rFailed to read configuration file:\n{}", err),
+            Error::ConfigRead(err) => write!(f, "\rFailed to read configuration file:\n{}", err),
+            Error::ConfigWrite(err) => write!(f, "\rFailed to write to configuration file:\n{}", err),
             Error::Bytes(err) => write!(f, "\rA serialization error occurred:\n{:?}", err),
             Error::Base58(err) => write!(f, "\rA serialization error occurred:\n{}", err),
             Error::Canon(err) => write!(f, "\rA serialization error occurred:\n{:?}", err),
@@ -145,7 +152,6 @@ impl fmt::Display for Error {
             Error::NotEnoughGas => write!(f, "\rNot enough gas to perform this transaction"),
             Error::NotEnoughBalance => write!(f, "\rInsufficient balance to perform this operation"),
             Error::NoteCombinationProblem => write!(f, "\rNote combination for the given value is impossible given the maximum amount of inputs in a transaction"),
-            Error::UserExit => write!(f, "\rBye!"),
         }
     }
 }
@@ -160,7 +166,8 @@ impl fmt::Debug for Error {
             Error::Offline => write!(f, "\rThis command cannot be performed while offline. Please configure a valid Rusk instance and try again."),
             Error::IO(err) => write!(f, "\rAn IO error occurred:\n{:?}", err),
             Error::JSON(err) => write!(f, "\rA serialization error occurred:\n{:?}", err),
-            Error::TOML(err) => write!(f, "\rFailed to read configuration file:\n{}", err),
+            Error::ConfigRead(err) => write!(f, "\rFailed to read configuration file:\n{:?}", err),
+            Error::ConfigWrite(err) => write!(f, "\rFailed to write to configuration file:\n{:?}", err),
             Error::Bytes(err) => write!(f, "\rA serialization error occurred:\n{:?}", err),
             Error::Base58(err) => write!(f, "\rA serialization error occurred:\n{:?}", err),
             Error::Canon(err) => write!(f, "\rA serialization error occurred:\n{:?}", err),
@@ -169,7 +176,6 @@ impl fmt::Debug for Error {
             Error::NotEnoughGas => write!(f, "\rNot enough gas to perform this transaction"),
             Error::NotEnoughBalance => write!(f, "\rInsufficient balance to perform this operation"),
             Error::NoteCombinationProblem => write!(f, "\rNote combination for the given value is impossible given the maximum amount of inputs in a transaction"),
-            Error::UserExit => write!(f, "\rBye!"),
         }
     }
 }

--- a/rusk-wallet/src/lib/error.rs
+++ b/rusk-wallet/src/lib/error.rs
@@ -22,8 +22,12 @@ pub enum Error {
     Prover(ProverError),
     /// Local Store errors
     Store(StoreError),
-    /// Network error while communicating with rusk
+    /// Network error
     Network(tonic::transport::Error),
+    /// Rusk connection failure
+    RuskConn(tonic::transport::Error),
+    /// Prover cluster connection failure
+    ProverConn(tonic::transport::Error),
     /// Command not available in offline mode
     Offline,
     /// Filesystem errors
@@ -139,6 +143,8 @@ impl fmt::Display for Error {
             Error::Prover(err) => write!(f, "\r{}", err),
             Error::Store(err) => write!(f, "\r{}", err),
             Error::Network(err) => write!(f, "\rA network error occurred while communicating with Rusk:\n{}", err),
+            Error::RuskConn(err) => write!(f, "\rCouldn't establish connection with Rusk: {}\nPlease check your settings and try again.", err),
+            Error::ProverConn(err) => write!(f, "\rCouldn't establish connection with the prover cluster: {}\nPlease check your settings and try again.", err),
             Error::Offline => write!(f, "\rThis command cannot be performed while offline. Please configure a valid Rusk instance and try again."),
             Error::IO(err) => write!(f, "\rAn IO error occurred:\n{}", err),
             Error::JSON(err) => write!(f, "\rA serialization error occurred:\n{}", err),
@@ -163,6 +169,8 @@ impl fmt::Debug for Error {
             Error::Prover(err) => write!(f, "\r{:?}", err),
             Error::Store(err) => write!(f, "\r{:?}", err),
             Error::Network(err) => write!(f, "\rA network error occurred while communicating with Rusk:\n{:?}", err),
+            Error::RuskConn(err) => write!(f, "\rCouldn't establish connection with Rusk:\n{:?}", err),
+            Error::ProverConn(err) => write!(f, "\rCouldn't establish connection with the prover cluster:\n{:?}", err),
             Error::Offline => write!(f, "\rThis command cannot be performed while offline. Please configure a valid Rusk instance and try again."),
             Error::IO(err) => write!(f, "\rAn IO error occurred:\n{:?}", err),
             Error::JSON(err) => write!(f, "\rA serialization error occurred:\n{:?}", err),

--- a/rusk-wallet/src/main.rs
+++ b/rusk-wallet/src/main.rs
@@ -57,7 +57,7 @@ pub(crate) struct WalletArgs {
     #[clap(short = 'r', long)]
     rusk_addr: Option<String>,
 
-    /// Prover service address [default: `rusk_addr`]
+    /// Prover service address
     #[clap(short = 'p', long)]
     prover_addr: Option<String>,
 
@@ -195,9 +195,15 @@ struct Rusk {
 /// Connect to rusk services via TCP
 async fn rusk_tcp(rusk_addr: &str, prov_addr: &str) -> Result<Rusk, Error> {
     Ok(Rusk {
-        network: NetworkClient::connect(rusk_addr.to_string()).await?,
-        state: StateClient::connect(rusk_addr.to_string()).await?,
-        prover: ProverClient::connect(prov_addr.to_string()).await?,
+        network: NetworkClient::connect(rusk_addr.to_string())
+            .await
+            .map_err(Error::RuskConn)?,
+        state: StateClient::connect(rusk_addr.to_string())
+            .await
+            .map_err(Error::RuskConn)?,
+        prover: ProverClient::connect(prov_addr.to_string())
+            .await
+            .map_err(Error::ProverConn)?,
     })
 }
 


### PR DESCRIPTION
- `data_dir` is now used across the board
- create configuration file if not exists
- notify user when defaulting configuration
- main flow is easier to understand
- separate prover from rusk address config values
- explicit connection errors


Resolves #647
Resolves #655
Resolves #656
Resolves #659 