### PR TITLE
rusk-recovery: Fix key generation

### DIFF
--- a/rusk-recovery/src/keys.rs
+++ b/rusk-recovery/src/keys.rs
@@ -80,7 +80,8 @@ fn check_keys_cache(
                 loader.circuit_name()
             );
 
-            match rusk_profile::keys_for(loader.circuit_id()) {
+            let keys = rusk_profile::keys_for(loader.circuit_id())?;
+            match keys.get_verifier() {
                 Ok(_) => {
                     info!(
                         "{}   {}",


### PR DESCRIPTION
Since `keys_for` doesn't check for key existence, a `get_verifier` is called to check the presence of the keys in the filesystem

Resolves #695