### PR TITLE
Add `governance-contract` tests

### DIFF
--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -17,7 +17,13 @@ dusk-jubjub = { version = "0.11", default-features = false, features = ["canon"]
 dusk-pki = { version = "0.10.0-rc", default-features = false }
 dusk-schnorr = { version = "0.10.0-rc", default-features = false, features = ["canon"] }
 dusk-poseidon = { version = "0.25.0-rc", default-features = false, features = ["canon"] }
-rusk-abi = { path = "../../rusk-abi", features = ["module"] }
+rusk-abi = { path = "../../rusk-abi", version = "0.7", features = ["module"] }
 
 [features]
 no-bridge = []
+
+[dev-dependencies]
+transfer-wrapper = { path = "../../test-utils/transfer-wrapper", version = "0.3" }
+microkelvin = "0.15.0-rc"
+rand = "0.8"
+blake2 = { version = "0.10", default-features = false }

--- a/contracts/governance/tests/executor.rs
+++ b/contracts/governance/tests/executor.rs
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_abi::{ContractId, Transaction};
+use dusk_pki::SecretSpendKey;
+use governance_contract::GovernanceContract;
+use std::error::Error;
+use transfer_wrapper::TransferWrapper;
+
+const GOVERNANCE_BYTECODE: &[u8] = include_bytes!(
+    "../../../target/wasm32-unknown-unknown/release/governance_contract.wasm"
+);
+
+pub struct Executor {
+    genesis_ssk: SecretSpendKey,
+    wrapper: TransferWrapper,
+    contract_id: ContractId,
+    block_heigth: u64,
+}
+
+impl Executor {
+    pub fn new(
+        seed: u64,
+        contract: GovernanceContract,
+        genesis_value: u64,
+    ) -> Executor {
+        let mut wrapper = TransferWrapper::new(seed, genesis_value);
+
+        let (genesis_ssk, _) = wrapper.genesis_identifier();
+        let contract_id = wrapper.deploy(contract, GOVERNANCE_BYTECODE);
+        Executor {
+            genesis_ssk,
+            wrapper,
+            contract_id,
+            block_heigth: 0,
+        }
+    }
+
+    pub fn state(&self) -> GovernanceContract {
+        self.wrapper.state(&self.contract_id)
+    }
+
+    pub fn run_tx(
+        &mut self,
+        transaction: Transaction,
+    ) -> Result<GovernanceContract, Box<dyn Error>> {
+        self.block_heigth = self.block_heigth + 1;
+
+        let (unspent_notes, note_keys) =
+            self.wrapper.unspent_notes(&self.genesis_ssk);
+
+        let refund_vk = self.genesis_ssk.view_key();
+        let refund_psk = self.genesis_ssk.public_spend_key();
+        let remainder_psk = refund_psk.clone();
+
+        let gas_limit = 1_750_000_000;
+        let gas_price = 1;
+        let fee = self.wrapper.fee(gas_limit, gas_price, &refund_psk);
+
+        self.wrapper.execute(
+            self.block_heigth,
+            &unspent_notes,
+            &note_keys,
+            &refund_vk,
+            &remainder_psk,
+            true,
+            fee,
+            None,
+            Some((self.contract_id, transaction)),
+        )?;
+        Ok(self.state())
+    }
+}

--- a/contracts/governance/tests/governance.rs
+++ b/contracts/governance/tests/governance.rs
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_bls12_381_sign::{
+    PublicKey as BlsPublicKey, SecretKey as BlsSecretKey,
+};
+use dusk_pki::{PublicKey, SecretKey};
+use executor::Executor;
+use governance_contract::{GovernanceContract, Transfer};
+use microkelvin::{BackendCtor, DiskBackend, Persistence};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+mod executor;
+mod tx;
+
+fn testbackend() -> BackendCtor<DiskBackend> {
+    BackendCtor::new(DiskBackend::ephemeral)
+}
+
+const DUMMY_TS: u64 = 946681200000; // Dummy timestamp representing 01/01/2000
+
+#[test]
+fn mint_burn_transfer() {
+    Persistence::with_backend(&testbackend(), |_| Ok(()))
+        .expect("Backend found");
+
+    let mut rng = StdRng::seed_from_u64(0xbeef);
+    let a = PublicKey::from(&SecretKey::random(&mut rng));
+    let b = PublicKey::from(&SecretKey::random(&mut rng));
+
+    let sk_authority = BlsSecretKey::random(&mut rng);
+
+    let mut contract = GovernanceContract::default();
+    // set authority
+    contract.authority = BlsPublicKey::from(&sk_authority);
+
+    let genesis_value = 100_000_000_000_000;
+
+    let mut executor = Executor::new(2324, contract, genesis_value);
+    let contract = executor.state();
+
+    assert_eq!(contract.total_supply(), 0);
+    assert_eq!(contract.balance(&a), 0);
+    assert_eq!(contract.balance(&b), 0);
+
+    let mint = tx::mint(&a, 100, &sk_authority);
+    let contract = executor.run_tx(mint).expect("Failed to mint");
+
+    assert_eq!(contract.total_supply(), 100);
+    assert_eq!(contract.balance(&a), 100);
+    assert_eq!(contract.balance(&b), 0);
+
+    let t_1 = Transfer {
+        // transfer 200 from a to b
+        from: a,
+        to: b,
+        amount: 200,
+        timestamp: DUMMY_TS,
+    };
+    let transfer_1 = tx::transfer(vec![t_1], &sk_authority);
+    let contract = executor
+        .run_tx(transfer_1)
+        .expect("Failed to execute transfer 1");
+
+    assert_eq!(contract.total_supply(), 200);
+    assert_eq!(contract.balance(&a), 0);
+    assert_eq!(contract.balance(&b), 200);
+
+    let t_2 = Transfer {
+        // transfer 50 from b to a
+        from: b,
+        to: a,
+        amount: 50,
+        timestamp: DUMMY_TS,
+    };
+
+    let transfer_2 = tx::transfer(vec![t_2], &sk_authority);
+    let contract = executor
+        .run_tx(transfer_2)
+        .expect("Failed to execute transfer 2");
+
+    assert_eq!(contract.total_supply(), 200);
+    assert_eq!(contract.balance(&a), 50);
+    assert_eq!(contract.balance(&b), 150);
+}

--- a/contracts/governance/tests/tx.rs
+++ b/contracts/governance/tests/tx.rs
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use blake2::{digest::consts::U32, Digest};
+use canonical::EncodeToVec;
+use dusk_abi::Transaction;
+use dusk_bls12_381::BlsScalar;
+use dusk_bls12_381_sign::{
+    PublicKey as BlsPublicKey, SecretKey as BlsSecretKey,
+    Signature as BlsSignature,
+};
+use dusk_bytes::Serializable;
+use dusk_pki::PublicKey;
+use governance_contract::{Transfer, TX_MINT, TX_TRANSFER};
+use std::iter;
+
+type Blake2b = blake2::Blake2b<U32>;
+
+pub fn transfer(
+    transfers: Vec<Transfer>,
+    sk_authority: &BlsSecretKey,
+) -> Transaction {
+    let seed = seed(&transfers);
+
+    let scalars = iter::once([seed, BlsScalar::from(TX_TRANSFER as u64)])
+        .flatten()
+        .chain(transfers.iter().flat_map(Transfer::as_scalars))
+        .collect::<Vec<_>>();
+
+    let signature = sign(sk_authority, &scalars);
+
+    let transaction = (TX_TRANSFER, seed, signature, transfers);
+    Transaction::from_canon(&transaction)
+}
+
+pub fn mint(
+    address: &PublicKey,
+    amount: u64,
+    sk_authority: &BlsSecretKey,
+) -> Transaction {
+    let mut r = rand::thread_rng();
+    let seed = BlsScalar::random(&mut r);
+    let scalars = iter::once([seed, BlsScalar::from(TX_MINT as u64)])
+        .chain(iter::once(address.as_ref().to_hash_inputs()))
+        .flatten()
+        .chain(iter::once(BlsScalar::from(amount)))
+        .collect::<Vec<_>>();
+
+    let signature = sign(sk_authority, &scalars);
+
+    let transaction = (TX_MINT, seed, signature, *address, amount);
+    Transaction::from_canon(&transaction)
+}
+
+fn sign(sk: &BlsSecretKey, scalars: &[BlsScalar]) -> BlsSignature {
+    let scalar_bytes = &dusk_poseidon::sponge::hash(scalars).to_bytes();
+
+    let pk = BlsPublicKey::from(sk);
+    sk.sign(&pk, &scalar_bytes[..])
+}
+
+fn seed(data: &Vec<Transfer>) -> BlsScalar {
+    let msg = data.encode_to_vec();
+    let mut digest: [u8; BlsScalar::SIZE] = Blake2b::digest(msg).into();
+
+    // Truncate the contract id to fit bls
+    digest[31] &= 0x3f;
+
+    BlsScalar::from_bytes(&digest).unwrap_or_default()
+}


### PR DESCRIPTION
### transfer-wrapper
Add `unspent_notes` utility method

### governance-contract: 

Add tests
Fix some error in the contract:
- Fix `SeedAlreadyUsed` when transfer insufficient funds
- Fix signature verification when not compiled for wasm

Resolves #833 