### PR TITLE
rusk: RuskState drops unstaged commits too aggressively

### DIFF
--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -51,7 +51,7 @@ phoenix-core = "0.16.0-rc"
 kadcast = "0.4.0-rc.5"
 canonical = "0.7"
 canonical_derive = "0.7"
-parking_lot = "0.11"
+parking_lot = "0.12"
 
 rusk-recovery = { path = "../rusk-recovery", features = ["state"] }
 transfer-circuits = { path = "../circuits/transfer" }

--- a/rusk/src/lib/lib.rs
+++ b/rusk/src/lib/lib.rs
@@ -112,14 +112,14 @@ impl Rusk {
     pub fn state(&self) -> Result<RuskState> {
         let network = self.network.clone();
 
-        Ok(RuskState(network))
+        Ok(RuskState::new(network))
     }
 
     /// Persist a state of the network as new state
     pub fn persist(&self, state: &mut RuskState) -> Result<NetworkStateId> {
         let backend = self.backend;
-        let network = state.network();
-        let id = network.lock().persist(&backend())?;
+        let network = state.inner();
+        let id = network.persist(&backend())?;
 
         if let Some(path) = &self.path {
             id.write(path)?;

--- a/rusk/src/lib/services/state.rs
+++ b/rusk/src/lib/services/state.rs
@@ -188,7 +188,7 @@ impl State for Rusk {
                     }
                 }
 
-                let mut forked_state = state.fork();
+                let mut forked_state = state.clone();
                 let mut gas_meter = GasMeter::with_limit(tx.fee().gas_limit);
 
                 // We do not care if the transaction fails or succeeds here

--- a/rusk/tests/rusk-state.rs
+++ b/rusk/tests/rusk-state.rs
@@ -49,7 +49,6 @@ fn initial_state() -> Result<Rusk> {
 
     Ok(rusk)
 }
-
 fn push_note(rusk_state: &mut RuskState) -> Result<()> {
     info!("Generating a note");
     let mut rng = StdRng::seed_from_u64(0xdead);
@@ -74,6 +73,7 @@ fn push_note(rusk_state: &mut RuskState) -> Result<()> {
     Ok(())
 }
 
+#[test]
 pub fn rusk_state_accepted() -> Result<()> {
     // Setup the logger
     logger();
@@ -95,6 +95,7 @@ pub fn rusk_state_accepted() -> Result<()> {
     Ok(())
 }
 
+#[test]
 pub fn rusk_state_finalized() -> Result<()> {
     // Setup the logger
     logger();
@@ -115,6 +116,7 @@ pub fn rusk_state_finalized() -> Result<()> {
     Ok(())
 }
 
+#[test]
 pub fn rusk_state_ephemeral() -> Result<()> {
     // Setup the logger
     logger();
@@ -134,6 +136,26 @@ pub fn rusk_state_ephemeral() -> Result<()> {
 
         push_note(&mut state)?;
 
+        let transfer = state.transfer_contract()?;
+
+        assert!(transfer.get_note(1)?.is_some(), "Note added");
+        assert!(transfer.get_note(2)?.is_some(), "Note added");
+        assert!(transfer.get_note(3)?.is_some(), "Note added");
+
+        // Testing that cloning the current state is not affecting either the
+        // current scope or the outer scope.
+
+        let mut state_cloned = state.clone();
+
+        state_cloned.revert();
+
+        let transfer = state_cloned.transfer_contract()?;
+
+        assert!(transfer.get_note(1)?.is_some(), "Note still present");
+        assert!(transfer.get_note(2)?.is_none(), "Note removed");
+        assert!(transfer.get_note(3)?.is_none(), "Note removed");
+
+        // The original state didn't change
         let transfer = state.transfer_contract()?;
 
         assert!(transfer.get_note(1)?.is_some(), "Note added");


### PR DESCRIPTION
This code makes usage of `unsafe` to handle manually the dropping of the raw Mutex.
Basically the whole state is locked until dropped, in order to avoid parallel calls to interfere which each other.
A similar problem was mentioned [here](https://stackoverflow.com/questions/70806839/passing-mutex-and-mutexguard-in-a-struct) and the OP solved using a crate called [lockpool](https://crates.io/crates/lockpool) but it's not well-known and doesn't look solid  and maintained.

The approach used in this PR is a pattern permitted by `parking_lot`, so between the two I would prefer the `unsafe`. But we might look for an `unsafe`-free alternative in the future.

> Note:
> We could improve using an `RwLock` instead of `Mutex` but it will make the API more complex and we will have to repeat the code; so we should add this functionality only if needed.

Resolves #713 