### PR TITLE
rusk: add gRPC logs

### DIFF
--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -35,6 +35,7 @@ toml = "0.5"
 serde = "1.0"
 bs58 = "0.4"
 hex = "0.4"
+uuid = { version = "1.1", features = ["v4", "fast-rng"] }
 
 dusk-schnorr = "0.10.0-rc"
 dusk-poseidon = { version = "0.25.0-rc", features = ["canon"] }

--- a/rusk/src/lib/services/prover.rs
+++ b/rusk/src/lib/services/prover.rs
@@ -18,7 +18,6 @@ use dusk_bytes::{DeserializableSlice, Serializable};
 use dusk_pki::PublicSpendKey;
 use once_cell::sync::Lazy;
 use tonic::{Request, Response, Status};
-use tracing::{error, info};
 
 use dusk_plonk::prelude::*;
 use dusk_schnorr::Signature;
@@ -40,25 +39,6 @@ use transfer_circuits::{
     StcoCrossover, StcoMessage, WfoChange, WfoCommitment,
     WithdrawFromObfuscatedCircuit, WithdrawFromTransparentCircuit,
 };
-
-macro_rules! handle {
-    ($self: ident, $req: ident, $handler: ident, $name: expr) => {{
-        info!("Received {} request", $name);
-        match $self.$handler(&$req.get_ref()) {
-            Ok(response) => {
-                info!(
-                    "{} was successfully processed. Sending response...",
-                    $name
-                );
-                Ok(response)
-            }
-            Err(e) => {
-                error!("An error occurred processing {}: {:?}", $name, e);
-                Err(e)
-            }
-        }
-    }};
-}
 
 #[derive(Debug, Default)]
 pub struct RuskProver {}
@@ -118,35 +98,35 @@ impl Prover for RuskProver {
         &self,
         request: Request<ExecuteProverRequest>,
     ) -> Result<Response<ExecuteProverResponse>, Status> {
-        return handle!(self, request, prove_execute, "prove_execute");
+        self.prove_execute(request.get_ref())
     }
 
     async fn prove_stct(
         &self,
         request: Request<StctProverRequest>,
     ) -> Result<Response<StctProverResponse>, Status> {
-        return handle!(self, request, prove_stct, "prove_stct");
+        self.prove_stct(request.get_ref())
     }
 
     async fn prove_stco(
         &self,
         request: Request<StcoProverRequest>,
     ) -> Result<Response<StcoProverResponse>, Status> {
-        return handle!(self, request, prove_stco, "prove_stco");
+        self.prove_stco(request.get_ref())
     }
 
     async fn prove_wfct(
         &self,
         request: Request<WfctProverRequest>,
     ) -> Result<Response<WfctProverResponse>, Status> {
-        return handle!(self, request, prove_wfct, "prove_wfct");
+        self.prove_wfct(request.get_ref())
     }
 
     async fn prove_wfco(
         &self,
         request: Request<WfcoProverRequest>,
     ) -> Result<Response<WfcoProverResponse>, Status> {
-        return handle!(self, request, prove_wfco, "prove_wfco");
+        self.prove_wfco(request.get_ref())
     }
 }
 

--- a/rusk/src/lib/services/state.rs
+++ b/rusk/src/lib/services/state.rs
@@ -25,7 +25,6 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::task::LocalPoolHandle;
 use tonic::{Request, Response, Status};
-use tracing::info;
 
 pub use rusk_schema::state_server::{State, StateServer};
 pub use rusk_schema::{
@@ -122,8 +121,6 @@ impl State for Rusk {
         &self,
         request: Request<EchoRequest>,
     ) -> Result<Response<EchoResponse>, Status> {
-        info!("Received Echo request");
-
         let request = request.into_inner();
 
         Ok(Response::new(EchoResponse {
@@ -135,8 +132,6 @@ impl State for Rusk {
         &self,
         request: Request<PreverifyRequest>,
     ) -> Result<Response<PreverifyResponse>, Status> {
-        info!("Received Preverify request");
-
         let request = request.into_inner();
 
         let tx_proto = request.tx.ok_or_else(|| {
@@ -160,8 +155,6 @@ impl State for Rusk {
         &self,
         request: Request<ExecuteStateTransitionRequest>,
     ) -> Result<Response<ExecuteStateTransitionResponse>, Status> {
-        info!("Received ExecuteStateTransition request");
-
         let mut state = self.state()?;
 
         let request = request.into_inner();
@@ -240,8 +233,6 @@ impl State for Rusk {
         &self,
         request: Request<VerifyStateTransitionRequest>,
     ) -> Result<Response<VerifyStateTransitionResponse>, Status> {
-        info!("Received VerifyStateTransition request");
-
         let request = request.into_inner();
         let generator = PublicKey::from_slice(&request.generator)
             .map_err(Error::Serialization)?;
@@ -261,8 +252,6 @@ impl State for Rusk {
         &self,
         request: Request<StateTransitionRequest>,
     ) -> Result<Response<StateTransitionResponse>, Status> {
-        info!("Received Accept request");
-
         let request = request.into_inner();
         let generator = PublicKey::from_slice(&request.generator)
             .map_err(Error::Serialization)?;
@@ -282,8 +271,6 @@ impl State for Rusk {
         &self,
         request: Request<StateTransitionRequest>,
     ) -> Result<Response<StateTransitionResponse>, Status> {
-        info!("Received Finalize request");
-
         let request = request.into_inner();
         let generator = PublicKey::from_slice(&request.generator)
             .map_err(Error::Serialization)?;
@@ -303,8 +290,6 @@ impl State for Rusk {
         &self,
         _request: Request<RevertRequest>,
     ) -> Result<Response<RevertResponse>, Status> {
-        info!("Received Revert request");
-
         let mut state = self.state()?;
         state.revert();
 
@@ -316,8 +301,6 @@ impl State for Rusk {
         &self,
         request: Request<PersistRequest>,
     ) -> Result<Response<PersistResponse>, Status> {
-        info!("Received Persist request");
-
         let request = request.into_inner();
 
         let mut state = self.state()?;
@@ -340,8 +323,6 @@ impl State for Rusk {
         &self,
         _request: Request<GetProvisionersRequest>,
     ) -> Result<Response<GetProvisionersResponse>, Status> {
-        info!("Received GetProvisioners request");
-
         let state = self.state()?;
         let provisioners = state
             .get_provisioners()?
@@ -374,8 +355,6 @@ impl State for Rusk {
         &self,
         _request: Request<GetStateRootRequest>,
     ) -> Result<Response<GetStateRootResponse>, Status> {
-        info!("Received GetEphemeralStateRoot request");
-
         let state_root = self.state()?.root().to_vec();
         Ok(Response::new(GetStateRootResponse { state_root }))
     }
@@ -387,8 +366,6 @@ impl State for Rusk {
         &self,
         request: Request<GetNotesRequest>,
     ) -> Result<Response<Self::GetNotesStream>, Status> {
-        info!("Received GetNotes request");
-
         let request = request.into_inner();
 
         let vk = match request.vk.is_empty() {
@@ -454,8 +431,6 @@ impl State for Rusk {
         &self,
         request: Request<GetNotesOwnedByRequest>,
     ) -> Result<Response<GetNotesOwnedByResponse>, Status> {
-        info!("Received GetNotesOwnedBy request");
-
         let vk = ViewKey::from_slice(&request.get_ref().vk)
             .map_err(Error::Serialization)?;
         let block_height = request.get_ref().height;
@@ -472,8 +447,6 @@ impl State for Rusk {
         &self,
         _request: Request<GetAnchorRequest>,
     ) -> Result<Response<GetAnchorResponse>, Status> {
-        info!("Received GetAnchor request");
-
         let anchor = self.state()?.fetch_anchor()?.to_bytes().to_vec();
         Ok(Response::new(GetAnchorResponse { anchor }))
     }
@@ -482,8 +455,6 @@ impl State for Rusk {
         &self,
         request: Request<GetOpeningRequest>,
     ) -> Result<Response<GetOpeningResponse>, Status> {
-        info!("Received GetOpening request");
-
         let note = Note::from_slice(&request.get_ref().note)
             .map_err(Error::Serialization)?;
 
@@ -503,8 +474,6 @@ impl State for Rusk {
         &self,
         request: Request<GetStakeRequest>,
     ) -> Result<Response<GetStakeResponse>, Status> {
-        info!("Received GetStake request");
-
         const ERR: Error = Error::Serialization(dusk_bytes::Error::InvalidData);
 
         let mut bytes = [0u8; PublicKey::SIZE];
@@ -536,8 +505,6 @@ impl State for Rusk {
         &self,
         request: Request<FindExistingNullifiersRequest>,
     ) -> Result<Response<FindExistingNullifiersResponse>, Status> {
-        info!("Received FindExistingNullifiers request");
-
         let nullifiers = &request.get_ref().nullifiers;
 
         let nullifiers = nullifiers


### PR DESCRIPTION
Use the existing tonic middleware to wrap requests with informative logs

Resolves #722