### PR TITLE
rusk-wallet: Implement `fetch_block_height` for State client

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings can be loaded from a config file [#637]
 - Create config file if not exists [#647]
 - Notify user when defaulting configuration [#655]
+- Implementation for `State`'s `fetch_block_height` [#651]
 
 ## Changed
 - Export consensus public key as binary
@@ -162,6 +163,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#631]: https://github.com/dusk-network/rusk/issues/631
 [#637]: https://github.com/dusk-network/rusk/issues/637
 [#647]: https://github.com/dusk-network/rusk/issues/647
+[#651]: https://github.com/dusk-network/rusk/issues/651
 [#655]: https://github.com/dusk-network/rusk/issues/655
 [#656]: https://github.com/dusk-network/rusk/issues/656
 [#659]: https://github.com/dusk-network/rusk/issues/659

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "rusk-wallet"
-version = "0.7.0-rc.0"
+version = "0.7.0-rc.1"
 edition = "2021"
 
 [dependencies]
 clap = { version = "3.1", features = ["derive"] }
 tokio = { version = "1.15", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 block-modes = "0.8"
+gql_client = "1.0"
+serde_json = "1.0"
 tiny-bip39 = "0.8"
 crossterm = "0.22"
 rand_core = "0.6"

--- a/rusk-wallet/src/lib/config.rs
+++ b/rusk-wallet/src/lib/config.rs
@@ -15,6 +15,8 @@ use std::{
 pub(crate) const IPC_DEFAULT: &str = "uds";
 /// Default Rusk address uses UDS
 pub(crate) const RUSK_ADDR: &str = "/tmp/rusk_listener";
+/// Default GraphQL endopoint
+pub(crate) const GQL_ADDR: &str = "http://nodes.dusk.network:9500/graphql";
 
 mod parser {
 
@@ -27,6 +29,7 @@ mod parser {
         pub wallet: ParsedWalletConfig,
         pub rusk: ParsedRuskConfig,
         pub explorer: ParsedExplorerConfig,
+        pub chain: ParsedChainConfig,
     }
 
     #[derive(Deserialize)]
@@ -49,6 +52,11 @@ mod parser {
         pub tx_url: Option<String>,
     }
 
+    #[derive(Deserialize)]
+    pub struct ParsedChainConfig {
+        pub gql_url: Option<String>,
+    }
+
     /// Attempts to parse the content of a file into config values
     pub fn parse(content: &str) -> Result<ParsedConfig, Error> {
         toml::from_str(content).map_err(Error::ConfigRead)
@@ -64,6 +72,8 @@ pub(crate) struct Config {
     pub rusk: RuskConfig,
     /// Dusk explorer configuration
     pub explorer: ExplorerConfig,
+    /// Dusk chain configuration
+    pub chain: ChainConfig,
 }
 
 /// Wallet and store configuration
@@ -95,6 +105,13 @@ pub(crate) struct RuskConfig {
 pub(crate) struct ExplorerConfig {
     /// Base url for transactions
     pub tx_url: Option<String>,
+}
+
+/// Dusk Chain configuration
+#[derive(Serialize)]
+pub(crate) struct ChainConfig {
+    /// GraphQL http endpoint
+    pub gql_url: String,
 }
 
 impl Config {
@@ -184,6 +201,9 @@ impl Config {
                 prover_addr: RUSK_ADDR.to_string(),
             },
             explorer: ExplorerConfig { tx_url: None },
+            chain: ChainConfig {
+                gql_url: GQL_ADDR.to_string(),
+            },
         }
     }
 }
@@ -219,6 +239,12 @@ impl From<parser::ParsedConfig> for Config {
             },
             explorer: ExplorerConfig {
                 tx_url: parsed.explorer.tx_url,
+            },
+            chain: ChainConfig {
+                gql_url: parsed
+                    .chain
+                    .gql_url
+                    .unwrap_or_else(|| GQL_ADDR.to_string()),
             },
         }
     }

--- a/rusk-wallet/src/main.rs
+++ b/rusk-wallet/src/main.rs
@@ -330,7 +330,7 @@ async fn exec() -> Result<(), Error> {
                 clients.state.clone(),
                 clients.network,
             );
-            let state = State::new(clients.state);
+            let state = State::new(clients.state, cfg.chain.gql_url.clone());
             CliWallet::new(cfg, store, state, prover)
         }
         Err(err) => {


### PR DESCRIPTION
Query block height from the GraphQL endpoint.

NOTE: GraphQL can be modified in the `config.toml` under the `[chain]` section. However, it has not been included as a runtime argument for now.

See also #650
See also #651