### PR TITLE
Make the CI faster

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -30,19 +30,6 @@ jobs:
           profile: minimal
       - run: rustup component add rustfmt
       - run: rustup target add wasm32-unknown-unknown
-
-      - name: Cache Cargo home
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-cargo-home
-        with:
-          # See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{env.cache-name}}-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-
       - run: >
           RUSK_PROFILE_PATH="/var/opt/build-cache"
           RUSK_KEEP_KEYS="1"

--- a/rusk/Makefile
+++ b/rusk/Makefile
@@ -5,7 +5,6 @@ test: ## Run Rusk tests
 	@cargo test \
 		-vvv \
 		--release \
-		-- --nocapture \
-		--test-threads 1
+		-- --nocapture
 
-.PHONY: keys test help
+.PHONY: test help


### PR DESCRIPTION
- rusk: Change Makefile to enable multi-thread tests

  The flag was used when the rusk state was shared across multiple tests,
but this is not the case anymore.

- Remove Cargo cache from CI

  On the self hosted github action machine, it's actually faster due to
the number of cores rebuild the cargo cache than actually store it and
retrieve it.