### PR TITLE
wallet: Invalid config shouldnt fallback

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `data_dir` can be properly overriden [#656]
+- Invalid configuration should not fallback into default [#670]
 
 ## Added
 - Notes cache [#650]
@@ -169,3 +170,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#655]: https://github.com/dusk-network/rusk/issues/655
 [#656]: https://github.com/dusk-network/rusk/issues/656
 [#659]: https://github.com/dusk-network/rusk/issues/659
+[#670]: https://github.com/dusk-network/rusk/issues/670

--- a/rusk-wallet/README.md
+++ b/rusk-wallet/README.md
@@ -73,11 +73,13 @@ make install
 
 You will need to connect to a running [**Rusk**](https://github.com/dusk-network/rusk) instance for full wallet capabilities.
 
-Settings can be fed using a `config.toml` file. The CLI expects it to be either in your default data directory (`~/.dusk/config.toml`) or in the current working directory. The latter will be given priority if found first.
+The default settings are located in [config.toml](config.toml).
 
-The user can override any particular configuration variable without having to manually edit the config file by explicitly passing the corresponding runtime argument(s) when running the CLI.
+The base data directory will be provided via the `--data-dir` argument. It defaults to `$HOME/.dusk/config.toml`.
 
-Here's an [example](config.toml) for reference.
+The configuration file `config.toml` will be read from the base data directory. If none is present, the default settings will be copied to the base data directory, and used.
+
+The CLI arguments takes precedence and overrides any configuration present in the configuration file.
 
 ## Running the CLI Wallet
 

--- a/rusk-wallet/config.toml
+++ b/rusk-wallet/config.toml
@@ -1,12 +1,12 @@
-# Wallet configuration
 [wallet]
 
-# Connection to Rusk
 [rusk]
 ipc_method = "tcp_ip"
-rusk_addr = "http://127.0.0.1:8585"
-prover_addr = "http://127.0.0.1:8585"
+rusk_addr = "https://nodes.dusk.network:8585"
+prover_addr = "https://provers.dusk.network:8686"
 
-# Dusk explorer
 [explorer]
 tx_url = "https://explorer.dusk.network/transactions/transaction/?id="
+
+[chain]
+gql_url = "http://nodes.dusk.network:9500/graphql"

--- a/rusk-wallet/src/lib/prompt.rs
+++ b/rusk-wallet/src/lib/prompt.rs
@@ -29,18 +29,22 @@ use crate::{CliCommand, Error};
 
 /// Request the user to authenticate with a password
 pub(crate) fn request_auth(msg: &str) -> Hash {
-    let pwd = match env::var("RUSK_WALLET_PWD") {
-        Ok(p) => p,
-        Err(_) => {
+    let pwd = match env::var("RUSK_WALLET_PWD").ok() {
+        Some(p) => p,
+
+        None => {
             let q = Question::password("password")
                 .message(format!("{}:", msg))
                 .mask('*')
                 .build();
+
             let a = requestty::prompt_one(q).expect("password");
             let p = a.as_string().unwrap();
+
             p.to_string()
         }
     };
+
     blake3::hash(pwd.as_bytes())
 }
 


### PR DESCRIPTION
Currently we are using a fallback strategy to pick sequences of
configurations until a valid one is found.

This is misleading in the sense of making the user believe he is working
with a valid configuration, when in fact the wallet is using a different
one - possibly with undesirable parameters.

Resolves #670