### PR TITLE
Daksh14/governance

### DIFF
--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -13,7 +13,7 @@ dusk-abi = "0.11"
 dusk-bls12_381 = { version = "0.9", default-features = false, features = ["canon"] }
 dusk-bytes = "0.1"
 dusk-jubjub = { version = "0.11", default-features = false, features = ["canon"] }
-dusk-hamt = { version = "0.10.0-rc", default-features = false }
+dusk-hamt = { version = "0.10.0-rc", default-features = false, optional = true }
 dusk-pki = { version = "0.10.0-rc", default-features = false }
 dusk-schnorr = { version = "0.10.0-rc", default-features = false, features = ["canon"] }
 dusk-poseidon = { version = "0.25.0-rc", default-features = false, features = ["canon"] }
@@ -21,3 +21,5 @@ rusk-abi = { path = "../../rusk-abi", features = ["module"] }
 
 [features]
 no-bridge = []
+map = ["dusk-hamt"]
+default = ["map"]

--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -22,4 +22,3 @@ rusk-abi = { path = "../../rusk-abi", features = ["module"] }
 [features]
 no-bridge = []
 map = ["dusk-hamt"]
-default = ["map"]

--- a/contracts/governance/src/collection.rs
+++ b/contracts/governance/src/collection.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use alloc::vec::Vec;
 use canonical::CanonError;
 use canonical_derive::Canon;

--- a/contracts/governance/src/collection.rs
+++ b/contracts/governance/src/collection.rs
@@ -1,0 +1,36 @@
+use alloc::vec::Vec;
+use canonical::CanonError;
+use canonical_derive::Canon;
+
+#[derive(Clone, Canon, Debug)]
+pub struct Collection<K, V> {
+    data: Vec<(K, V)>,
+}
+
+impl<K: PartialEq, V> Collection<K, V> {
+    pub fn get(&self, key: &K) -> Result<Option<&V>, CanonError> {
+        Ok(self.data.iter().find(|(x, _)| x == key).map(|(_, y)| y))
+    }
+
+    pub fn insert(&mut self, key: K, value: V) -> Result<(), CanonError> {
+        self.data.push((key, value));
+
+        Ok(())
+    }
+
+    pub fn remove(&mut self, key: &K) -> Result<Option<V>, CanonError> {
+        if let Some(index) = self.data.iter().position(|(x, _)| x == key) {
+            let (_, val) = self.data.remove(index);
+
+            Ok(Some(val))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl<K, V> Default for Collection<K, V> {
+    fn default() -> Self {
+        Self { data: Vec::new() }
+    }
+}

--- a/contracts/governance/src/governance.rs
+++ b/contracts/governance/src/governance.rs
@@ -4,24 +4,29 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#[cfg(not(feature = "map"))]
+use crate::collection::Collection;
+
 use core::iter;
 
 use alloc::vec;
 use alloc::vec::Vec;
 use canonical_derive::Canon;
 use dusk_bls12_381::BlsScalar;
-use dusk_hamt::Map;
 use dusk_jubjub::GENERATOR_EXTENDED;
 use dusk_pki::PublicKey;
 use dusk_schnorr::Signature;
 
 use crate::*;
 
+#[cfg(feature = "map")]
+type Collection<K, V> = dusk_hamt::Map<K, V>;
+
 #[derive(Debug, Default, Clone, Canon)]
 pub struct GovernanceContract {
-    pub(crate) seeds: Map<BlsScalar, ()>,
-    pub(crate) balances: Map<PublicKey, u64>,
-    pub(crate) whitelist: Map<PublicKey, ()>,
+    pub(crate) seeds: Collection<BlsScalar, ()>,
+    pub(crate) balances: Collection<PublicKey, u64>,
+    pub(crate) whitelist: Collection<PublicKey, ()>,
     pub(crate) paused: bool,
     pub(crate) total_supply: u64,
 }

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -11,6 +11,9 @@ extern crate alloc;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 
+#[cfg(not(feature = "map"))]
+mod collection;
+
 mod error;
 mod governance;
 


### PR DESCRIPTION
Add feature to allow usage of both Vec and Map. 

The feature is called `map`

There are some clippy warnings when switching features. There are multiple ways to fix the clippy errors but I'm confused between.

1. Having a deref impl for the new added `Collection` will suppress all the warnings but it's unnecessary.
2. Calling methods differently for different features in the function body. This might create too much duplicate code.

**Note**: The Vec's `get`, `remove` methods are very naive implementations. Do we need to revise them for being more efficient?

What do you guys think?