### PR TITLE
Remove null and use the common empty protobuf

### DIFF
--- a/rusk-schema/Cargo.toml
+++ b/rusk-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-schema"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 license = "MPL-2.0"

--- a/rusk-schema/protos/network.proto
+++ b/rusk-schema/protos/network.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package rusk;
 
+import "google/protobuf/empty.proto";
+
 message MessageMetadata {
     uint32 kadcast_height=1;
     string src_address=2;
@@ -33,21 +35,19 @@ message AliveNodesResponse {
     repeated string address = 1;
 }
 
-message Null {};
-
 service Network {
 
     // Receive messages coming from the network
-    rpc Listen(Null) returns (stream Message) {}
+    rpc Listen(google.protobuf.Empty) returns (stream Message) {}
 
     // Broadcast a message to the network
-    rpc Broadcast(BroadcastMessage) returns (Null) {}
+    rpc Broadcast(BroadcastMessage) returns (google.protobuf.Empty) {}
 
     // Propagate a message to the network and notify current receivers
-    rpc Propagate(PropagateMessage) returns (Null) {}
+    rpc Propagate(PropagateMessage) returns (google.protobuf.Empty) {}
 
     // Send a message to a specific target in the network
-    rpc Send(SendMessage) returns (Null) {}
+    rpc Send(SendMessage) returns (google.protobuf.Empty) {}
 
     // Retrieve network nodes considered alive
     rpc AliveNodes(AliveNodesRequest) returns (AliveNodesResponse) {}

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk"
-version = "0.5.0-rc.1"
+version = "0.6.0"
 edition = "2021"
 autobins = false
 

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 edition = "2021"
 autobins = false
 

--- a/rusk/src/lib/services/network.rs
+++ b/rusk/src/lib/services/network.rs
@@ -22,7 +22,7 @@ use futures::Stream;
 pub use rusk_schema::{
     network_server::{Network, NetworkServer},
     AliveNodesRequest, AliveNodesResponse, BroadcastMessage, Message,
-    MessageMetadata, Null, PropagateMessage, SendMessage,
+    MessageMetadata, PropagateMessage, SendMessage,
 };
 use std::io::Write;
 use std::net::AddrParseError;
@@ -100,7 +100,7 @@ impl Network for KadcastDispatcher {
     async fn send(
         &self,
         request: Request<SendMessage>,
-    ) -> Result<Response<Null>, Status> {
+    ) -> Result<Response<()>, Status> {
         debug!("Received SendMessage request");
         let req = request.get_ref();
         self.peer
@@ -111,13 +111,13 @@ impl Network for KadcastDispatcher {
                 })?,
             )
             .await;
-        Ok(Response::new(Null {}))
+        Ok(Response::new(()))
     }
 
     async fn propagate(
         &self,
         request: Request<PropagateMessage>,
-    ) -> Result<Response<Null>, Status> {
+    ) -> Result<Response<()>, Status> {
         debug!("Received PropagateMessage request");
 
         let wire_message = {
@@ -136,13 +136,13 @@ impl Network for KadcastDispatcher {
                 warn!("Error in dispatcher notification {}", e);
                 0
             });
-        Ok(Response::new(Null {}))
+        Ok(Response::new(()))
     }
 
     async fn broadcast(
         &self,
         request: Request<BroadcastMessage>,
-    ) -> Result<Response<Null>, Status> {
+    ) -> Result<Response<()>, Status> {
         debug!("Received BroadcastMessage request");
         let req = request.get_ref();
         let kadcast_height: u8 = req
@@ -152,7 +152,7 @@ impl Network for KadcastDispatcher {
         self.peer
             .broadcast(&req.message, Some(kadcast_height))
             .await;
-        Ok(Response::new(Null {}))
+        Ok(Response::new(()))
     }
 
     async fn alive_nodes(
@@ -174,7 +174,7 @@ impl Network for KadcastDispatcher {
 
     async fn listen(
         &self,
-        _: Request<Null>,
+        _: Request<()>,
     ) -> Result<Response<Self::ListenStream>, Status> {
         debug!("Received Listen request");
         let mut rx = self.inbound_dispatcher.subscribe();


### PR DESCRIPTION
This closes #461 and removes Null from `network.proto`. Replace it with unit type.