### PR TITLE
governance-contract: Add broker and update methods for broker and authority

### DIFF
--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -11,6 +11,7 @@ canonical = "0.7"
 canonical_derive = "0.7"
 dusk-abi = "0.11"
 dusk-bls12_381 = { version = "0.9", default-features = false, features = ["canon"] }
+dusk-bls12_381-sign = "0.3.0-rc"
 dusk-bytes = "0.1"
 dusk-jubjub = { version = "0.11", default-features = false, features = ["canon"] }
 dusk-pki = { version = "0.10.0-rc", default-features = false }

--- a/contracts/governance/src/error.rs
+++ b/contracts/governance/src/error.rs
@@ -11,6 +11,7 @@ use core::fmt;
 pub enum Error {
     AddressIsNotWhitelisted,
     BalanceOverflow,
+    InvalidPublicKey,
     Canon(CanonError),
     ContractIsPaused,
     InsufficientBalance,

--- a/contracts/governance/src/governance.rs
+++ b/contracts/governance/src/governance.rs
@@ -42,8 +42,9 @@ impl GovernanceContract {
     ) -> Result<(), Error> {
         // Cannot construct BlsPublicKey in a const context that's why we
         // construct it in the function body.
-        let authority = BlsPublicKey::from_bytes(Self::AUTHORITY).map_err(|_| Error::InvalidPublicKey)?;
-        
+        let authority = BlsPublicKey::from_bytes(Self::AUTHORITY)
+            .map_err(|_| Error::InvalidPublicKey)?;
+
         let seed = arguments[0];
 
         if self.seeds.get(&seed)?.is_some() {


### PR DESCRIPTION
Add broker in the state of the Contract and shift authority to the state too. Add methods to update each. 

TODO:  Find where broker is used from the state. It is currently not being used and is an unread field.