### PR TITLE
Return latest block height from `fetch_notes`

### DIFF
--- a/contracts/transfer/Cargo.toml
+++ b/contracts/transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-contract"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 
 [lib]

--- a/contracts/transfer/src/transfer/tree.rs
+++ b/contracts/transfer/src/transfer/tree.rs
@@ -204,17 +204,15 @@ impl Tree {
         Ok(self.tree.branch(pos)?)
     }
 
-    pub fn notes(
+    pub fn leaves(
         &self,
         block_height: u64,
-    ) -> Result<impl Iterator<Item = Result<&Note, Error>>, Error> {
+    ) -> Result<impl Iterator<Item = Result<&Leaf, Error>>, Error> {
         Ok(self
             .tree
             .annotated_iter_walk(BlockHeightFilter(block_height))?
             .into_iter()
-            .map(|result| {
-                result.map_err(|e| e.into()).map(|leaf| leaf.as_ref())
-            }))
+            .map(|result| result.map_err(|e| e.into())))
     }
 }
 

--- a/rusk-schema/CHANGELOG.md
+++ b/rusk-schema/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add the latest block `height` in `GetNotesOwnedByResponse` [#651]
+- Insert `generator` in state transition requests [#699]
+
+### Changed
+
+- Change `Stake` and `GetStakeResponse` to support new stake contract spec [#614]
+
+## [0.1.0] - 2021-04-05
+
+### Added
+
+- Initial release
+
+[#699]: https://github.com/dusk-network/rusk/issues/699
+[#651]: https://github.com/dusk-network/rusk/issues/651
+[#614]: https://github.com/dusk-network/rusk/issues/614
+
+<!-- Releases -->
+
+[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-schema-v0.2.0...HEAD
+[0.2.0]: https://github.com/dusk-network/rusk/releases/tag/rusk-schema-v0.1.0...rusk-schema-v0.2.0
+[0.1.0]: https://github.com/dusk-network/rusk/releases/tag/rusk-schema-v0.1.0

--- a/rusk-schema/CHANGELOG.md
+++ b/rusk-schema/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2021-04-15
+
 ### Added
 
 - Add the latest block `height` in `GetNotesOwnedByResponse` [#651]

--- a/rusk-schema/Cargo.toml
+++ b/rusk-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-schema"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 license = "MPL-2.0"

--- a/rusk-schema/protos/state.proto
+++ b/rusk-schema/protos/state.proto
@@ -70,6 +70,7 @@ message GetNotesOwnedByRequest {
 
 message GetNotesOwnedByResponse {
     repeated bytes notes = 1;
+    uint64 height = 2;
 }
 
 message GetAnchorRequest {}

--- a/rusk/src/lib/services/state.rs
+++ b/rusk/src/lib/services/state.rs
@@ -360,13 +360,11 @@ impl State for Rusk {
         let block_height = request.get_ref().height;
 
         let state = self.state()?;
-        let notes = state
-            .fetch_notes(block_height, &vk)?
-            .iter()
-            .map(|note| note.to_bytes().to_vec())
-            .collect();
 
-        Ok(Response::new(GetNotesOwnedByResponse { notes }))
+        let (notes, height) = state.fetch_notes(block_height, &vk)?;
+        let notes = notes.iter().map(|note| note.to_bytes().to_vec()).collect();
+
+        Ok(Response::new(GetNotesOwnedByResponse { notes, height }))
     }
 
     async fn get_anchor(

--- a/rusk/tests/services/state_service.rs
+++ b/rusk/tests/services/state_service.rs
@@ -53,7 +53,7 @@ const BLOCK_HEIGHT: u64 = 1;
 fn fetch_note(rusk: &Rusk) -> Result<Option<Note>> {
     info!("Fetching the first note from the state");
     let vk = SSK.view_key();
-    let notes = rusk.state()?.fetch_notes(BLOCK_HEIGHT, &vk)?;
+    let (notes, _) = rusk.state()?.fetch_notes(BLOCK_HEIGHT, &vk)?;
 
     if notes.len() == 1 {
         trace!("Note found");
@@ -142,11 +142,14 @@ pub async fn test_fetch_notes() -> Result<()> {
         vk: vk.to_bytes().to_vec(),
     });
 
-    let response = client.get_notes_owned_by(request).await?;
+    let response = client.get_notes_owned_by(request).await?.into_inner();
 
-    let len = response.into_inner().notes.len();
-
-    assert_eq!(len, 1, "Expected 1 note");
+    assert_eq!(response.notes.len(), 1, "Expected 1 note");
+    assert_eq!(
+        response.height, BLOCK_HEIGHT,
+        "Expected latest block height to be {}",
+        BLOCK_HEIGHT
+    );
 
     Ok(())
 }

--- a/test-utils/transfer-wrapper/Cargo.toml
+++ b/test-utils/transfer-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-wrapper"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [dependencies]

--- a/test-utils/transfer-wrapper/src/wrapper.rs
+++ b/test-utils/transfer-wrapper/src/wrapper.rs
@@ -306,9 +306,10 @@ impl TransferWrapper {
 
     pub fn notes(&self, block_height: u64) -> Vec<Note> {
         self.transfer_state()
-            .notes_from_height(block_height)
+            .leaves_from_height(block_height)
             .expect("Failed to fetch notes iterator from state")
-            .map(|note| *note.expect("Failed to fetch note from canonical"))
+            .map(|leaf| *leaf.expect("Failed to fetch note from canonical"))
+            .map(|leaf| leaf.note)
             .collect()
     }
 
@@ -340,7 +341,7 @@ impl TransferWrapper {
 
     pub fn anchor(&mut self) -> BlsScalar {
         self.transfer_state()
-            .notes()
+            .tree()
             .inner()
             .root()
             .unwrap_or_default()
@@ -348,7 +349,7 @@ impl TransferWrapper {
 
     pub fn opening(&mut self, pos: u64) -> PoseidonBranch<TRANSFER_TREE_DEPTH> {
         self.transfer_state()
-            .notes()
+            .tree()
             .opening(pos)
             .unwrap_or_else(|_| {
                 panic!("Failed to fetch note of position {:?} for opening", pos)


### PR DESCRIPTION
To achieve a proper caching strategy, a wallet requires knowledge of which block height it should sync its known notes from. This PR solves this problem by returning the maximum block height of the notes it processes in `GetNotesOwnedBy`.

Resolves #651