### PR TITLE
Add 'all' target to alice and bob contracts

### DIFF
--- a/contracts/alice/Makefile
+++ b/contracts/alice/Makefile
@@ -1,3 +1,5 @@
+all: wasm
+
 wasm: ## Generate the optimized WASM for the contract given
 	@RUSTFLAGS="$(RUSTFLAGS) --remap-path-prefix $(HOME)= -C link-args=-zstack-size=65536" \
     	cargo build \
@@ -8,3 +10,5 @@ wasm: ## Generate the optimized WASM for the contract given
     		--target wasm32-unknown-unknown
 
 test:
+
+.PHONY: all test wasm

--- a/contracts/bob/Makefile
+++ b/contracts/bob/Makefile
@@ -1,3 +1,5 @@
+all: wasm
+
 wasm: ## Generate the optimized WASM for the contract given
 	@RUSTFLAGS="$(RUSTFLAGS) --remap-path-prefix $(HOME)= -C link-args=-zstack-size=65536" \
     	cargo build \
@@ -8,3 +10,5 @@ wasm: ## Generate the optimized WASM for the contract given
     		--target wasm32-unknown-unknown
 
 test:
+
+.PHONY: all test wasm


### PR DESCRIPTION
Fixes failing `make all` due to missing `all` target