### PR TITLE
Upgraded Clap from v3 to v4; adapted macro parameters accordingly

### DIFF
--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -42,7 +42,7 @@ canonical_derive = "0.7"
 dusk-bytes = "0.1"
 dusk-bls12_381 = "0.9"
 dusk-bls12_381-sign = "0.3.0-rc"
-clap = { version = "3.1", features = ["cargo", "env", "derive"] }
+clap = { version = "4.0.29", features = ["cargo", "env", "derive"] }
 thiserror = "1.0"
 console = "0.12"
 tracing = "0.1"

--- a/rusk-recovery/src/bin/keys.rs
+++ b/rusk-recovery/src/bin/keys.rs
@@ -8,6 +8,7 @@ mod task;
 mod version;
 
 use clap::Parser;
+use clap::builder::ArgAction;
 use std::path::PathBuf;
 use version::VERSION_BUILD;
 
@@ -19,7 +20,7 @@ struct Cli {
     #[clap(
         short,
         long,
-        parse(from_os_str),
+        value_parser,
         value_name = "PATH",
         env = "RUSK_PROFILE_PATH"
     )]
@@ -30,7 +31,7 @@ struct Cli {
     keep: bool,
 
     /// Sets different levels of verbosity
-    #[clap(short, long, parse(from_occurrences))]
+    #[clap(short, long, action = ArgAction::Count)]
     verbose: usize,
 }
 

--- a/rusk-recovery/src/bin/state.rs
+++ b/rusk-recovery/src/bin/state.rs
@@ -14,7 +14,7 @@ use std::error::Error;
 use std::{env, io};
 use std::{fs, path::PathBuf};
 use tracing::info;
-use version::VERSION_BUILD;
+// use version::VERSION_BUILD;
 
 use rusk_recovery_tools::state::{deploy, restore_state, zip, Snapshot};
 
@@ -26,7 +26,7 @@ struct Cli {
     #[clap(
         short,
         long,
-        parse(from_os_str),
+        value_parser,
         value_name = "PATH",
         env = "RUSK_PROFILE_PATH"
     )]
@@ -37,16 +37,16 @@ struct Cli {
     force: bool,
 
     /// Create a state applying the init config specified in this file.
-    #[clap(short, long, parse(from_os_str), value_name = "CONFIG")]
+    #[clap(short, long, value_parser, value_name = "CONFIG")]
     init: Option<PathBuf>,
 
     /// Sets different levels of verbosity
-    #[clap(short, long, parse(from_occurrences))]
+    #[clap(short, long, action = ArgAction::Count)]
     verbose: usize,
 
     /// If specified, the generated state is written on this file instead of
     /// save the state in the profile path.
-    #[clap(short, long, parse(from_os_str), takes_value(true))]
+    #[clap(Arg::num_args(1), short, long, value_parser)]
     output: Option<PathBuf>,
 }
 

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -21,7 +21,7 @@ async-stream = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", features = ["fmt", "env-filter", "json"] }
 hyper = { version = "0.14", features = ["full"] }
-clap = { version = "3.1", features = ["env"] }
+clap = { version = "4.0.29", features = ["env"] }
 prost = "0.9"
 tower = "0.4"
 futures = "0.3"


### PR DESCRIPTION
Doesn't compile; unresolved compile error at `rusk-recovery/state.rs:49`, (`Arg::num_args()`), contradicting Clap documentation!