### PR TITLE
Add check for repeated nullifiers

### DIFF
--- a/rusk-schema/CHANGELOG.md
+++ b/rusk-schema/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `discarded_txs` field to `ExecuteStateTransitionResponse` [#704]
+
+### Removed
+
+- Remove `success` field from `ExecuteStateTransitionResponse` [#704]
+
 ## [0.2.0] - 2021-04-15
 
 ### Added
@@ -24,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[#704]: https://github.com/dusk-network/rusk/issues/704
 [#699]: https://github.com/dusk-network/rusk/issues/699
 [#651]: https://github.com/dusk-network/rusk/issues/651
 [#614]: https://github.com/dusk-network/rusk/issues/614

--- a/rusk-schema/CHANGELOG.md
+++ b/rusk-schema/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2021-04-26
+
 ### Added
 
 - Add `discarded_txs` field to `ExecuteStateTransitionResponse` [#704]
@@ -39,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-schema-v0.2.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-schema-v0.3.0...HEAD
+[0.3.0]: https://github.com/dusk-network/rusk/releases/tag/rusk-schema-v0.2.0...rusk-schema-v0.3.0
 [0.2.0]: https://github.com/dusk-network/rusk/releases/tag/rusk-schema-v0.1.0...rusk-schema-v0.2.0
 [0.1.0]: https://github.com/dusk-network/rusk/releases/tag/rusk-schema-v0.1.0

--- a/rusk-schema/Cargo.toml
+++ b/rusk-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-schema"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 license = "MPL-2.0"

--- a/rusk-schema/protos/state.proto
+++ b/rusk-schema/protos/state.proto
@@ -37,8 +37,8 @@ message ExecuteStateTransitionRequest {
 }
 
 message ExecuteStateTransitionResponse {
-    bool success = 1;
-    repeated ExecutedTransaction txs = 2;
+    repeated ExecutedTransaction txs = 1;
+    repeated Transaction discarded_txs = 2;
     bytes state_root = 3;
 }
 


### PR DESCRIPTION
The PR adds a check on nullifiers in all state transitions. In the "accepting" set of state transitions Rusk will now error if nullifiers are repeated. In execute state transition the transactions containing nullifiers previously used by the same transaction set will be discarded.

Resolves #704