### PR TITLE
Add vector feature, mint tokens on tranfers

### DIFF
--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -13,7 +13,6 @@ dusk-abi = "0.11"
 dusk-bls12_381 = { version = "0.9", default-features = false, features = ["canon"] }
 dusk-bytes = "0.1"
 dusk-jubjub = { version = "0.11", default-features = false, features = ["canon"] }
-dusk-hamt = { version = "0.10.0-rc", default-features = false }
 dusk-pki = { version = "0.10.0-rc", default-features = false }
 dusk-schnorr = { version = "0.10.0-rc", default-features = false, features = ["canon"] }
 dusk-poseidon = { version = "0.25.0-rc", default-features = false, features = ["canon"] }

--- a/contracts/governance/src/collection.rs
+++ b/contracts/governance/src/collection.rs
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use alloc::vec::Vec;
+use canonical::CanonError;
+use canonical_derive::Canon;
+
+#[derive(Clone, Canon, Debug)]
+pub struct Collection<K, V> {
+    data: Vec<(K, V)>,
+}
+
+impl<K: PartialEq, V: PartialEq> Collection<K, V> {
+    // Methods return a result to keep things consistent with the map methods
+    pub fn get(&self, key: &K) -> Result<Option<&V>, CanonError> {
+        Ok(self.data.iter().find_map(|(k, v)| (k == key).then_some(v)))
+    }
+
+    pub fn insert(&mut self, key: K, value: V) -> Result<(), CanonError> {
+        if let Some(pos) = self.data.iter().position(|(k, _)| k == &key) {
+            self.data[pos] = (key, value)
+        } else {
+            self.data.push((key, value))
+        }
+
+        Ok(())
+    }
+
+    pub fn remove(&mut self, key: &K) -> Result<(), CanonError> {
+        self.data.retain(|(k, _)| k != key);
+
+        Ok(())
+    }
+}
+
+impl<K, V> Default for Collection<K, V> {
+    fn default() -> Self {
+        Self { data: Vec::new() }
+    }
+}

--- a/contracts/governance/src/governance.rs
+++ b/contracts/governance/src/governance.rs
@@ -10,18 +10,18 @@ use alloc::vec;
 use alloc::vec::Vec;
 use canonical_derive::Canon;
 use dusk_bls12_381::BlsScalar;
-use dusk_hamt::Map;
 use dusk_jubjub::GENERATOR_EXTENDED;
 use dusk_pki::PublicKey;
 use dusk_schnorr::Signature;
 
+use crate::collection::Collection;
 use crate::*;
 
 #[derive(Debug, Default, Clone, Canon)]
 pub struct GovernanceContract {
-    pub(crate) seeds: Map<BlsScalar, ()>,
-    pub(crate) balances: Map<PublicKey, u64>,
-    pub(crate) whitelist: Map<PublicKey, ()>,
+    pub(crate) seeds: Collection<BlsScalar, ()>,
+    pub(crate) balances: Collection<PublicKey, u64>,
+    pub(crate) whitelist: Collection<PublicKey, ()>,
     pub(crate) paused: bool,
     pub(crate) total_supply: u64,
 }
@@ -70,10 +70,11 @@ impl GovernanceContract {
         (!self.paused).then_some(()).ok_or(Error::ContractIsPaused)
     }
 
+    // to keep code consistent with other collections, we supress deref warnings
+    // as its not implemented for other when we switch features.
     fn is_allowed(&self, address: &PublicKey) -> Result<(), Error> {
         self.whitelist
             .get(address)?
-            .as_deref()
             .copied()
             .ok_or(Error::AddressIsNotWhitelisted)
     }
@@ -169,7 +170,6 @@ impl GovernanceContract {
         let value = self
             .balances
             .get(&address)?
-            .as_deref()
             .copied()
             .unwrap_or(0)
             .checked_add(value)
@@ -202,7 +202,6 @@ impl GovernanceContract {
         let value = self
             .balances
             .get(&address)?
-            .as_deref()
             .copied()
             .unwrap_or(0)
             .checked_sub(value)
@@ -238,8 +237,7 @@ impl GovernanceContract {
         {
             self.is_allowed(&from)?;
 
-            let mut base =
-                self.balances.get(&from)?.as_deref().copied().unwrap_or(0);
+            let mut base = self.balances.get(&from)?.copied().unwrap_or(0);
 
             if base < amount {
                 let remaining = amount - base;
@@ -248,13 +246,12 @@ impl GovernanceContract {
 
                 base = 0;
             } else {
-                base = base - amount;
+                base -= amount;
             }
 
             let target = self
                 .balances
                 .get(&to)?
-                .as_deref()
                 .copied()
                 .unwrap_or(0)
                 .checked_add(amount)

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -11,6 +11,7 @@ extern crate alloc;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 
+mod collection;
 mod error;
 mod governance;
 


### PR DESCRIPTION
Adds functionality that mints new tokens if balance is insufficient during transfer. Adds a `map` feature for the contract to use a `Vec` instead of a `dusk_hamt::Map`