### PR TITLE
rusk-recovery: Add support for tar archives

### DIFF
--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -56,7 +56,6 @@ serde = { version = "1", optional = true }
 toml = { version = "0.5", optional = true }
 bs58 = { version = "0.4", optional = true }
 tempfile = "3.3"
-walkdir = "2.3"
 
 [features]
 state = ["serde_derive", "serde", "toml", "bs58"]

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -50,6 +50,8 @@ tracing-subscriber = { version = "0.2.0", features = ["fmt"] }
 http_req = "0.8"
 zip = "0.5"
 url = "2.3"
+flate2 = "1"
+tar = "0.4"
 
 serde_derive = { version = "1", optional = true }
 serde = { version = "1", optional = true }

--- a/rusk-recovery/src/bin/state.rs
+++ b/rusk-recovery/src/bin/state.rs
@@ -16,7 +16,7 @@ use std::{fs, path::PathBuf};
 use tracing::info;
 use version::VERSION_BUILD;
 
-use rusk_recovery_tools::state::{deploy, restore_state, zip, Snapshot};
+use rusk_recovery_tools::state::{deploy, restore_state, tar, Snapshot};
 
 #[derive(Parser, Debug)]
 #[clap(name = "rusk-recovery-state")]
@@ -154,7 +154,7 @@ pub fn exec(config: ExecConfig) -> Result<(), Box<dyn Error>> {
         let state_folder = rusk_profile::get_rusk_state_dir()?;
         let input = state_folder.parent().expect("state dir not equal to root");
         info!("{} state into the output file", theme.info("Zipping"),);
-        zip::zip(input, &output)?;
+        tar::archive(input, &output)?;
     }
 
     Ok(())

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -29,7 +29,8 @@ use url::Url;
 pub use snapshot::{Balance, GenesisStake, Snapshot};
 
 mod snapshot;
-pub mod zip;
+pub mod tar;
+mod zip;
 
 const GENESIS_BLOCK_HEIGHT: u64 = 0;
 
@@ -277,7 +278,7 @@ fn load_state(url: &str) -> Result<NetworkState, Box<dyn Error>> {
     let state_dir = rusk_profile::get_rusk_state_dir()?;
     let output = state_dir.parent().expect("state dir not equal to root");
 
-    zip::unzip(&buffer, output)?;
+    tar::unarchive(&buffer, output)?;
 
     let network = restore_state(&id_path)?;
     info!(

--- a/rusk-recovery/src/state/tar.rs
+++ b/rusk-recovery/src/state/tar.rs
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::error::Error;
+use std::path::Path;
+
+use super::zip;
+
+/// Unarchive files into a destination folder
+pub fn unarchive(buffer: &[u8], output: &Path) -> Result<(), Box<dyn Error>> {
+    zip::unzip(buffer, output)
+}
+
+/// Archive a folder into a destination file.
+pub fn archive(src_dir: &Path, dst_file: &Path) -> Result<(), Box<dyn Error>> {
+    Ok(())
+}

--- a/rusk-recovery/src/state/tar.rs
+++ b/rusk-recovery/src/state/tar.rs
@@ -4,17 +4,28 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use flate2::{read, write, Compression};
 use std::error::Error;
+use std::fs::File;
 use std::path::Path;
+use tar::Archive;
 
 use super::zip;
 
 /// Unarchive files into a destination folder
 pub fn unarchive(buffer: &[u8], output: &Path) -> Result<(), Box<dyn Error>> {
-    zip::unzip(buffer, output)
+    let tar = read::GzDecoder::new(buffer);
+    let mut archive = Archive::new(tar);
+    archive
+        .unpack(output)
+        .or_else(|_| zip::unzip(buffer, output))
 }
 
 /// Archive a folder into a destination file.
 pub fn archive(src_dir: &Path, dst_file: &Path) -> Result<(), Box<dyn Error>> {
+    let tar_gz = File::create(dst_file)?;
+    let enc = write::GzEncoder::new(tar_gz, Compression::default());
+    let mut tar = tar::Builder::new(enc);
+    tar.append_dir_all("", src_dir)?;
     Ok(())
 }

--- a/rusk-recovery/src/state/zip.rs
+++ b/rusk-recovery/src/state/zip.rs
@@ -4,18 +4,12 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::fs::{self, File};
-use std::io::{Cursor, Read, Seek, Write};
+use std::error::Error;
+use std::fs::{self};
+use std::io::{Cursor, Read};
 use std::path::Path;
-use std::{error::Error, path::PathBuf};
 
-use tracing::log::info;
-use walkdir::{DirEntry, WalkDir};
-use zip::result::ZipError;
-use zip::write::FileOptions;
 use zip::ZipArchive;
-
-use crate::theme::Theme;
 
 /// Unzip binaries into a destination folder
 pub fn unzip(buffer: &[u8], output: &Path) -> Result<(), Box<dyn Error>> {
@@ -35,62 +29,4 @@ pub fn unzip(buffer: &[u8], output: &Path) -> Result<(), Box<dyn Error>> {
         }
     }
     Ok(())
-}
-
-/// Zip a folder into a destination file.
-pub fn zip(src_dir: &Path, dst_file: &Path) -> Result<(), Box<dyn Error>> {
-    if !Path::new(src_dir).is_dir() {
-        Err(ZipError::FileNotFound)?;
-    }
-
-    let path = Path::new(dst_file);
-    let file = File::create(&path)?;
-
-    let walkdir = WalkDir::new(src_dir);
-    let it = walkdir.into_iter();
-
-    zip_dir(&mut it.filter_map(|e| e.ok()), &src_dir.to_path_buf(), file)?;
-
-    Ok(())
-}
-
-fn zip_dir<T>(
-    it: &mut dyn Iterator<Item = DirEntry>,
-    prefix: &PathBuf,
-    writer: T,
-) -> Result<(), Box<dyn Error>>
-where
-    T: Write + Seek,
-{
-    let theme = Theme::default();
-    let mut zip = zip::ZipWriter::new(writer);
-    let options = FileOptions::default().unix_permissions(0o755);
-
-    let mut buffer = Vec::new();
-    for entry in it {
-        let path = entry.path();
-        let name = path.strip_prefix(Path::new(prefix))?;
-
-        // Write file or directory explicitly
-        // Some unzip tools unzip files with directory paths correctly, some do
-        // not!
-        if path.is_file() {
-            info!("{} {:?} as {:?}", theme.info("Zipping"), path, name);
-            #[allow(deprecated)]
-            zip.start_file_from_path(name, options)?;
-            let mut f = File::open(path)?;
-
-            f.read_to_end(&mut buffer)?;
-            zip.write_all(&buffer)?;
-            buffer.clear();
-        } else if !name.as_os_str().is_empty() {
-            // Only if not root! Avoids path spec / warning
-            // and mapname conversion failed error on unzip
-            info!("{} dir {:?} as {:?}", theme.info("Zipping"), path, name);
-            #[allow(deprecated)]
-            zip.add_directory_from_path(name, options)?;
-        }
-    }
-    zip.finish()?;
-    Result::Ok(())
 }

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -36,7 +36,6 @@ serde = "1.0"
 bs58 = "0.4"
 hex = "0.4"
 tempfile = "3.2"
-zip  = "0.5"
 
 dusk-schnorr = "0.10.0-rc"
 dusk-poseidon = { version = "0.25.0-rc", features = ["canon"] }

--- a/rusk/src/bin/ephemeral.rs
+++ b/rusk/src/bin/ephemeral.rs
@@ -5,14 +5,12 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use clap::{value_parser, Arg, Command};
-use std::{
-    env,
-    fs::{self, File},
-    io::{BufReader, Read, Result},
-    path::{Path, PathBuf},
-};
+use rusk_recovery_tools::state::tar;
+use std::env;
+use std::fs::File;
+use std::io::{Read, Result};
+use std::path::PathBuf;
 use tempfile::TempDir;
-use zip::ZipArchive;
 
 pub(crate) fn inject_args(command: Command<'_>) -> Command<'_> {
     command.arg(
@@ -29,31 +27,19 @@ pub(crate) fn inject_args(command: Command<'_>) -> Command<'_> {
 
 pub(crate) fn configure(state_zip: &PathBuf) -> Result<Option<TempDir>> {
     let tmpdir = tempfile::tempdir()?;
-    unzip(state_zip, tmpdir.path())?;
+
+    let mut f = File::open(state_zip)?;
+    let mut data = Vec::new();
+    f.read_to_end(&mut data)?;
+
+    let unarchive = tar::unarchive(&data[..], tmpdir.path());
+
+    if let Err(e) = unarchive {
+        tracing::error!("Invalid state input {}", e);
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, ""));
+    }
 
     env::set_var("RUSK_STATE_PATH", tmpdir.as_ref().as_os_str());
 
     Ok(Some(tmpdir))
-}
-
-/// Unzip a file into the output directory.
-fn unzip(zipfile: &PathBuf, output: &Path) -> Result<()> {
-    let f = File::open(zipfile)?;
-    let reader = BufReader::new(f);
-    let mut zip = ZipArchive::new(reader)?;
-
-    for i in 0..zip.len() {
-        let mut entry = zip.by_index(i)?;
-        let entry_path = output.join(entry.name());
-
-        if entry.is_dir() {
-            let _ = fs::create_dir_all(entry_path);
-        } else {
-            let mut buffer = Vec::with_capacity(entry.size() as usize);
-            entry.read_to_end(&mut buffer)?;
-            fs::write(entry_path, buffer)?;
-        }
-    }
-
-    Ok(())
 }


### PR DESCRIPTION
- Use `tar` module as entry point for all the archive stuff
- Fallback tar to zip

See also #740