### PR TITLE
Add 'all' target to 'make'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,13 @@ help: ## Display this help screen
 		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-abi: ## Build the ABI and test it
-	$(MAKE) -C ./rusk-abi test
+all: keys wasm abi circuits state allmacros contracts ## Build everything
 
+abi: ## Build the ABI
+	$(MAKE) -C ./rusk-abi all
+	
 allmacros: ## Build the workspace macro libs and test them
-	$(MAKE) -C ./macros test
+	$(MAKE) -C ./macros all
 
 keys: ## Create the keys for the circuits
 	$(MAKE) -C ./rusk-recovery keys
@@ -20,13 +22,18 @@ wasm: ## Generate the WASM for all the contracts
 	$(MAKE) -C ./test-utils $@
 	$(MAKE) -C ./rusk-abi $@
 
-circuits: ## Build and test circuit crates
-	$(MAKE) -j -C ./circuits test
+circuits: ## Build circuit crates
+	$(MAKE) -j -C ./circuits all
 
 contracts: ## Execute the test for all contracts
-	$(MAKE) -j1 -C ./contracts test
+	$(MAKE) -j1 -C ./contracts all
 
-test: keys wasm abi circuits state allmacros contracts ## Run the tests
+test: keys wasm ## Run the tests
+	$(MAKE) -C ./rusk-abi/ $@
+	$(MAKE) -j -C ./circuits $@
+	$(MAKE) state
+	$(MAKE) -C ./macros $@
+	$(MAKE) -j1 -C ./contracts $@
 	$(MAKE) -C ./rusk/ $@
 	$(MAKE) -C ./test-utils $@
 
@@ -36,4 +43,4 @@ run: keys state ## Run the server
 node: rusk ## Build node binary
 	$(MAKE) -C ./node binary
 
-.PHONY: abi keys state wasm circuits contracts test run help node
+.PHONY: all abi keys state wasm circuits contracts test run help node

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ The Dusk's Smart Contract Platform.
 _Unstable_ : No guarantees can be made regarding the API stability, the project
 is in development.
 
+## Build
+
+To build rusk:
+
+```
+source .env
+make all
+```
+
 ## Tests
 
 To run tests:

--- a/circuits/Makefile
+++ b/circuits/Makefile
@@ -5,9 +5,11 @@ help: ## Display this help screen
 		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+all: $(SUBDIRS) ## Build all in the subfolder
+
 test: $(SUBDIRS) ## Run all the tests in the subfolder
 
 $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 
-.PHONY: test help $(SUBDIRS)
+.PHONY: all test help $(SUBDIRS)

--- a/circuits/transfer/Makefile
+++ b/circuits/transfer/Makefile
@@ -3,8 +3,12 @@ help: ## Display this help screen
 		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+all: ## Build the circuits
+	@cargo build --release \
+		--features builder
+
 test: ## Run the transfer circuits tests
 	@cargo test --release \
 		--features builder
 
-.PHONY: test help
+.PHONY: all test help

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -5,6 +5,8 @@ help: ## Display this help screen
 		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+all: $(SUBDIRS) ## Build all the contracts
+
 test: $(SUBDIRS) ## Run all the tests in the subfolder
 
 wasm: $(SUBDIRS) ## Generate the WASM for all the contracts
@@ -12,4 +14,4 @@ wasm: $(SUBDIRS) ## Generate the WASM for all the contracts
 $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 
-.PHONY: test help $(SUBDIRS)
+.PHONY: all test help $(SUBDIRS)

--- a/contracts/stake/Makefile
+++ b/contracts/stake/Makefile
@@ -3,6 +3,9 @@ help: ## Display this help screen
 		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+all: ## Build the stake contract
+	@cargo build --release
+
 check: wasm ## Run the Rust check on the project features
 	@cargo check --target wasm32-unknown-unknown
 	@cargo check
@@ -17,4 +20,4 @@ wasm: ## Build the WASM files
 		--target wasm32-unknown-unknown \
 		-- -C link-args=-s
 
-.PHONY: check test wasm help
+.PHONY: all check test wasm help

--- a/contracts/transfer/Makefile
+++ b/contracts/transfer/Makefile
@@ -3,6 +3,9 @@ help: ## Display this help screen
 		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+all: ## Build the transfer contract
+	@cargo build --release
+
 check: wasm ## Run the Rust check on the project features
 	@cargo check --target wasm32-unknown-unknown
 	@cargo check
@@ -17,4 +20,4 @@ wasm: ## Build the WASM files
 		--target wasm32-unknown-unknown \
 		-- -C link-args=-s
 
-.PHONY: check test wasm help
+.PHONY: all check test wasm help

--- a/macros/Makefile
+++ b/macros/Makefile
@@ -5,9 +5,11 @@ help: ## Display this help screen
 		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+all: $(SUBDIRS) ## Build all in the subfolder
+
 test: $(SUBDIRS) ## Run all the tests in the subfolder
 
 $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 
-.PHONY: test help $(SUBDIRS)
+.PHONY: all test help $(SUBDIRS)

--- a/macros/code-hasher/Makefile
+++ b/macros/code-hasher/Makefile
@@ -3,8 +3,11 @@ help: ## Display this help screen
 		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+all: ## Build the code-hasher macro
+	@cargo build --release 
+
 test: ## Perform the test of the code-hasher macro
 	@cargo test \
 		--release \
 
-.PHONY: test help
+.PHONY: all test help

--- a/rusk-abi/Makefile
+++ b/rusk-abi/Makefile
@@ -1,5 +1,8 @@
 SUBDIRS := $(wildcard ./tests/contracts/*/.)
 
+all: ## Build the ABI
+	cargo build --all-features
+
 help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
@@ -12,4 +15,4 @@ test: $(SUBDIRS)
 $(SUBDIRS):
 	$(MAKE) -C $@
 
-.PHONY: help all test $(SUBDIRS)
+.PHONY: all help test $(SUBDIRS)


### PR DESCRIPTION
This PR implements #782 

With this changes, it is possible to build everything without running tests, allowing to save time.
This is done by running `make all`.

At the same time, for compatibility reasons, the current behavior of `make test` is maintained (i.e., it builds everything first and then run tests).

To give a hint on the performance difference,
on my machine, `make test` takes around 40 minutes to complete (in a new setup),
while 'make all' only takes 15 minutes.