### PR TITLE
rusk-recovery: change the default init toml

### DIFF
--- a/rusk-recovery/config/testnet.toml
+++ b/rusk-recovery/config/testnet.toml
@@ -1,5 +1,3 @@
-base_state = "https://dusk-infra.ams3.digitaloceanspaces.com/keys/genesis.zip"
-
 [acl.stake]
 owners = [
     '22uowXa4bAwa9uehMFoSZjGCDTUSLGhFjCWxrEGHng8kWsEJSQBZxcCa8PeGMdTXWt9XyYNEx4S85XrGwfE8G1iG5j1ptEU4sSu1Hq3QKHsnBEZwTDLNBQeesSfmUadSjfRh'

--- a/rusk-recovery/config/testnet_remote.toml
+++ b/rusk-recovery/config/testnet_remote.toml
@@ -1,0 +1,5 @@
+base_state = "https://dusk-infra.ams3.digitaloceanspaces.com/keys/testnet-state.zip"
+
+[acl.stake]
+owners = []
+allowlist = []

--- a/rusk-recovery/src/bin/state.rs
+++ b/rusk-recovery/src/bin/state.rs
@@ -55,7 +55,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = match args.init {
         Some(path) => fs::read_to_string(path)?,
-        None => include_str!("../../config/testnet.toml").into(),
+        None => include_str!("../../config/testnet_remote.toml").into(),
     };
     let snapshot = toml::from_str(&config)?;
 

--- a/rusk-recovery/src/state/snapshot.rs
+++ b/rusk-recovery/src/state/snapshot.rs
@@ -146,7 +146,7 @@ mod tests {
             .collect();
 
         Snapshot {
-            base_state: Some("https://dusk-infra.ams3.digitaloceanspaces.com/keys/genesis.zip".into()),
+            base_state: None,
             balance: vec![
                 Balance {
                     address: (*state::DUSK_KEY).into(),


### PR DESCRIPTION
Change the default init toml to use the prebuilt testn…

Resolves #755