### PR TITLE
rusk-profile: Remove keys existance duplicated checks

### DIFF
--- a/rusk-profile/Cargo.toml
+++ b/rusk-profile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-profile"
-version = "0.5.0-rc.0"
+version = "0.5.1-rc.0"
 edition = "2021"
 autobins = false
 

--- a/rusk-profile/src/lib.rs
+++ b/rusk-profile/src/lib.rs
@@ -170,14 +170,9 @@ pub fn keys_for(id: &[u8; 32]) -> Result<Keys, io::Error> {
     let mut dir = get_rusk_keys_dir()?;
     dir.push(hex::encode(id));
 
-    let pk_dir = dir.with_extension("pk");
-    let vd_dir = dir.with_extension("vd");
-
-    if pk_dir.exists() && vd_dir.exists() {
-        Ok(Keys(*id))
-    } else {
-        Err(io::Error::new(io::ErrorKind::NotFound, "keys not found"))
-    }
+    // No need to check if the keys exist, because it's guaranteed to be
+    // checked by the get_verifier and get_prover functions.
+    Ok(Keys(*id))
 }
 
 pub fn add_keys_for(


### PR DESCRIPTION
No need to check if the keys exist, because it's guaranteed to be
checked by the get_verifier and get_prover functions.

Resolves #685