### PR TITLE
Add `GetNotes` allowing for streaming notes to client

### DIFF
--- a/contracts/transfer/Cargo.toml
+++ b/contracts/transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-contract"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 
 [lib]

--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -15,7 +15,7 @@ mod transfer;
 mod wasm;
 
 pub use error::Error;
-pub use transfer::{Call, TransferContract};
+pub use transfer::{Call, Leaf, TransferContract};
 pub type Map<K, V> = dusk_hamt::Hamt<K, V, ()>;
 
 #[cfg(target_arch = "wasm32")]

--- a/contracts/transfer/src/transfer.rs
+++ b/contracts/transfer/src/transfer.rs
@@ -21,9 +21,10 @@ mod call;
 mod circuits;
 mod tree;
 
-use tree::{Leaf, Tree};
+use tree::Tree;
 
 pub use call::Call;
+pub use tree::Leaf;
 
 pub type PublicKeyBytes = [u8; PublicKey::SIZE];
 

--- a/rusk-schema/CHANGELOG.md
+++ b/rusk-schema/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `GetNotes` call to stream notes from the server [#702]
+
+### Deprecated
+
+- Mark `GetNotesOwnedByRequest` fields as `[deprecated=true]` [#702]
+
 ## [0.3.0] - 2021-04-26
 
 ### Added
@@ -35,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 
 [#704]: https://github.com/dusk-network/rusk/issues/704
+[#702]: https://github.com/dusk-network/rusk/issues/702
 [#699]: https://github.com/dusk-network/rusk/issues/699
 [#651]: https://github.com/dusk-network/rusk/issues/651
 [#614]: https://github.com/dusk-network/rusk/issues/614

--- a/rusk-schema/CHANGELOG.md
+++ b/rusk-schema/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2021-04-28
+
 ### Added
 
+- Add `state_root` to VST response [#708]
 - Add `GetNotes` call to stream notes from the server [#702]
 
 ### Deprecated
@@ -42,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[#704]: https://github.com/dusk-network/rusk/issues/704
+[#708]: https://github.com/dusk-network/rusk/issues/708
 [#702]: https://github.com/dusk-network/rusk/issues/702
 [#699]: https://github.com/dusk-network/rusk/issues/699
 [#651]: https://github.com/dusk-network/rusk/issues/651
@@ -50,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-schema-v0.3.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-schema-v0.3.1...HEAD
+[0.3.1]: https://github.com/dusk-network/rusk/releases/tag/rusk-schema-v0.3.0...rusk-schema-v0.3.1
 [0.3.0]: https://github.com/dusk-network/rusk/releases/tag/rusk-schema-v0.2.0...rusk-schema-v0.3.0
 [0.2.0]: https://github.com/dusk-network/rusk/releases/tag/rusk-schema-v0.1.0...rusk-schema-v0.2.0
 [0.1.0]: https://github.com/dusk-network/rusk/releases/tag/rusk-schema-v0.1.0

--- a/rusk-schema/Cargo.toml
+++ b/rusk-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-schema"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 license = "MPL-2.0"

--- a/rusk-schema/protos/state.proto
+++ b/rusk-schema/protos/state.proto
@@ -66,12 +66,22 @@ message GetStateRootResponse {
 }
 
 message GetNotesOwnedByRequest {
-    uint64 height = 1;
-    bytes vk = 2;
+    uint64 height = 1 [deprecated=true];
+    bytes vk = 2 [deprecated=true];
 }
 
 message GetNotesOwnedByResponse {
     repeated bytes notes = 1;
+    uint64 height = 2;
+}
+
+message GetNotesRequest {
+    uint64 height = 1;
+    bytes vk = 2;
+}
+
+message GetNotesResponse {
+    bytes note = 1;
     uint64 height = 2;
 }
 
@@ -135,6 +145,11 @@ service State {
     rpc GetProvisioners(GetProvisionersRequest) returns (GetProvisionersResponse) {}
     rpc GetStateRoot(GetStateRootRequest) returns (GetStateRootResponse) {}
     rpc GetNotesOwnedBy(GetNotesOwnedByRequest) returns (GetNotesOwnedByResponse) {}
+
+    // Streams notes from a given block height, optionally filtered by the
+    // given view key. If the view key is not present, *all* notes will be
+    // streamed.
+    rpc GetNotes(GetNotesRequest) returns (stream GetNotesResponse) {}
     rpc GetAnchor(GetAnchorRequest) returns (GetAnchorResponse) {}
     rpc GetOpening(GetOpeningRequest) returns (GetOpeningResponse) {}
     rpc GetStake(GetStakeRequest) returns (GetStakeResponse) {}

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -15,6 +15,8 @@ path = "src/bin/main.rs"
 [dependencies]
 tonic = "0.6"
 tokio = { version = "1.15", features = ["rt-multi-thread", "time", "fs", "macros"] }
+tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["rt"] }
 async-stream = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", features = ["fmt", "env-filter"] }

--- a/rusk/src/lib/lib.rs
+++ b/rusk/src/lib/lib.rs
@@ -32,6 +32,8 @@ pub static PUB_PARAMS: Lazy<PublicParameters> = Lazy::new(|| unsafe {
     PublicParameters::from_slice_unchecked(pp.as_slice())
 });
 
+const STREAM_BUF_SIZE: usize = 64;
+
 pub struct RuskBuilder {
     id: Option<NetworkStateId>,
     path: Option<PathBuf>,
@@ -77,6 +79,7 @@ impl RuskBuilder {
             network,
             backend,
             path,
+            stream_buffer_size: STREAM_BUF_SIZE,
         };
 
         Ok(rusk)
@@ -96,6 +99,7 @@ pub struct Rusk {
     backend: fn() -> BackendCtor<DiskBackend>,
     network: Arc<Mutex<NetworkState>>,
     path: Option<PathBuf>,
+    stream_buffer_size: usize,
 }
 
 impl Rusk {

--- a/rusk/src/lib/state.rs
+++ b/rusk/src/lib/state.rs
@@ -163,18 +163,9 @@ impl RuskState {
         Ok(())
     }
 
-    /// Returns all the notes from a given block height
-    pub fn notes(&self, height: u64) -> Result<Vec<Note>> {
-        Ok(self
-            .transfer_contract()?
-            .leaves_from_height(height)?
-            .map(|leaf| leaf.expect("Failed to fetch leaf from canonical"))
-            .map(|leaf| leaf.note)
-            .collect())
-    }
-
     /// Returns the notes from a given block height and owned by [`ViewKey`],
     /// together with the highest block height found in the tree.
+    #[deprecated]
     pub fn fetch_notes(
         &self,
         height: u64,

--- a/rusk/tests/services/multi_transfer.rs
+++ b/rusk/tests/services/multi_transfer.rs
@@ -6,17 +6,19 @@
 
 use crate::common::keys::BLS_SK;
 use crate::common::*;
+
 use canonical::{Canon, Source};
 use dusk_bls12_381_sign::PublicKey;
 use dusk_pki::{SecretSpendKey, ViewKey};
 use dusk_schnorr::Signature;
+use futures::StreamExt;
 use parking_lot::Mutex;
 use rusk::services::network::{KadcastDispatcher, NetworkServer};
 use rusk::services::prover::ExecuteProverRequest;
 use rusk::services::state::{
     ExecuteStateTransitionRequest, FindExistingNullifiersRequest,
-    GetAnchorRequest, GetNotesOwnedByRequest, GetOpeningRequest,
-    PreverifyRequest, StateTransitionRequest, VerifyStateTransitionRequest,
+    GetAnchorRequest, GetNotesRequest, GetOpeningRequest, PreverifyRequest,
+    StateTransitionRequest, VerifyStateTransitionRequest,
 };
 use rusk_schema::network_client::NetworkClient;
 use rusk_schema::prover_client::ProverClient;
@@ -422,19 +424,20 @@ impl wallet::StateClient for TestStateClient {
     fn fetch_notes(&self, vk: &ViewKey) -> Result<Vec<Note>, Self::Error> {
         let mut client = StateClient::new(self.channel.clone());
 
-        let request = tonic::Request::new(GetNotesOwnedByRequest {
+        let request = tonic::Request::new(GetNotesRequest {
             height: 0,
             vk: vk.to_bytes().to_vec(),
         });
 
-        let response = client.get_notes_owned_by(request).wait()?;
+        let stream = client.get_notes(request).wait()?.into_inner();
 
-        response
-            .into_inner()
-            .notes
-            .iter()
-            .map(|n| Note::from_slice(n).map_err(Error::Serialization))
+        Ok(stream
+            .map(|response| {
+                let response = response.expect("Stream item should be Ok()");
+                Note::from_slice(&response.note).expect("Note should be valid")
+            })
             .collect()
+            .wait())
     }
 
     /// Fetch the current anchor of the state.

--- a/rusk/tests/services/stake.rs
+++ b/rusk/tests/services/stake.rs
@@ -5,10 +5,12 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::common::*;
+
 use canonical::{Canon, Source};
 use dusk_bls12_381_sign::{PublicKey, SecretKey};
 use dusk_pki::{SecretSpendKey, ViewKey};
 use dusk_schnorr::Signature;
+use futures::StreamExt;
 use parking_lot::Mutex;
 use rusk::services::network::{KadcastDispatcher, NetworkServer};
 use rusk::services::prover::{
@@ -16,9 +18,8 @@ use rusk::services::prover::{
 };
 use rusk::services::state::{
     ExecuteStateTransitionRequest, FindExistingNullifiersRequest,
-    GetAnchorRequest, GetNotesOwnedByRequest, GetOpeningRequest,
-    GetStakeRequest, PreverifyRequest, StateTransitionRequest,
-    VerifyStateTransitionRequest,
+    GetAnchorRequest, GetNotesRequest, GetOpeningRequest, GetStakeRequest,
+    PreverifyRequest, StateTransitionRequest, VerifyStateTransitionRequest,
 };
 use rusk_schema::network_client::NetworkClient;
 use rusk_schema::prover_client::ProverClient;
@@ -356,19 +357,20 @@ impl wallet::StateClient for TestStateClient {
     fn fetch_notes(&self, vk: &ViewKey) -> Result<Vec<Note>, Self::Error> {
         let mut client = StateClient::new(self.channel.clone());
 
-        let request = tonic::Request::new(GetNotesOwnedByRequest {
+        let request = tonic::Request::new(GetNotesRequest {
             height: 0,
             vk: vk.to_bytes().to_vec(),
         });
 
-        let response = client.get_notes_owned_by(request).wait()?;
+        let stream = client.get_notes(request).wait()?.into_inner();
 
-        response
-            .into_inner()
-            .notes
-            .iter()
-            .map(|n| Note::from_slice(n).map_err(Error::Serialization))
+        Ok(stream
+            .map(|response| {
+                let response = response.expect("Stream item should be Ok()");
+                Note::from_slice(&response.note).expect("Note should be valid")
+            })
             .collect()
+            .wait())
     }
 
     /// Fetch the current anchor of the state.


### PR DESCRIPTION
The new `GetNotes` RPC is capable of streaming notes starting from a particular block height, and optionally filter them by a given view key. This allows for filtering on the server side (less private) and also on the client side (private) and effectively solves the ever growing memory required to execute `GetNotesOwnedBy`.

We deprecate `GetNotesOwnedBy` by setting `[deprecated=true]` on the fields of `GetNotesOwnedByRequest`. Any client using the new version will get a compiler warning that this request is deprecated.

Resolves #702 