### PR TITLE
governance-contract: Use the `broker` inside the contract's logic

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -26,11 +26,12 @@ pub const TX_UNPAUSE: u8 = 0x01;
 pub const TX_MINT: u8 = 0x02;
 pub const TX_BURN: u8 = 0x03;
 pub const TX_TRANSFER: u8 = 0x04;
+pub const TX_FEE: u8 = 0x05;
 
 #[derive(Debug, Clone, PartialEq, Eq, Canon)]
 pub struct Transfer {
-    pub from: PublicKey,
-    pub to: PublicKey,
+    pub from: Option<PublicKey>,
+    pub to: Option<PublicKey>,
     pub amount: u64,
     pub timestamp: u64,
 }

--- a/contracts/governance/src/wasm/bridge.rs
+++ b/contracts/governance/src/wasm/bridge.rs
@@ -46,17 +46,17 @@ fn t(bytes: &mut [u8; PAGE_SIZE]) {
         TX_PAUSE => contract.pause(),
         TX_UNPAUSE => contract.unpause(),
         TX_MINT => {
-            let (address, value) = Canon::decode(&mut source)
+            let (address, value): (PublicKey, u64) = Canon::decode(&mut source)
                 .expect("[TX_MINT] arguments should be decoded");
 
-            contract.mint(address, value).unwrap();
+            contract.mint(&address, value).unwrap();
         }
 
         TX_BURN => {
-            let (address, value) = Canon::decode(&mut source)
+            let (address, value): (PublicKey, u64) = Canon::decode(&mut source)
                 .expect("[TX_BURN] arguments should be decoded");
 
-            contract.burn(address, value).unwrap();
+            contract.burn(&address, value).unwrap();
         }
 
         TX_TRANSFER => {
@@ -64,6 +64,13 @@ fn t(bytes: &mut [u8; PAGE_SIZE]) {
                 .expect("[TX_TRANSFER] arguments should be decoded");
 
             contract.transfer(batch).unwrap();
+        }
+
+        TX_FEE => {
+            let batch = Canon::decode(&mut source)
+                .expect("[TX_FEE] arguments should be decoded");
+
+            contract.fee(batch).unwrap();
         }
 
         _ => panic!("Tx id not implemented"),

--- a/contracts/governance/tests/executor/builder.rs
+++ b/contracts/governance/tests/executor/builder.rs
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_pki::PublicKey;
+use governance_contract::Transfer;
+
+const DUMMY_TS: u64 = 946681200000; // Dummy timestamp representing 01/01/2000
+
+pub struct TransferBuilder(Transfer);
+
+impl TransferBuilder {
+    pub fn to(mut self, account: PublicKey) -> Self {
+        self.0.to = Some(account);
+        self
+    }
+
+    pub fn from(mut self, account: PublicKey) -> Self {
+        self.0.from = Some(account);
+        self
+    }
+}
+
+pub fn transfer(amount: u64) -> TransferBuilder {
+    TransferBuilder(Transfer {
+        from: None,
+        to: None,
+        amount,
+        timestamp: DUMMY_TS,
+    })
+}
+
+pub fn withdraw(amount: u64) -> TransferBuilder {
+    transfer(amount)
+}
+
+pub fn deposit(amount: u64) -> TransferBuilder {
+    transfer(amount)
+}
+
+impl From<TransferBuilder> for Transfer {
+    fn from(builder: TransferBuilder) -> Transfer {
+        builder.0
+    }
+}

--- a/contracts/governance/tests/executor/mod.rs
+++ b/contracts/governance/tests/executor/mod.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+pub mod builder;
 pub mod tx;
 
 use dusk_abi::{ContractId, Transaction};
@@ -62,9 +63,14 @@ impl Executor {
         let gas_price = 1;
         let fee = self.wrapper.fee(gas_limit, gas_price, &refund_psk);
 
+        let note = unspent_notes
+            .iter()
+            .max_by_key(|n| n.value(Some(&refund_vk)).unwrap_or_default())
+            .expect("At least one note should be unspent");
+
         self.wrapper.execute(
             self.block_heigth,
-            &unspent_notes,
+            &[*note],
             &note_keys,
             &refund_vk,
             &remainder_psk,

--- a/contracts/governance/tests/executor/tx.rs
+++ b/contracts/governance/tests/executor/tx.rs
@@ -12,7 +12,7 @@ use dusk_bls12_381_sign::{
 };
 use dusk_pki::PublicKey;
 use governance_contract::{
-    Transfer, TX_MINT, TX_PAUSE, TX_TRANSFER, TX_UNPAUSE,
+    Transfer, TX_FEE, TX_MINT, TX_PAUSE, TX_TRANSFER, TX_UNPAUSE,
 };
 
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -43,12 +43,32 @@ where
     Transaction::from_canon(&transaction)
 }
 
-pub fn transfer(
+pub fn transfer<T>(
     sk_authority: &BlsSecretKey,
     seed: BlsScalar,
-    transfers: Vec<Transfer>,
-) -> Transaction {
+    transfers: Vec<T>,
+) -> Transaction
+where
+    T: Into<Transfer>,
+{
+    let transfers: Vec<Transfer> =
+        transfers.into_iter().map(|t| t.into()).collect();
+
     signed_transaction(sk_authority, (seed, TX_TRANSFER, transfers))
+}
+
+pub fn fee<T>(
+    sk_authority: &BlsSecretKey,
+    seed: BlsScalar,
+    transfers: Vec<T>,
+) -> Transaction
+where
+    T: Into<Transfer>,
+{
+    let transfers: Vec<Transfer> =
+        transfers.into_iter().map(|t| t.into()).collect();
+
+    signed_transaction(sk_authority, (seed, TX_FEE, transfers))
 }
 
 pub fn mint(


### PR DESCRIPTION
- Update `unspent_notes` to find the better note for the tests
- Change the `broker` to be a `PublicKey`
- Add a new `fee` transaction to the Governance contract
- Change the `Transfer` struct to support optional `from` and `to`, fields, in order to allow for transfers to and from the `broker` account
- Added new utility functions to `executor/builder.rs` to build `Transfer` objects with optional `from` and `to` fields, to simplify test code
- Added a new test case in `governance.rs` to test the `fee` transaction

Resolves #845