### PR TITLE
Fix build after rustc_tools_utils upgraded

### DIFF
--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/bin/state.rs"
 required-features = ["state"]
 
 [build-dependencies]
-rustc_tools_util = "0.2"
+rustc_tools_util = "=0.2.0"
 
 [dependencies]
 hex = "0.4"

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -71,4 +71,4 @@ hex = "0.4"
 
 [build-dependencies]
 tonic-build = "0.6"
-rustc_tools_util = "0.2"
+rustc_tools_util = "=0.2.0"


### PR DESCRIPTION
rusk: change `rustc_tools_utils` dep to always use `0.2.0`
rusk-recovery: change `rustc_tools_utils` dep to always use `0.2.0`

The version `0.2.1` of rustc_tools_utils introduced a breaking change, the 
`get_channel` now returns a `String` instead of an `Option<String>`.

Resolves #745