### PR TITLE
node: Implement DataBroker service to facilitate catch-up procedures

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/bin/main.rs"
 [dependencies]
 tracing = "0.1"
 hex = "0.4"
-dusk-consensus = { git = "https://github.com/dusk-network/consensus/", version = "0.1.1-rc.2" }
+dusk-consensus = { git = "https://github.com/dusk-network/consensus/", version = "0.1.1-rc.3"  }
 kadcast = "0.5.0-rc"
 sha3 = { version = "0.10" }
 anyhow = "1.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -35,6 +35,7 @@ rustc_tools_util = "=0.2.0"
 blake2 = "0.10.5"
 dusk-bls12_381-sign = { version = "0.3.0-rc", default-features = false }
 console-subscriber = { version = "0.1.8", optional = true }
+smallvec = "1.10.0"
 
 ## Binary dependencies
 clap = { version = "3.1", features = ["env"] }

--- a/node/default.config.toml
+++ b/node/default.config.toml
@@ -8,7 +8,7 @@ consensus_keys_path = '/tmp/consensus_bls.keys'
 public_address = '127.0.0.1:9000'
 # listen_address = '127.0.0.1:9000'
 bootstrapping_nodes = []
-auto_propagate = true
+auto_propagate = false
 channel_size = 1000
 recursive_discovery = true
 
@@ -32,3 +32,7 @@ fec_redundancy = 0.15
 [network.fec.decoder]
 cache_ttl = '1m'
 cache_prune_every = '5m'
+
+[databroker]
+max_inv_entries = 500
+max_ongoing_requests = 100

--- a/node/default.config.toml
+++ b/node/default.config.toml
@@ -36,3 +36,4 @@ cache_prune_every = '5m'
 [databroker]
 max_inv_entries = 500
 max_ongoing_requests = 100
+delay_on_resp_msg = 500

--- a/node/src/bin/config.rs
+++ b/node/src/bin/config.rs
@@ -20,6 +20,8 @@ pub(crate) struct Config {
     pub(crate) network: KadcastConfig,
     db_path: Option<PathBuf>,
     consensus_keys_path: Option<PathBuf>,
+
+    databroker: node::databroker::conf::Params,
 }
 
 /// Default log_level.
@@ -64,6 +66,7 @@ impl From<&ArgMatches> for Config {
         }
 
         config.network.merge(matches);
+        config.databroker.merge(matches);
         config
     }
 }
@@ -148,5 +151,9 @@ impl Config {
             .as_path()
             .display()
             .to_string()
+    }
+
+    pub(crate) fn databroker(&self) -> &node::databroker::conf::Params {
+        &self.databroker
     }
 }

--- a/node/src/bin/main.rs
+++ b/node/src/bin/main.rs
@@ -48,7 +48,7 @@ pub fn main() -> anyhow::Result<()> {
             let service_list: Vec<Box<Services>> = vec![
                 Box::<MempoolSrv>::default(),
                 Box::new(ChainSrv::new(config.consensus_keys_path())),
-                Box::<DataBrokerSrv>::default(),
+                Box::new(DataBrokerSrv::new(config.databroker())),
             ];
 
             let db = rocksdb::Backend::create_or_open(config.db_path());

--- a/node/src/bin/main.rs
+++ b/node/src/bin/main.rs
@@ -7,6 +7,7 @@
 use dusk_consensus::config::ACCUMULATOR_WORKERS_AMOUNT;
 use node::chain::ChainSrv;
 use node::database::{rocksdb, DB};
+use node::databroker::DataBrokerSrv;
 use node::mempool::MempoolSrv;
 use node::network::Kadcast;
 use node::vm::Config as VMConfig;
@@ -47,6 +48,7 @@ pub fn main() -> anyhow::Result<()> {
             let service_list: Vec<Box<Services>> = vec![
                 Box::<MempoolSrv>::default(),
                 Box::new(ChainSrv::new(config.consensus_keys_path())),
+                Box::<DataBrokerSrv>::default(),
             ];
 
             let db = rocksdb::Backend::create_or_open(config.db_path());

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -151,6 +151,8 @@ impl<DB: database::DB, N: Network> dusk_consensus::commons::Database
         }
     }
 
+    /// Makes attempts to fetch a candidate block from either the local storage
+    /// or the network.
     async fn get_candidate_block_by_hash(
         &self,
         h: &Hash,
@@ -168,10 +170,9 @@ impl<DB: database::DB, N: Network> dusk_consensus::commons::Database
 
         const RECV_PEERS_COUNT: usize = 5;
         const TIMEOUT_MILLIS: u64 = 1000;
-        // If the candidate block is not found in local storage, make an attempt
-        // to fetch it from the network
-        // For redundancy reasons, we send the request to multiple peers
 
+        // For redundancy reasons, we send the GetCandidate request to multiple
+        // network peers
         let request = Message::new_get_candidate(GetCandidate { hash: *h });
         let res = self
             .network
@@ -198,7 +199,7 @@ impl<DB: database::DB, N: Network> dusk_consensus::commons::Database
                 }
 
                 tracing::info!(
-                    "received candidate_resp height: {:?}  hash: {:?}",
+                    "received candidate height: {:?}  hash: {:?}",
                     b.header.height,
                     hex::ToHex::encode_hex::<String>(&b.header.hash)
                 );

--- a/node/src/chain/genesis.rs
+++ b/node/src/chain/genesis.rs
@@ -16,7 +16,7 @@ pub(crate) fn generate_state() -> (Block, Provisioners) {
     let mut block = Block::default();
 
     // Load provisioners keys from external consensus keys files.
-    let keys = node_data::bls::load_provisioners_keys(3);
+    let keys = node_data::bls::load_provisioners_keys(7);
     let mut provisioners = Provisioners::new();
 
     for (_, (_, pk)) in keys.iter().enumerate() {

--- a/node/src/chain/mod.rs
+++ b/node/src/chain/mod.rs
@@ -86,51 +86,49 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
             tokio::select! {
                 // Receives results from the upper layer
                 recv = &mut self.upper.result.recv() => {
-                    if let Ok(res) = recv {
-                        match res {
-                            Ok(blk) => {
-                                if let Err(e) = self.accept_block::<DB, VM, N>( &db, &vm, &network, &blk).await {
-                                    tracing::error!("failed to accept block: {}", e);
-                                } else {
-                                    network.read().await.
-                                        broadcast(&Message::new_with_block(Box::new(blk))).await;
-                                }
-                            }
-                            Err(e) => {
-                                tracing::error!("consensus halted due to: {:?}", e);
+                    let res = recv?;
+                    match res {
+                        Ok(blk) => {
+                            if let Err(e) = self.accept_block::<DB, VM, N>( &db, &vm, &network, &blk).await {
+                                tracing::error!("failed to accept block: {}", e);
+                            } else {
+                                network.read().await.
+                                    broadcast(&Message::new_block(Box::new(blk))).await;
                             }
                         }
+                        Err(e) => {
+                            tracing::error!("consensus halted due to: {:?}", e);
+                        }
                     }
+
                 },
                 // Receives inbound wire messages.
                 // Component should either process it or re-route it to the next upper layer
                 recv = &mut self.inbound.recv() => {
-                    if let Ok(mut msg) = recv {
-                        match &msg.payload {
-                            Payload::Block(b) => {
-                                if let Err(e) = self.accept_block::<DB, VM, N>(&db, &vm, &network, b).await {
-                                    tracing::error!("failed to accept block: {}", e);
-                                } else {
-                                    network.read().await.broadcast(&msg).await;
-                                }
+                    let msg = recv?;
+                    match &msg.payload {
+                        Payload::Block(b) => {
+                            if let Err(e) = self.accept_block::<DB, VM, N>(&db, &vm, &network, b).await {
+                                tracing::error!("failed to accept block: {}", e);
+                            } else {
+                                network.read().await.broadcast(&msg).await;
                             }
-
-                            // Re-route message to upper layer (in this case it is the Consensus layer)
-                            Payload::NewBlock(_) |  Payload::Reduction(_) => {
-                                self.upper.main_inbound.try_send(msg);
-                            }
-                            Payload::Agreement(_) | Payload::AggrAgreement(_) => {
-                                self.upper.agreement_inbound.try_send(msg);
-                            }
-                            _ => tracing::warn!("invalid inbound message"),
                         }
+
+                        // Re-route message to upper layer (in this case it is the Consensus layer)
+                        Payload::NewBlock(_) |  Payload::Reduction(_) => {
+                            self.upper.main_inbound.try_send(msg);
+                        }
+                        Payload::Agreement(_) | Payload::AggrAgreement(_) => {
+                            self.upper.agreement_inbound.try_send(msg);
+                        }
+                        _ => tracing::warn!("invalid inbound message"),
                     }
                 },
                 // Re-routes messages originated from Consensus (upper) layer to the network layer.
                 recv = &mut self.upper.outbound.recv() => {
-                    if let Ok(msg) = recv {
-                        network.read().await.broadcast(&msg).await;
-                    }
+                    let msg = recv?;
+                    network.read().await.broadcast(&msg).await;
                 },
             }
         }
@@ -152,6 +150,29 @@ impl ChainSrv {
         }
     }
 
+    /// Requests missing blocks by sending GetBlocks wire message to N alive
+    /// peers.
+    async fn request_missing_blocks<N: Network, DB: database::DB>(
+        db: &Arc<RwLock<DB>>,
+        network: &Arc<RwLock<N>>,
+        locator: [u8; 32],
+        peers_count: usize,
+    ) -> anyhow::Result<()> {
+        // GetBlocks
+        let msg =
+            Message::new_get_blocks(node_data::message::payload::GetBlocks {
+                locator,
+            });
+
+        network
+            .read()
+            .await
+            .send_to_alive_peers(&msg, peers_count)
+            .await;
+
+        Ok(())
+    }
+
     async fn init<N: Network, DB: database::DB, VM: vm::VMExecution>(
         &mut self,
         network: &Arc<RwLock<N>>,
@@ -168,6 +189,23 @@ impl ChainSrv {
             vm,
             network,
         );
+
+        // Store genesis block
+        db.read()
+            .await
+            .update(|t| t.store_block(&self.most_recent_block, true));
+
+        // Always request missing blocks on startup.
+        //
+        // Instead of waiting for next block to be produced and delivered, we
+        // request missing blocks from randomly selected the network nodes.
+        Self::request_missing_blocks(
+            db,
+            network,
+            self.most_recent_block.header.hash,
+            3,
+        )
+        .await?;
 
         anyhow::Ok(0)
     }
@@ -247,7 +285,11 @@ impl ChainSrv {
         }
 
         if blk_header.height != prev_block_header.height + 1 {
-            return Err(anyhow!("invalid block height"));
+            return Err(anyhow!(
+                "invalid block height block_height: {:?}, curr_height: {:?}",
+                blk_header.height,
+                prev_block_header.height,
+            ));
         }
 
         if blk_header.prev_block_hash != prev_block_header.hash {

--- a/node/src/database/mod.rs
+++ b/node/src/database/mod.rs
@@ -47,6 +47,11 @@ pub trait Ledger {
     fn store_block(&self, b: &ledger::Block, persisted: bool) -> Result<()>;
     fn delete_block(&self, b: &ledger::Block) -> Result<()>;
     fn fetch_block(&self, hash: &[u8]) -> Result<Option<ledger::Block>>;
+    fn fetch_block_hash_by_height(
+        &self,
+        height: u64,
+    ) -> Result<Option<[u8; 32]>>;
+
     fn get_block_exists(&self, hash: &[u8]) -> Result<bool>;
 
     fn get_ledger_tx_by_hash(
@@ -89,6 +94,9 @@ pub trait Mempool {
         &self,
         max_gas_limit: u64,
     ) -> Result<Vec<ledger::Transaction>>;
+
+    /// Get all transactions hashes.
+    fn get_txs_hashes(&self) -> Result<Vec<[u8; 32]>>;
 }
 
 pub trait Persist: Ledger + Candidate + Mempool + core::fmt::Debug {

--- a/node/src/database/rocksdb.rs
+++ b/node/src/database/rocksdb.rs
@@ -835,7 +835,7 @@ mod tests {
     #[test]
     fn test_fetch_block_hash_by_height() {
         let t = TestWrapper {
-            path: "test_get_ledger_tx_by_hash",
+            path: "test_fetch_block_hash_by_height",
         };
 
         t.run(|path| {

--- a/node/src/databroker/conf.rs
+++ b/node/src/databroker/conf.rs
@@ -16,7 +16,7 @@ pub struct Params {
 
     /// delay_on_resp_msg is in milliseconds. It mitigates stress on UDP
     /// buffers when network latency is 0 (localnet network only)
-    pub delay_on_resp_msg: u64,
+    pub delay_on_resp_msg: Option<u64>,
 }
 
 impl Default for Params {
@@ -24,7 +24,7 @@ impl Default for Params {
         Self {
             max_inv_entries: 100,
             max_ongoing_requests: 1000,
-            delay_on_resp_msg: 0,
+            delay_on_resp_msg: None,
         }
     }
 }
@@ -33,8 +33,8 @@ impl std::fmt::Display for &Params {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "max_inv_entries: {}, max_ongoing_requests: {} delay_on_resp_msg: {}",
-            self.max_inv_entries, self.max_ongoing_requests, self.delay_on_resp_msg,
+            "max_inv_entries: {}, max_ongoing_requests: {}",
+            self.max_inv_entries, self.max_ongoing_requests,
         )
     }
 }
@@ -71,7 +71,7 @@ impl Params {
         if let Some(delay_on_resp_msg) = matches.value_of("delay_on_resp_msg") {
             match delay_on_resp_msg.parse() {
                 Ok(delay_on_resp_msg) => {
-                    self.delay_on_resp_msg = delay_on_resp_msg;
+                    self.delay_on_resp_msg = Some(delay_on_resp_msg);
                 }
                 Err(e) => {
                     tracing::error!(

--- a/node/src/databroker/conf.rs
+++ b/node/src/databroker/conf.rs
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::fmt::Formatter;
+
+use clap::ArgMatches;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Params {
+    pub max_inv_entries: usize,
+    pub max_ongoing_requests: usize,
+
+    /// delay_on_resp_msg is in milliseconds. It mitigates stress on UDP
+    /// buffers when network latency is 0 (localnet network only)
+    pub delay_on_resp_msg: u64,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Self {
+            max_inv_entries: 100,
+            max_ongoing_requests: 1000,
+            delay_on_resp_msg: 0,
+        }
+    }
+}
+
+impl std::fmt::Display for &Params {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "max_inv_entries: {}, max_ongoing_requests: {} delay_on_resp_msg: {}",
+            self.max_inv_entries, self.max_ongoing_requests, self.delay_on_resp_msg,
+        )
+    }
+}
+
+impl Params {
+    pub fn merge(&mut self, matches: &ArgMatches) {
+        if let Some(max_inv_entries) = matches.value_of("max_inv_entries") {
+            match max_inv_entries.parse() {
+                Ok(max_inv_entries) => {
+                    self.max_inv_entries = max_inv_entries;
+                }
+                Err(e) => {
+                    tracing::error!("Failed to parse max_inv_entries: {:?}", e);
+                }
+            }
+        };
+
+        if let Some(max_ongoing_requests) =
+            matches.value_of("max_ongoing_requests")
+        {
+            match max_ongoing_requests.parse() {
+                Ok(max_ongoing_requests) => {
+                    self.max_ongoing_requests = max_ongoing_requests;
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to parse max_ongoing_requests: {:?}",
+                        e
+                    );
+                }
+            }
+        };
+
+        if let Some(delay_on_resp_msg) = matches.value_of("delay_on_resp_msg") {
+            match delay_on_resp_msg.parse() {
+                Ok(delay_on_resp_msg) => {
+                    self.delay_on_resp_msg = delay_on_resp_msg;
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to parse delay_on_resp_msg: {:?}",
+                        e
+                    );
+                }
+            }
+        };
+    }
+}

--- a/node/src/databroker/mod.rs
+++ b/node/src/databroker/mod.rs
@@ -1,0 +1,156 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::database::{Candidate, Ledger, Mempool};
+use crate::{database, vm, Network};
+use crate::{LongLivedService, Message};
+use anyhow::{anyhow, bail, Result};
+
+use dusk_consensus::user::committee::CommitteeSet;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dusk_consensus::commons::{ConsensusError, Database, RoundUpdate};
+use dusk_consensus::consensus::Consensus;
+use dusk_consensus::contract_state::{
+    CallParams, Error, Operations, Output, StateRoot,
+};
+use dusk_consensus::user::provisioners::Provisioners;
+use node_data::ledger::{self, Block, Hash, Header};
+use node_data::message::{payload, AsyncQueue, Metadata};
+use node_data::message::{Payload, Topics};
+use node_data::Serializable;
+use tokio::sync::{oneshot, Mutex, RwLock};
+use tokio::task::JoinHandle;
+
+use std::any;
+
+const TOPICS: &[u8] = &[
+    Topics::GetBlocks as u8,
+    Topics::GetData as u8,
+    Topics::GetCandidate as u8,
+    Topics::GetMempool as u8,
+];
+
+struct Response {
+    msg: Message,
+    recv_peer: SocketAddr,
+}
+
+#[derive(Default)]
+pub struct DataBrokerSrv {
+    /// A queue of pending requests to process.
+    /// Request here is literally a GET message
+    requests: AsyncQueue<Message>,
+}
+
+#[async_trait]
+impl<N: Network, DB: database::DB, VM: vm::VMExecution>
+    LongLivedService<N, DB, VM> for DataBrokerSrv
+{
+    async fn execute(
+        &mut self,
+        network: Arc<RwLock<N>>,
+        db: Arc<RwLock<DB>>,
+        vm: Arc<RwLock<VM>>,
+    ) -> anyhow::Result<usize> {
+        // Register routes
+        LongLivedService::<N, DB, VM>::add_routes(
+            self,
+            TOPICS,
+            self.requests.clone(),
+            &network,
+        )
+        .await?;
+
+        tracing::info!("data broker service started");
+
+        loop {
+            tokio::select! {
+                // Receives inbound wire messages.
+                recv = &mut self.requests.recv() => {
+                    if let Ok(msg) = recv {
+
+                        let network = network.clone();
+                        let db = db.clone();
+
+                        tokio::spawn(async move {
+                            match Self::handle_request(&network, &db, &msg).await {
+                                Ok(resp) => {
+                                    // Send response
+                                    network.write().await.
+                                        send_to_peer(&resp.msg, resp.recv_peer).await;
+                                },
+                                Err(e) => {
+                                    tracing::warn!("error handling msg: {:?}", e);
+                                }
+                            }
+                        });
+                    }
+                },
+            }
+        }
+    }
+
+    /// Returns service name.
+    fn name(&self) -> &'static str {
+        "data_broker"
+    }
+}
+
+impl DataBrokerSrv {
+    /// Handles inbound messages.
+    async fn handle_request<N: Network, DB: database::DB>(
+        network: &Arc<RwLock<N>>,
+        db: &Arc<RwLock<DB>>,
+        msg: &Message,
+    ) -> anyhow::Result<Response> {
+        /// source address of the request becomes the receiver address of the
+        /// response
+        let recv_peer = msg
+            .metadata
+            .as_ref()
+            .map(|m| m.src_addr)
+            .ok_or_else(|| anyhow::anyhow!("invalid metadata src_addr"))?;
+
+        match &msg.payload {
+            // Handle GetCandidate requests
+            Payload::GetCandidate(m) => {
+                let msg =
+                    Self::handle_get_candidate(network, db, m.clone()).await?;
+                Ok(Response { msg, recv_peer })
+            }
+            _ => Err(anyhow::anyhow!("unhandled message")),
+        }
+    }
+
+    async fn handle_get_candidate<N: Network, DB: database::DB>(
+        network: &Arc<RwLock<N>>,
+        db: &Arc<RwLock<DB>>,
+        m: node_data::message::payload::GetCandidate,
+    ) -> Result<Message> {
+        let mut res = Option::None;
+        db.read()
+            .await
+            .view(|t| {
+                res = t.fetch_candidate_block(&m.hash)?;
+                Ok(())
+            })
+            .map_err(|e| {
+                anyhow::anyhow!("could not fetch candidate block: {:?}", e)
+            })?;
+
+        match res {
+            Some(block) => {
+                Ok(Message::new_candidate_resp(payload::CandidateResp {
+                    candidate: block,
+                }))
+            }
+            None => Err(anyhow::anyhow!("could not find candidate block")),
+        }
+    }
+}

--- a/node/src/databroker/mod.rs
+++ b/node/src/databroker/mod.rs
@@ -154,11 +154,9 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
 
                             // Mitigate pressure on UDP buffers.
                             // Needed only in localnet.
-                            if conf.delay_on_resp_msg > 0 {
+                            if let Some(milli_sec) = conf.delay_on_resp_msg {
                                 tokio::time::sleep(
-                                    std::time::Duration::from_millis(
-                                        conf.delay_on_resp_msg,
-                                    ),
+                                    std::time::Duration::from_millis(milli_sec),
                                 )
                                 .await;
                             }

--- a/node/src/databroker/mod.rs
+++ b/node/src/databroker/mod.rs
@@ -82,7 +82,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
                             match Self::handle_request(&network, &db, &msg).await {
                                 Ok(resp) => {
                                     // Send response
-                                    network.write().await.
+                                    network.read().await.
                                         send_to_peer(&resp.msg, resp.recv_peer).await;
                                 },
                                 Err(e) => {
@@ -124,7 +124,7 @@ impl DataBrokerSrv {
                     Self::handle_get_candidate(network, db, m.clone()).await?;
                 Ok(Response { msg, recv_peer })
             }
-            _ => Err(anyhow::anyhow!("unhandled message")),
+            _ => Err(anyhow::anyhow!("unhandled message payload")),
         }
     }
 


### PR DESCRIPTION
fixes #872 
fixes #887 
fixes #888  

The PR covers also a complete design and implementation of so called DataBroker service. Additionally, for testing purposes it makes it possible to sync-up blockchain state from genesis block (a sort of a basic sync-up procedure)