### PR TITLE
Implement stake allowlist

### DIFF
--- a/contracts/stake/src/contract/transaction.rs
+++ b/contracts/stake/src/contract/transaction.rs
@@ -112,4 +112,17 @@ impl StakeContract {
 
         (id, transaction)
     }
+
+    pub fn allowlist_transaction(
+        pk: PublicKey,
+        signature: Signature,
+        owner: PublicKey,
+    ) -> (ContractId, Transaction) {
+        let id = rusk_abi::stake_contract();
+
+        let transaction = (TX_ADD_ALLOWLIST, pk, owner, signature);
+        let transaction = Transaction::from_canon(&transaction);
+
+        (id, transaction)
+    }
 }

--- a/contracts/stake/src/lib.rs
+++ b/contracts/stake/src/lib.rs
@@ -35,3 +35,4 @@ pub const MINIMUM_STAKE: Dusk = dusk(1_000.0);
 pub const TX_STAKE: u8 = 0x00;
 pub const TX_UNSTAKE: u8 = 0x01;
 pub const TX_WITHDRAW: u8 = 0x02;
+pub const TX_ADD_ALLOWLIST: u8 = 0x03;

--- a/contracts/stake/src/wasm/bridge.rs
+++ b/contracts/stake/src/wasm/bridge.rs
@@ -80,6 +80,13 @@ fn t(bytes: &mut [u8; PAGE_SIZE]) {
             contract.withdraw(pk, signature, address, nonce);
         }
 
+        TX_ADD_ALLOWLIST => {
+            let (pk, owner, signature): (PublicKey, PublicKey, Signature) =
+                Canon::decode(&mut source).expect("Failed to parse arguments");
+
+            contract.allowlist(pk, signature, owner);
+        }
+
         _ => panic!("Tx id not implemented"),
     }
 

--- a/rusk-recovery/src/provisioners.rs
+++ b/rusk-recovery/src/provisioners.rs
@@ -35,6 +35,13 @@ pub fn keys(testnet: bool) -> &'static [PublicKey; 5] {
     }
 }
 
+pub fn owner(testnet: bool) -> PublicKey {
+    match testnet {
+        true => *DUSK_KEY,
+        false => PROVISIONERS[0],
+    }
+}
+
 pub static DUSK_KEY: Lazy<PublicKey> =
     Lazy::new(|| parse_key(include_bytes!("../dusk.cpk")));
 

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -125,12 +125,19 @@ fn genesis_stake(testnet: bool) -> StakeContract {
         stake_contract
             .insert_stake(*provisioner, stake)
             .expect("Genesis stake to be pushed to the stake");
+        stake_contract
+            .insert_allowlist(*provisioner)
+            .expect("Failed to allow genesis provisioner");
     }
     info!(
         "{} Added {} provisioners",
         theme.action("Generating"),
         provisioners::keys(testnet).len()
     );
+
+    stake_contract
+        .add_owner(provisioners::owner(testnet))
+        .expect("Failed to set stake contract owner");
 
     stake_contract
 }

--- a/rusk/tests/services/stake.rs
+++ b/rusk/tests/services/stake.rs
@@ -166,6 +166,12 @@ fn generate_stake(rusk_state: &mut RuskState) -> Result<()> {
         Stake::with_eligibility(MINIMUM_STAKE, MINIMUM_STAKE, 0),
     )?;
 
+    let sk3 = TestStore.retrieve_sk(2).expect("Should not fail in test");
+    let pk3 = PublicKey::from(&sk3);
+    stake.insert_allowlist(pk).expect("Cannot allow");
+    stake.insert_allowlist(rpk).expect("Cannot allow");
+    stake.insert_allowlist(pk3).expect("Cannot allow");
+
     info!("Updating the new stake contract state");
     unsafe {
         rusk_state.set_contract_state(&rusk_abi::stake_contract(), &stake)?;

--- a/test-utils/transfer-wrapper/src/lib.rs
+++ b/test-utils/transfer-wrapper/src/lib.rs
@@ -35,4 +35,5 @@ lazy_static! {
 
 mod wrapper;
 
+pub use wrapper::StakeState;
 pub use wrapper::TransferWrapper;


### PR DESCRIPTION
### stake-contract: 
Implement TX_ADD_ALLOWLIST operation:
- Stake contract now belong to a `owner`
- The `owner` can allow BLS public keys
- A `stake` transaction fail if it doesn't belong to an allowed key

### rusk-recovery:
* Set stake contract ownership
* Allow existing BLS keys

### transfer-wrapper: 
* Support stake contract's allowlist

### rusk: 
* Adapt tests to allow the BLS public keys

---------

Resolves #732
