### PR TITLE
rusk-wallet: enable `bundled` feature for `rusqlite`

### DIFF
--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -28,7 +28,7 @@ bs58 = "0.4"
 rand = "0.8"
 aes = "0.7"
 hex = "0.4"
-rusqlite = "0.26"
+rusqlite = { version = "0.27.0", features = ["bundled"] }
 
 dusk-wallet-core = "0.13.0-rc"
 canonical = "0.7"


### PR DESCRIPTION
Fix #666