### PR TITLE
rusk-recovery: support external base state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test: keys wasm abi circuits state allmacros contracts ## Run the tests
 	$(MAKE) -C ./rusk/ $@
 	$(MAKE) -C ./test-utils $@
 
-run: wasm ## Run the server
-	cargo run --release
+run: keys state ## Run the server
+	cargo run --release --bin rusk
 
 .PHONY: abi keys state wasm circuits contracts test run help

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -49,6 +49,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.2.0", features = ["fmt"] }
 http_req = "0.8"
 zip = "0.5"
+url = "2.3"
 
 serde_derive = { version = "1", optional = true }
 serde = { version = "1", optional = true }

--- a/rusk-recovery/config/example.toml
+++ b/rusk-recovery/config/example.toml
@@ -1,3 +1,11 @@
+# The location for the base state to which apply this configuration
+#
+# The url can be either remote or local (eg: file:///path/state.zip)
+# The content of the file shall be the same format generated 
+# by `rusk-recovery-state --output <state.zip>` command
+# If no base_state is specified a local one will be generated
+base_state = "https://dusk-infra.ams3.digitaloceanspaces.com/keys/genesis.zip"
+
 [acl.stake]
 
 # List of the stake contract owners

--- a/rusk-recovery/config/genesis.toml
+++ b/rusk-recovery/config/genesis.toml
@@ -1,0 +1,3 @@
+[acl.stake]
+owners = []
+allowlist = []

--- a/rusk-recovery/config/testnet.toml
+++ b/rusk-recovery/config/testnet.toml
@@ -1,3 +1,5 @@
+base_state = "https://dusk-infra.ams3.digitaloceanspaces.com/keys/genesis.zip"
+
 [acl.stake]
 owners = ['ytfMYL5bFeZDZJAVDWX56PyoAoB4DBoNEdEFbdSrhjFYTatod7JgepeqZRN9wVLofau5j9xEo9H8HkKFUAbF9s7kd43VcGhsZkXDiZu2nS1B6pagXPZno6dy9yrigADUbE1']
 allowlist = [

--- a/rusk-recovery/src/bin/state.rs
+++ b/rusk-recovery/src/bin/state.rs
@@ -93,7 +93,7 @@ pub fn exec(config: ExecConfig) -> Result<(), Box<dyn Error>> {
     };
 
     if config.force {
-        clean_state().expect("Failed to clean up Network State directory");
+        clean_state()?;
     }
 
     let state_path = rusk_profile::get_rusk_state_dir()?;
@@ -127,8 +127,7 @@ pub fn exec(config: ExecConfig) -> Result<(), Box<dyn Error>> {
 
     info!("{} new state", theme.info("Building"));
 
-    let state_id =
-        deploy(config.init, ctor).expect("Failed to deploy network state");
+    let state_id = deploy(config.init, ctor)?;
 
     info!("{} persisted id", theme.success("Storing"));
     state_id.write(&id_path)?;
@@ -153,7 +152,7 @@ pub fn exec(config: ExecConfig) -> Result<(), Box<dyn Error>> {
 
     if let Some(output) = config.output_file {
         let state_folder = rusk_profile::get_rusk_state_dir()?;
-        let input = state_folder.parent().expect("A valid directory");
+        let input = state_folder.parent().expect("state dir not equal to root");
         info!("{} state into the output file", theme.info("Zipping"),);
         zip::zip(input, &output)?;
     }

--- a/rusk-recovery/src/bin/state.rs
+++ b/rusk-recovery/src/bin/state.rs
@@ -8,10 +8,15 @@ mod task;
 mod version;
 
 use clap::Parser;
+use microkelvin::{BackendCtor, DiskBackend, Persistence};
+use rusk_recovery_tools::theme::Theme;
+use std::error::Error;
+use std::{env, io};
 use std::{fs, path::PathBuf};
+use tracing::info;
 use version::VERSION_BUILD;
 
-use rusk_recovery_tools::state::{exec, ExecConfig};
+use rusk_recovery_tools::state::{deploy, restore_state, zip, Snapshot};
 
 #[derive(Parser, Debug)]
 #[clap(name = "rusk-recovery-state")]
@@ -27,25 +32,17 @@ struct Cli {
     )]
     profile: PathBuf,
 
-    /// Builds the state from scratch instead of downloading it.
-    #[clap(short = 'w', long, env = "RUSK_BUILD_STATE")]
-    build: bool,
-
     /// Forces a build/download even if the state is in the profile path.
     #[clap(short = 'f', long, env = "RUSK_FORCE_STATE")]
     force: bool,
 
     /// Create a state applying the init config specified in this file.
-    #[clap(short, long, parse(from_os_str))]
-    init: PathBuf,
+    #[clap(short, long, parse(from_os_str), value_name = "CONFIG")]
+    init: Option<PathBuf>,
 
     /// Sets different levels of verbosity
     #[clap(short, long, parse(from_occurrences))]
     verbose: usize,
-
-    /// Use prebuilt contracts when building the state from scratch.
-    #[clap(short = 'c', long = "contracts", env = "RUSK_PREBUILT_CONTRACTS")]
-    use_prebuilt_contracts: bool,
 
     /// If specified, the generated state is written on this file instead of
     /// save the state in the profile path.
@@ -56,22 +53,130 @@ struct Cli {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Cli::parse();
 
-    let snapshot = fs::read_to_string(args.init)?;
-    let snapshot = toml::from_str(&snapshot)?;
+    let config = match args.init {
+        Some(path) => fs::read_to_string(path)?,
+        None => include_str!("../../config/testnet.toml").into(),
+    };
+    let snapshot = toml::from_str(&config)?;
 
     task::run(
         || {
-            exec(
-                ExecConfig {
-                    build: args.build,
-                    force: args.force,
-                    output_file: args.output.clone(),
-                    use_prebuilt_contracts: args.use_prebuilt_contracts,
-                },
-                &snapshot,
-            )
+            exec(ExecConfig {
+                init: &snapshot,
+                force: args.force,
+                output_file: args.output.clone(),
+            })
         },
         args.profile,
         args.verbose,
     )
+}
+
+pub struct ExecConfig<'a> {
+    pub init: &'a Snapshot,
+    pub force: bool,
+    pub output_file: Option<PathBuf>,
+}
+
+pub fn exec(config: ExecConfig) -> Result<(), Box<dyn Error>> {
+    let theme = Theme::default();
+    info!("{} Network state", theme.action("Checking"));
+
+    let _tmpdir = match config.output_file.clone() {
+        Some(output) if output.exists() => Err("Output already exists")?,
+        Some(_) => {
+            let tmp_dir = tempfile::tempdir()?;
+            env::set_var("RUSK_STATE_PATH", tmp_dir.path());
+            Some(tmp_dir)
+        }
+        None => None,
+    };
+
+    if config.force {
+        clean_state().expect("Failed to clean up Network State directory");
+    }
+
+    let state_path = rusk_profile::get_rusk_state_dir()?;
+    let id_path = rusk_profile::get_rusk_state_id_path()?;
+
+    let ctor = &BackendCtor::new(|| {
+        DiskBackend::new(rusk_profile::get_rusk_state_dir()?)
+    });
+
+    // if the state already exists in the expected path, stop early.
+    if state_path.exists() && id_path.exists() {
+        info!("{} existing state", theme.info("Found"));
+
+        // `restore_state` function requires a backend set to the Persistence.
+        //
+        // Usually it's instantiated inside the `deploy` function, but in this
+        // case that function it's not called at all, so there is the need to
+        // explicitly instantiate it.
+        Persistence::with_backend(ctor, |_| Ok(()))?;
+
+        let network = restore_state(&id_path)?;
+        info!(
+            "{} state id at {}",
+            theme.success("Checked"),
+            id_path.display()
+        );
+        info!("{} {}", theme.action("Root"), hex::encode(network.root()));
+
+        return Ok(());
+    }
+
+    info!("{} new state", theme.info("Building"));
+
+    let state_id =
+        deploy(config.init, ctor).expect("Failed to deploy network state");
+
+    info!("{} persisted id", theme.success("Storing"));
+    state_id.write(&id_path)?;
+
+    let network = restore_state(&id_path)?;
+    info!(
+        "{} {}",
+        theme.action("Final Root"),
+        hex::encode(network.root())
+    );
+
+    info!(
+        "{} network state at {}",
+        theme.success("Stored"),
+        state_path.display()
+    );
+    info!(
+        "{} persisted id at {}",
+        theme.success("Stored"),
+        id_path.display()
+    );
+
+    if let Some(output) = config.output_file {
+        let state_folder = rusk_profile::get_rusk_state_dir()?;
+        let input = state_folder.parent().expect("A valid directory");
+        info!("{} state into the output file", theme.info("Zipping"),);
+        zip::zip(input, &output)?;
+    }
+
+    Ok(())
+}
+
+fn clean_state() -> Result<(), io::Error> {
+    let state_path = rusk_profile::get_rusk_state_dir()?;
+    let id_path = rusk_profile::get_rusk_state_id_path()?;
+
+    fs::remove_dir_all(state_path).or_else(|e| {
+        if e.kind() == io::ErrorKind::NotFound {
+            Ok(())
+        } else {
+            Err(e)
+        }
+    })?;
+    fs::remove_file(id_path).or_else(|e| {
+        if e.kind() == io::ErrorKind::NotFound {
+            Ok(())
+        } else {
+            Err(e)
+        }
+    })
 }

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -6,29 +6,30 @@
 
 use crate::theme::Theme;
 
+use canonical::{Canon, Sink, Source};
 use dusk_bytes::Serializable;
 use dusk_pki::PublicSpendKey;
 use http_req::request;
-use microkelvin::{Backend, BackendCtor, DiskBackend, Persistence};
+use microkelvin::{Backend, BackendCtor, Persistence};
 use once_cell::sync::Lazy;
 use phoenix_core::Note;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rusk_abi::ContractId;
+use rusk_vm::dusk_abi::ContractState;
 use rusk_vm::{Contract, NetworkState, NetworkStateId};
 use stake_contract::{Stake, StakeContract};
 use std::error::Error;
-use std::fs::File;
-use std::io::Read;
-use std::path::{Path, PathBuf};
-use std::{env, fs, io};
+use std::fs;
+use std::path::PathBuf;
 use tracing::info;
-use tracing::log::error;
 use transfer_contract::TransferContract;
+use url::Url;
 
 pub use snapshot::{Balance, GenesisStake, Snapshot};
 
 mod snapshot;
-mod zip;
+pub mod zip;
 
 const GENESIS_BLOCK_HEIGHT: u64 = 0;
 
@@ -42,49 +43,24 @@ pub static FAUCET_KEY: Lazy<PublicSpendKey> = Lazy::new(|| {
     PublicSpendKey::from_bytes(bytes).expect("faucet should have a valid key")
 });
 
-fn existing_diskbackend() -> BackendCtor<DiskBackend> {
-    BackendCtor::new(|| DiskBackend::new(rusk_profile::get_rusk_state_dir()?))
-}
+fn generate_transfer_state(
+    snapshot: &Snapshot,
+    state: &mut NetworkState,
+) -> Result<TransferContract, Box<dyn Error>> {
+    let mut transfer: TransferContract =
+        state.get_contract_cast_state(&rusk_abi::transfer_contract())?;
+    let theme = Theme::default();
 
-fn empty_diskbackend() -> BackendCtor<DiskBackend> {
-    BackendCtor::new(|| {
-        let dir = rusk_profile::get_rusk_state_dir()
-            .expect("Failed to get Rusk profile directory");
+    snapshot.transfers().enumerate().for_each(|(idx, balance)| {
+        info!("{} balance #{}", theme.action("Generating"), idx);
 
-        fs::remove_dir_all(&dir)
-            .or_else(|e| {
-                if e.kind() == io::ErrorKind::NotFound {
-                    Ok(())
-                } else {
-                    Err(e)
-                }
-            })
-            .expect("Failed to clean up Network State directory");
-
-        fs::create_dir_all(&dir)
-            .expect("Failed to create Network State directory");
-
-        DiskBackend::new(dir)
-    })
-}
-
-/// Creates a new transfer contract state with a single note in it - ownership
-/// of Dusk Network. If `testnet` is true an additional note - ownership of the
-/// faucet address - is added to the state.
-fn transfer_state(snapshot: &Snapshot) -> TransferContract {
-    let mut transfer = TransferContract::default();
-
-    snapshot.transfers().enumerate().for_each(|(idx, value)| {
-        let theme = Theme::default();
-        info!("{} Added {} transfer", theme.action("Generating"), idx);
-
-        let mut rng = match value.seed {
+        let mut rng = match balance.seed {
             Some(seed) => StdRng::seed_from_u64(seed),
             None => StdRng::from_entropy(),
         };
 
-        value.notes.iter().for_each(|&amount| {
-            let note = Note::transparent(&mut rng, value.address(), amount);
+        balance.notes.iter().for_each(|&amount| {
+            let note = Note::transparent(&mut rng, balance.address(), amount);
             transfer
                 .push_note(GENESIS_BLOCK_HEIGHT, note)
                 .expect("Genesis note to be pushed to the state");
@@ -101,17 +77,18 @@ fn transfer_state(snapshot: &Snapshot) -> TransferContract {
         .add_balance(rusk_abi::stake_contract(), stake_balance)
         .expect("Stake contract balance to be set with provisioner stakes");
 
-    transfer
+    Ok(transfer)
 }
 
-/// Creates a new stake contract state with preset stakes added for the
-/// staking/consensus keys in the `keys/` folder. The stakes will all be the
-/// same and the minimum amount.
-fn stake_state(snapshot: &Snapshot) -> StakeContract {
+fn generate_stake_state(
+    snapshot: &Snapshot,
+    state: &mut NetworkState,
+) -> Result<StakeContract, Box<dyn Error>> {
     let theme = Theme::default();
-    let mut stake_contract = StakeContract::default();
-    snapshot.stakes().for_each(|staker| {
-        info!("{} Added provisioner", theme.action("Generating"),);
+    let mut stake_contract: StakeContract =
+        state.get_contract_cast_state(&rusk_abi::stake_contract())?;
+    snapshot.stakes().enumerate().for_each(|(idx, staker)| {
+        info!("{} provisioner #{}", theme.action("Generating"), idx);
         let stake = Stake::with_eligibility(
             staker.amount,
             staker.reward.unwrap_or_default(),
@@ -136,78 +113,76 @@ fn stake_state(snapshot: &Snapshot) -> StakeContract {
             .expect("Failed to allow");
     });
 
-    stake_contract
+    Ok(stake_contract)
 }
 
-pub fn deploy_from_contracts<B>(
-    snapshot: &Snapshot,
-    ctor: &BackendCtor<B>,
-    contracts_folder: Option<&PathBuf>,
-) -> Result<NetworkStateId, Box<dyn Error>>
-where
-    B: 'static + Backend,
-{
-    Persistence::with_backend(ctor, |_| Ok(()))?;
-
+fn generate_empty_state() -> Result<NetworkState, Box<dyn Error>> {
     let theme = Theme::default();
     info!("{} new network state", theme.action("Generating"));
 
-    let transfer_code = match contracts_folder {
-        Some(folder) => {
-            let mut buffer = Vec::new();
-            let mut file = File::open(folder.join("transfer_contract.wasm"))?;
-            file.read_to_end(&mut buffer)?;
-            buffer
-        }
-        None => include_bytes!(
-            "../../target/wasm32-unknown-unknown/release/transfer_contract.wasm"
-        )
-        .to_vec(),
-    };
+    let transfer_code = include_bytes!(
+        "../../target/wasm32-unknown-unknown/release/transfer_contract.wasm"
+    )
+    .to_vec();
 
-    let stake_code = match contracts_folder {
-        Some(folder) => {
-            let mut buffer = Vec::new();
-            let mut file = File::open(folder.join("stake_contract.wasm"))?;
-            file.read_to_end(&mut buffer)?;
-            buffer
-        }
-        None => include_bytes!(
-            "../../target/wasm32-unknown-unknown/release/stake_contract.wasm"
-        )
-        .to_vec(),
-    };
+    let stake_code = include_bytes!(
+        "../../target/wasm32-unknown-unknown/release/stake_contract.wasm"
+    )
+    .to_vec();
 
-    let transfer = Contract::new(transfer_state(snapshot), transfer_code);
-    let stake = Contract::new(stake_state(snapshot), stake_code);
+    let mut transfer = TransferContract::default();
+
+    transfer
+        .add_balance(rusk_abi::stake_contract(), 0)
+        .expect("Stake contract balance to be set with provisioner stakes");
+    transfer
+        .update_root()
+        .expect("Root to be updated after pushing genesis note");
+
+    let transfer = Contract::new(transfer, transfer_code);
+    let stake = Contract::new(StakeContract::default(), stake_code);
 
     let mut network = NetworkState::default();
 
+    info!("{} Genesis Transfer Contract", theme.action("Deploying"));
+    network.deploy_with_id(rusk_abi::transfer_contract(), transfer)?;
+
+    info!("{} Genesis Stake Contract", theme.action("Deploying"));
+    network.deploy_with_id(rusk_abi::stake_contract(), stake)?;
+
     info!(
-        "{} Genesis Transfer Contract state",
-        theme.action("Deploying")
+        "{} {}",
+        theme.action("Empty Root"),
+        hex::encode(network.root())
     );
 
-    network
-        .deploy_with_id(rusk_abi::transfer_contract(), transfer)
-        .expect("Genesis Transfer Contract should be deployed");
+    Ok(network)
+}
 
-    info!("{} Genesis Stake Contract state", theme.action("Deploying"));
+/// Set the contract state for the given Contract Id.
+///
+/// # Safety
+///
+/// This function will corrupt the state if the contract state given is
+/// not the same type as the one stored in the state at the address
+/// provided; and the subsequent contract's call will fail.
+pub unsafe fn set_contract_state<C>(
+    contract_id: &ContractId,
+    state: &C,
+    network: &mut NetworkState,
+) -> Result<(), Box<dyn Error>>
+where
+    C: Canon,
+{
+    const PAGE_SIZE: usize = 1024 * 64;
+    let mut bytes = [0u8; PAGE_SIZE];
+    let mut sink = Sink::new(&mut bytes[..]);
+    ContractState::from_canon(state).encode(&mut sink);
+    let mut source = Source::new(&bytes[..]);
+    let contract_state = ContractState::decode(&mut source).unwrap();
+    *network.get_contract_mut(contract_id)?.state_mut() = contract_state;
 
-    network
-        .deploy_with_id(rusk_abi::stake_contract(), stake)
-        .expect("Genesis Transfer Contract should be deployed");
-
-    info!("{} network state", theme.action("Storing"));
-
-    network.commit();
-    network.push();
-
-    info!("{} {}", theme.action("Root"), hex::encode(network.root()));
-
-    let state_id = network.persist(ctor).expect("Error in persistence");
-
-    Ok(state_id)
+    Ok(())
 }
 
 pub fn deploy<B>(
@@ -217,184 +192,98 @@ pub fn deploy<B>(
 where
     B: 'static + Backend,
 {
-    deploy_from_contracts(snapshot, ctor, None)
-}
-
-pub struct ExecConfig {
-    pub build: bool,
-    pub force: bool,
-    pub use_prebuilt_contracts: bool,
-    pub output_file: Option<PathBuf>,
-}
-
-pub fn exec(
-    config: ExecConfig,
-    snapshot: &Snapshot,
-) -> Result<(), Box<dyn Error>> {
     let theme = Theme::default();
+    Persistence::with_backend(ctor, |_| Ok(()))?;
 
-    info!("{} Network state", theme.action("Checking"));
+    let mut network = match snapshot.base_state() {
+        Some(state) => load_state(state),
+        None => generate_empty_state(),
+    }?;
+    let transfer = generate_transfer_state(snapshot, &mut network)?;
+    let stake = generate_stake_state(snapshot, &mut network)?;
 
-    let _tmpdir = match config.output_file.clone() {
-        Some(output) if output.exists() => Err("Output already exists")?,
-        Some(_) if !config.build => Err("Output cannot be used when building")?,
-        Some(_) => {
-            let tmp_dir = tempfile::tempdir()?;
-            env::set_var("RUSK_STATE_PATH", tmp_dir.path());
-            Some(tmp_dir)
-        }
-        None => None,
+    // SAFETY: this is safe because we know the contracts exist
+    unsafe {
+        set_contract_state(&rusk_abi::stake_contract(), &stake, &mut network)?;
+        set_contract_state(
+            &rusk_abi::transfer_contract(),
+            &transfer,
+            &mut network,
+        )?;
     };
-
-    let state_path = rusk_profile::get_rusk_state_dir()?;
-    let id_path = rusk_profile::get_rusk_state_id_path()?;
-
-    // if we're not forcing a rebuild/download and the state already exists in
-    // the expected path, stop early.
-    if !config.force && state_path.exists() && id_path.exists() {
-        info!("{} existing state", theme.info("Found"));
-
-        try_network_restore()?;
-
-        info!(
-            "{} state id at {}",
-            theme.success("Checked"),
-            id_path.display()
-        );
-        return Ok(());
-    }
-
-    if config.build {
-        info!("{} new state", theme.info("Building"));
-
-        let contracts_folder = match config.use_prebuilt_contracts {
-            true => Some(get_contracts()?),
-            false => None,
-        };
-
-        let state_id = deploy_from_contracts(
-            snapshot,
-            &empty_diskbackend(),
-            contracts_folder.as_ref(),
-        )
-        .expect("Failed to deploy network state");
-
-        info!("{} persisted id", theme.success("Storing"));
-        state_id.write(&id_path)?;
-    } else {
-        info!("{} state from previous build", theme.info("Downloading"));
-
-        if let Err(err) = download_state() {
-            error!("{} downloading state", theme.error("Failed"));
-            return Err(err);
-        }
-    }
-    try_network_restore()?;
-
-    if !state_path.exists() {
-        error!(
-            "{} network state at {}",
-            theme.error("Missing"),
-            state_path.display()
-        );
-        return Err("Missing state at expected path".into());
-    }
-
-    if !id_path.exists() {
-        error!(
-            "{} persisted id at {}",
-            theme.error("Missing"),
-            id_path.display()
-        );
-        return Err("Missing persisted id at expected path".into());
-    }
+    network.commit();
+    network.push();
 
     info!(
-        "{} network state at {}",
-        theme.success("Stored"),
-        state_path.display()
-    );
-    info!(
-        "{} persisted id at {}",
-        theme.success("Stored"),
-        id_path.display()
-    );
-
-    if let Some(output) = config.output_file {
-        let state_folder = rusk_profile::get_rusk_state_dir()?;
-        let input = state_folder.parent().expect("A valid directory");
-        info!("{} state into the output file", theme.info("Zipping"),);
-        zip::zip(input, &output)?;
-    }
-
-    Ok(())
-}
-
-fn try_network_restore() -> Result<(), Box<dyn Error>> {
-    let theme = Theme::default();
-    Persistence::with_backend(&existing_diskbackend(), |_| Ok(()))?;
-    let network = NetworkState::new();
-    let id = NetworkStateId::read(rusk_profile::get_rusk_state_id_path()?)?;
-    let network = network.restore(id)?;
-    info!(
-        "{} restored {}",
-        theme.action("Root"),
+        "{} {}",
+        theme.action("Init Root"),
         hex::encode(network.root())
     );
-    Ok(())
+
+    let state_id = network.persist(ctor).expect("Error in persistence");
+
+    Ok(state_id)
 }
 
-const STATE_URL: &str =
-    "https://dusk-infra.ams3.digitaloceanspaces.com/keys/rusk-state.zip";
-const CONTRACTS_URL: &str =
-    "https://dusk-infra.ams3.digitaloceanspaces.com/keys/contracts.zip";
-
-/// Downloads the state into the rusk profile directory.
-fn download_state() -> Result<(), Box<dyn Error>> {
-    let mut profile_path = rusk_profile::get_rusk_profile_dir()?;
-    profile_path.pop();
-    download_and_unzip("state", STATE_URL, &profile_path)?;
-    Ok(())
-}
-
-fn get_contracts() -> Result<PathBuf, Box<dyn Error>> {
-    let folder = rusk_profile::get_rusk_profile_dir()?.join("contracts");
-    fs::create_dir_all(folder.as_path())
-        .expect("Unable to create contracts folder");
-
-    let transfer_missing = !folder.join("transfer_contract.wasm").is_file();
-    let stake_missing = !folder.join("stake_contract.wasm").is_file();
-
-    if transfer_missing || stake_missing {
-        download_and_unzip("contracts", CONTRACTS_URL, &folder)?;
-    }
-    Ok(folder)
-}
-
-/// Downloads a zip file and unzip it into the output directory.
-fn download_and_unzip(
-    description: &str,
-    uri: &str,
-    output: &Path,
-) -> Result<(), Box<dyn Error>> {
-    let theme = Theme::default();
-
-    let mut buffer = vec![];
-    let response = request::get(uri, &mut buffer)?;
-
-    // only accept success codes.
-    if !response.status_code().is_success() {
-        return Err(format!(
-            "{} download error: HTTP {}",
-            description,
-            response.status_code()
-        )
-        .into());
+/// Restore a state from a specific id_path
+pub fn restore_state(
+    id_path: &PathBuf,
+) -> Result<NetworkState, Box<dyn Error>> {
+    if !id_path.exists() {
+        return Err(
+            format!("Missing persisted id at {}", id_path.display()).into()
+        );
     }
 
-    info!("{} {} archive into", theme.info("Unzipping"), description);
+    let id = NetworkStateId::read(id_path)?;
+    let network = NetworkState::new().restore(id)?;
+
+    Ok(network)
+}
+
+/// Load a state file and save it into the rusk state directory.
+fn load_state(url: &str) -> Result<NetworkState, Box<dyn Error>> {
+    let id_path = rusk_profile::get_rusk_state_id_path()?;
+    assert!(
+        restore_state(&id_path).is_err(),
+        "No valid state should be found"
+    );
+
+    info!(
+        "{} base state from {url}",
+        Theme::default().action("Retrieving"),
+    );
+    let url = Url::parse(url)?;
+    let buffer = match url.scheme() {
+        "http" | "https" => {
+            let mut buffer = vec![];
+
+            let response = request::get(url, &mut buffer)?;
+
+            // only accept success codes.
+            if !response.status_code().is_success() {
+                return Err(format!(
+                    "State download error: HTTP {}",
+                    response.status_code()
+                )
+                .into());
+            }
+            buffer
+        }
+        "file" => fs::read(url.path())?,
+        _ => Err("Unsupported scheme")?,
+    };
+
+    let state_dir = rusk_profile::get_rusk_state_dir()?;
+    let output = state_dir.parent().expect("state dir not equal to root");
 
     zip::unzip(&buffer, output)?;
 
-    Ok(())
+    let network = restore_state(&id_path)?;
+    info!(
+        "{} {}",
+        Theme::default().action("Base Root"),
+        hex::encode(network.root())
+    );
+    Ok(network)
 }

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -96,21 +96,21 @@ fn generate_stake_state(
         );
         stake_contract
             .insert_stake(*staker.address(), stake)
-            .expect("Genesis stake to be pushed to the stake");
+            .expect("stake to be inserted into the state");
         stake_contract
             .insert_allowlist(*staker.address())
-            .expect("Failed to allow genesis provisioner");
+            .expect("staker to be inserted into the allowlist");
     });
     snapshot.owners().for_each(|provisioner| {
         stake_contract
             .add_owner(*provisioner)
-            .expect("Failed to set stake contract owner");
+            .expect("owner to be added into the state");
     });
 
     snapshot.allowlist().for_each(|provisioner| {
         stake_contract
             .insert_allowlist(*provisioner)
-            .expect("Failed to allow");
+            .expect("provisioner to be inserted into the allowlist");
     });
 
     Ok(stake_contract)
@@ -134,10 +134,10 @@ fn generate_empty_state() -> Result<NetworkState, Box<dyn Error>> {
 
     transfer
         .add_balance(rusk_abi::stake_contract(), 0)
-        .expect("Stake contract balance to be set with provisioner stakes");
+        .expect("stake contract balance to be set with provisioner stakes");
     transfer
         .update_root()
-        .expect("Root to be updated after pushing genesis note");
+        .expect("root to be updated after pushing genesis note");
 
     let transfer = Contract::new(transfer, transfer_code);
     let stake = Contract::new(StakeContract::default(), stake_code);
@@ -220,7 +220,7 @@ where
         hex::encode(network.root())
     );
 
-    let state_id = network.persist(ctor).expect("Error in persistence");
+    let state_id = network.persist(ctor)?;
 
     Ok(state_id)
 }
@@ -271,7 +271,7 @@ fn load_state(url: &str) -> Result<NetworkState, Box<dyn Error>> {
             buffer
         }
         "file" => fs::read(url.path())?,
-        _ => Err("Unsupported scheme")?,
+        _ => Err("Unsupported scheme for base state")?,
     };
 
     let state_dir = rusk_profile::get_rusk_state_dir()?;

--- a/rusk-recovery/src/state/snapshot.rs
+++ b/rusk-recovery/src/state/snapshot.rs
@@ -36,6 +36,7 @@ impl Balance {
 
 #[derive(Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct Snapshot {
+    base_state: Option<String>,
     acl: Acl,
 
     // This "serde skip" workaround seems needed as per https://github.com/toml-rs/toml-rs/issues/384
@@ -75,6 +76,10 @@ impl Snapshot {
     pub fn allowlist(&self) -> impl Iterator<Item = &PublicKey> {
         self.acl.stake.allowlist.iter().map(|pk| &**pk)
     }
+
+    pub fn base_state(&self) -> Option<&str> {
+        self.base_state.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -112,6 +117,7 @@ mod tests {
             .collect();
 
         Snapshot {
+            base_state: None,
             balance: vec![Balance {
                 address: (*state::DUSK_KEY).into(),
                 seed: Some(0xdead_beef),
@@ -140,6 +146,7 @@ mod tests {
             .collect();
 
         Snapshot {
+            base_state: Some("https://dusk-infra.ams3.digitaloceanspaces.com/keys/genesis.zip".into()),
             balance: vec![
                 Balance {
                     address: (*state::DUSK_KEY).into(),

--- a/rusk-recovery/src/state/zip.rs
+++ b/rusk-recovery/src/state/zip.rs
@@ -18,10 +18,7 @@ use zip::ZipArchive;
 use crate::theme::Theme;
 
 /// Unzip binaries into a destination folder
-pub(crate) fn unzip(
-    buffer: &[u8],
-    output: &Path,
-) -> Result<(), Box<dyn Error>> {
+pub fn unzip(buffer: &[u8], output: &Path) -> Result<(), Box<dyn Error>> {
     let reader = Cursor::new(buffer);
     let mut zip = ZipArchive::new(reader)?;
 
@@ -41,10 +38,7 @@ pub(crate) fn unzip(
 }
 
 /// Zip a folder into a destination file.
-pub(crate) fn zip(
-    src_dir: &Path,
-    dst_file: &Path,
-) -> Result<(), Box<dyn Error>> {
+pub fn zip(src_dir: &Path, dst_file: &Path) -> Result<(), Box<dyn Error>> {
     if !Path::new(src_dir).is_dir() {
         Err(ZipError::FileNotFound)?;
     }


### PR DESCRIPTION
### rusk-recovery
- Add `base-state` to init config
- Remove `build` flag (`RUSK_BUILD_STATE` env)
- Remove `contracts` flag (`RUSK_PREBUILT_CONTRACTS` env)

### Makefile
- Fix `make run`

Resolves #750