### PR TITLE
Add `state` recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ allmacros: ## Build the workspace macro libs and test them
 keys: ## Create the keys for the circuits
 	$(MAKE) -C ./rusk-recovery keys
 
+state: wasm ## Create the network state
+	$(MAKE) -C ./rusk-recovery state
+
 wasm: ## Generate the WASM for all the contracts
 	$(MAKE) -C ./contracts $@
 	$(MAKE) -C ./test-utils $@
@@ -23,11 +26,11 @@ circuits: ## Build and test circuit crates
 contracts: ## Execute the test for all contracts
 	$(MAKE) -j1 -C ./contracts test
 
-test: keys wasm abi circuits allmacros contracts ## Run the tests
+test: keys wasm abi circuits state allmacros contracts ## Run the tests
 	$(MAKE) -C ./rusk/ $@
 	$(MAKE) -C ./test-utils $@
 
 run: wasm ## Run the server
 	cargo run --release
 
-.PHONY: abi keys wasm circuits contracts test run help
+.PHONY: abi keys state wasm circuits contracts test run help

--- a/rusk-recovery/Makefile
+++ b/rusk-recovery/Makefile
@@ -1,3 +1,5 @@
+INITFILE?=./config/localnet.toml
+
 help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
@@ -5,7 +7,7 @@ keys: ## Build circuit keys
 	cargo run --release --bin rusk-recovery-keys --features keys
 
 state: ## Build network state
-	cargo run --release --bin rusk-recovery-state --features state
+	cargo run --release --bin rusk-recovery-state --features state -- --init $(INITFILE)
 
 test: ## Run Rusk tests
 	@cargo test \

--- a/rusk-recovery/src/state/zip.rs
+++ b/rusk-recovery/src/state/zip.rs
@@ -37,7 +37,6 @@ pub(crate) fn unzip(
             fs::write(entry_path, buffer)?;
         }
     }
-    println!("done");
     Ok(())
 }
 


### PR DESCRIPTION
rusk-recovery: add `INITFILE` to state recipe

- The `INITFILE` default to a `localnet.toml` if not overridden
- Removed a leftover during the unzip

Resolves #747
