### PR TITLE
Return gas charged to transaction in `execute`

### DIFF
--- a/contracts/stake/tests/stake.rs
+++ b/contracts/stake/tests/stake.rs
@@ -313,7 +313,7 @@ fn stake_withdraw_unstake() {
     };
 
     session.set_point_limit(tx.fee.gas_limit * tx.fee.gas_price);
-    let _: Option<Result<RawResult, ModuleError>> = session
+    let _: (u64, Option<Result<RawResult, ModuleError>>) = session
         .transact(rusk_abi::transfer_module(), "execute", &tx)
         .expect("Transacting should succeed");
 
@@ -519,7 +519,7 @@ fn stake_withdraw_unstake() {
     rusk_abi::set_block_height(session, 2);
 
     session.set_point_limit(tx.fee.gas_limit * tx.fee.gas_price);
-    let _: Option<Result<RawResult, ModuleError>> = session
+    let _: (u64, Option<Result<RawResult, ModuleError>>) = session
         .transact(rusk_abi::transfer_module(), "execute", &tx)
         .expect("Transacting should succeed");
 
@@ -740,7 +740,7 @@ fn stake_withdraw_unstake() {
     rusk_abi::set_block_height(session, 3);
 
     session.set_point_limit(tx.fee.gas_limit * tx.fee.gas_price);
-    let _: Option<Result<RawResult, ModuleError>> = session
+    let _: (u64, Option<Result<RawResult, ModuleError>>) = session
         .transact(rusk_abi::transfer_module(), "execute", &tx)
         .expect("Transacting should succeed");
 
@@ -894,7 +894,7 @@ fn allow() {
     };
 
     session.set_point_limit(tx.fee.gas_limit * tx.fee.gas_price);
-    let _: Option<Result<RawResult, ModuleError>> = session
+    let _: (u64, Option<Result<RawResult, ModuleError>>) = session
         .transact(rusk_abi::transfer_module(), "execute", &tx)
         .expect("Transacting should succeed");
 

--- a/contracts/transfer/tests/transfer.rs
+++ b/contracts/transfer/tests/transfer.rs
@@ -269,7 +269,7 @@ fn transfer() {
     };
 
     session.set_point_limit(tx.fee.gas_limit * tx.fee.gas_price);
-    let _: Option<Result<RawResult, ModuleError>> = session
+    let _: (u64, Option<Result<RawResult, ModuleError>>) = session
         .transact(rusk_abi::transfer_module(), "execute", &tx)
         .expect("Transacting should succeed");
 
@@ -384,7 +384,7 @@ fn alice_ping() {
     };
 
     session.set_point_limit(tx.fee.gas_limit * tx.fee.gas_price);
-    let _: Option<Result<RawResult, ModuleError>> = session
+    let _: (u64, Option<Result<RawResult, ModuleError>>) = session
         .transact(rusk_abi::transfer_module(), "execute", &tx)
         .expect("Transacting should succeed");
 
@@ -563,7 +563,7 @@ fn send_and_withdraw_transparent() {
     };
 
     session.set_point_limit(tx.fee.gas_limit * tx.fee.gas_price);
-    let _: Option<Result<RawResult, ModuleError>> = session
+    let _: (u64, Option<Result<RawResult, ModuleError>>) = session
         .transact(rusk_abi::transfer_module(), "execute", &tx)
         .expect("Transacting should succeed");
 
@@ -740,7 +740,7 @@ fn send_and_withdraw_transparent() {
     };
 
     session.set_point_limit(tx.fee.gas_limit * tx.fee.gas_price);
-    let _: Option<Result<RawResult, ModuleError>> = session
+    let _: (u64, Option<Result<RawResult, ModuleError>>) = session
         .transact(rusk_abi::transfer_module(), "execute", &tx)
         .expect("Transacting should succeed");
 
@@ -942,7 +942,7 @@ fn send_and_withdraw_obfuscated() {
     };
 
     session.set_point_limit(tx.fee.gas_limit * tx.fee.gas_price);
-    let _: Option<Result<RawResult, ModuleError>> = session
+    let _: (u64, Option<Result<RawResult, ModuleError>>) = session
         .transact(rusk_abi::transfer_module(), "execute", &tx)
         .expect("Transacting should succeed");
 
@@ -1170,7 +1170,7 @@ fn send_and_withdraw_obfuscated() {
     };
 
     session.set_point_limit(tx.fee.gas_limit * tx.fee.gas_price);
-    let _: Option<Result<RawResult, ModuleError>> = session
+    let _: (u64, Option<Result<RawResult, ModuleError>>) = session
         .transact(rusk_abi::transfer_module(), "execute", &tx)
         .expect("Transacting should succeed");
 

--- a/rusk/tests/services/multi_transfer.rs
+++ b/rusk/tests/services/multi_transfer.rs
@@ -49,7 +49,7 @@ use crate::common::*;
 const BLOCK_HEIGHT: u64 = 1;
 // This is purposefully chosen to be low to trigger the discarding of a
 // perfectly good transaction.
-const BLOCK_GAS_LIMIT: u64 = 400_000_000;
+const BLOCK_GAS_LIMIT: u64 = 250_000_000;
 const INITIAL_BALANCE: u64 = 10_000_000_000;
 
 // Creates the Rusk initial state for the tests below


### PR DESCRIPTION
The transfer contract now returns the gas charged to a transaction, and
we use that as an input for the rewards calculation, as opposed to the
total gas spent in the execution of a contract.

Since the gas spent in the execution of the transfer contract is a
larger number than the gas charged to a transaction - due to the fact
that some code is executed *after* charging - this prevents a small
inflationary effect from happening.

Resolves https://github.com/dusk-network/rusk/issues/790