### PR TITLE
node: Integrate RocksDB with two column families

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -26,5 +26,3 @@ tracing-subscriber = "0.2"
 async-channel = "1.7"
 
 rocksdb_lib = { package = "rocksdb", version = "0.19.0", default-features = false }
-
-[dev-dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -28,4 +28,3 @@ async-channel = "1.7"
 rocksdb_lib = { package = "rocksdb", version = "0.19.0", default-features = false }
 
 [dev-dependencies]
-lazy_static = "1.4"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,3 +24,8 @@ async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = "0.2"
 async-channel = "1.7"
+
+rocksdb_lib = { package = "rocksdb", version = "0.19.0", default-features = false }
+
+[dev-dependencies]
+lazy_static = "1.4"

--- a/node/src/bin/main.rs
+++ b/node/src/bin/main.rs
@@ -24,7 +24,7 @@ pub async fn main() {
         vec![Box::<MempoolSrv>::default(), Box::<ChainSrv>::default()];
 
     let net = Kadcast::new(kadcast::config::Config::default());
-    let db = rocksdb::Backend::create_or_open("/tmp/db/".to_string());
+    let db = rocksdb::Backend::create_or_open("".to_string());
 
     // node spawn_all is the entry point
     if let Err(e) = Node::new(net, db).spawn_all(service_list).await {

--- a/node/src/bin/main.rs
+++ b/node/src/bin/main.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use node::chain::ChainSrv;
-use node::database::rocksdb;
+use node::database::{rocksdb, DB};
 use node::mempool::MempoolSrv;
 use node::network::Kadcast;
 use node::{LongLivedService, Node};
@@ -24,7 +24,7 @@ pub async fn main() {
         vec![Box::<MempoolSrv>::default(), Box::<ChainSrv>::default()];
 
     let net = Kadcast::new(kadcast::config::Config::default());
-    let db = rocksdb::Backend {};
+    let db = rocksdb::Backend::create_or_open("/tmp/db/".to_string());
 
     // node spawn_all is the entry point
     if let Err(e) = Node::new(net, db).spawn_all(service_list).await {

--- a/node/src/chain/mod.rs
+++ b/node/src/chain/mod.rs
@@ -41,7 +41,7 @@ impl<N: Network, DB: database::DB> LongLivedService<N, DB> for ChainSrv {
                     Topics::Block => {
                         // Try to validate message
                         if self.is_valid(&msg).is_ok() {
-                            _ = network.read().await.repropagate(&msg, 0);
+                            network.read().await.repropagate(&msg, 0).await;
 
                             self.handle_block_msg(&msg);
                         }

--- a/node/src/data/mod.rs
+++ b/node/src/data/mod.rs
@@ -6,7 +6,7 @@
 
 use std::io::{self, Read, Write};
 
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Default)]
 pub enum Topics {
     // Data exchange topics.
     GetData = 8,
@@ -25,13 +25,8 @@ pub enum Topics {
     Agreement = 18,
     AggrAgreement = 19,
 
+    #[default]
     Unknown = 100,
-}
-
-impl Default for Topics {
-    fn default() -> Self {
-        Topics::Unknown
-    }
 }
 
 impl From<Topics> for u8 {

--- a/node/src/database/mod.rs
+++ b/node/src/database/mod.rs
@@ -4,20 +4,22 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use dusk_consensus::commons::Block;
 pub mod rocksdb;
 use anyhow::Result;
+
 pub trait DB: Send + Sync + 'static {
-    type T: Tx;
+    type T<'a>: Tx;
 
     /// Creates or open a database located at this path.
     ///
-    /// Panics if openning db or creating one fails.
+    /// Panics if opening db or creating one fails.
     fn create_or_open(path: String) -> Self;
 
     /// Provides a managed execution of a read-only isolated transaction.
-    fn view<F>(&'static mut self, f: F) -> Result<()>
+    fn view<F>(&self, f: F) -> Result<()>
     where
-        F: FnOnce(&Self::T) -> Result<()>;
+        F: for<'a> FnOnce(Self::T<'a>) -> Result<()>;
 
     /// Provides a managed execution of a read-write atomic transaction.
     ///
@@ -26,52 +28,28 @@ pub trait DB: Send + Sync + 'static {
     ///
     /// Transaction commit will happen only if no error is returned by `fn`
     /// and no panic is raised on `fn` execution.
-    fn update<F>(&'static self, f: F) -> Result<()>
+    fn update<F>(&self, f: F) -> Result<()>
     where
-        F: FnOnce(&mut Self::T) -> Result<()>;
+        F: for<'a> FnOnce(&Self::T<'a>) -> Result<()>;
 
     fn close(&mut self);
 }
 
 /// Implements both read-write and read-only transactions to DB.
-///
-/// TODO: Uncomment APIs when ContractCall and Block, Header and certificate are
-/// defined
 pub trait Tx {
-    // Read-only transactions.
-    //fn fetch_block_header(&self, hash: &[u8]) -> Result<&Header>;
-    //fn fetch_block_txs(&self, hash: &[u8]) -> Result<Vec<ContractCall>>;
-    //fn fetch_block_tx_by_hash(
-    //    &self,
-    //    tx_id: &[u8],
-    //) -> Result<(ContractCall, u32, &[u8])>;
-
-    fn fetch_block_hash_by_height(&self, height: u64) -> Result<&[u8]>;
-    fn fetch_block_exists(&self, hash: &[u8]) -> Result<bool>;
-    // fn fetch_block_by_state_root(
-    //    &self,
-    //    from_height: u64,
-    //    state_root: &[u8],
-    //) -> Result<&Block>;
-    fn fetch_registry(&self) -> Result<Registry>;
-
     // Read-write transactions
-    //fn store_block(&mut self, block: &Block, persisted: bool) -> Result<()>;
-    //fn delete_block(&mut self, b: &Block) -> Result<()>;
-    //fn fetch_block(&self, hash: &[u8]) -> Result<&Block>;
-    fn fetch_current_height(&self) -> Result<u64>;
-    fn fetch_block_height_since(
-        &self,
-        since_unix_time: i64,
-        offset: u64,
-    ) -> Result<u64>;
-    //fn store_candidate_message(&mut self, cm: Block) -> Result<()>;
-    //fn fetch_candidate_message(&self, hash: &[u8]) -> Result<Block>;
-    fn clear_candidate_messages(&mut self) -> Result<()>;
-    fn clear_database(&mut self) -> Result<()>;
+    fn store_block(&self, b: &Block, persisted: bool) -> Result<()>;
+    fn delete_block(&self, b: &Block) -> Result<()>;
+    fn fetch_block(&self, hash: &[u8]) -> Result<Option<Block>>;
+
+    // Candidate block functions
+    fn store_candidate_block(&self, cm: Block) -> Result<()>;
+    fn fetch_candidate_block(&self, hash: &[u8]) -> Result<Option<Block>>;
+    fn clear_candidates(&self) -> Result<()>;
+
+    fn clear_database(&self) -> Result<()>;
+
     fn commit(self) -> Result<()>;
-    fn rollback(&mut self) -> Result<()>;
-    fn close(&mut self);
 }
 
 #[derive(Default)]

--- a/node/src/database/rocksdb.rs
+++ b/node/src/database/rocksdb.rs
@@ -220,8 +220,6 @@ impl<'db, DB: DBAccess> Tx for Transaction<'db, DB> {
 mod tests {
     use super::*;
     use dusk_consensus::commons::{Certificate, Header, Signature};
-    use lazy_static::lazy_static;
-
     #[test]
     fn test_store_block() {
         let t = TestWrapper {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![feature(generic_associated_types)]
 #![allow(unused)]
 
 pub mod chain;

--- a/node/src/mempool/mod.rs
+++ b/node/src/mempool/mod.rs
@@ -60,7 +60,7 @@ impl<N: Network, DB: database::DB> LongLivedService<N, DB> for MempoolSrv {
                 match msg.topic {
                     Topics::Tx => {
                         if self.handle_tx(&msg).is_ok() {
-                            _ = network.read().await.repropagate(&msg, 0);
+                            network.read().await.repropagate(&msg, 0).await;
                         }
                     }
                     _ => todo!(),


### PR DESCRIPTION
fixes #806

With this PR we integrate RocksDB and implement briefly the main database operations  like add/fetch block, add/fetch candidate block.

Basic database transaction attributes are also addressed - like isolation and atomicity (durability is natively provided in RocksDB by enabling Write-Ahead-Log feature) .

In another issue/PR,  Block Transaction data and additional lookup indexes will be added. More Database APIs (like fetch block exists etc) will be also added.

Column families:

- CF_LEDGER - stores verified/accepted blocks and lookup indexes. Persisted to disk.
- CF_CANDIDATES - stores a list of candidates block needed by a consensus round. They will be usually stored in L0 (memtable-only)

 
