### PR TITLE
Add `iteration` to block header

### DIFF
--- a/consensus/CHANGELOG.md
+++ b/consensus/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `iteration` to block header [#848]
 - Add CHANGELOG. [#54]
 - Add `get_mempool_txs`. [#47]
 - Add node-data crate. [#44]
@@ -17,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Expose `verify_step_votes`. [#50]
+
+### Removed
+
+- Remove `step` from header's certificate [#848]
 
 ### Fixed
 
@@ -28,7 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First `consensus` release
 
-<!-- ISSUES -->
+
+[#848]: https://github.com/dusk-network/rusk/issues/848
+
+<!-- OLD CONSENSUS REPO ISSUES -->
 [#54]: https://github.com/dusk-network/consensus/issues/54
 [#53]: https://github.com/dusk-network/consensus/issues/53
 [#51]: https://github.com/dusk-network/consensus/issues/51

--- a/consensus/src/agreement/step.rs
+++ b/consensus/src/agreement/step.rs
@@ -225,12 +225,10 @@ impl<D: Database> Executor<D> {
             self.publish(msg).await;
         }
 
-        let (cert, hash) = agreements.into_iter().next().map(|a| {
-            (
-                a.payload.generate_certificate(a.header.step),
-                a.header.block_hash,
-            )
-        })?;
+        let (cert, hash) = agreements
+            .into_iter()
+            .next()
+            .map(|a| (a.payload.generate_certificate(), a.header.block_hash))?;
 
         // Create winning block
         self.create_winning_block(&hash, &cert).await
@@ -255,7 +253,7 @@ impl<D: Database> Executor<D> {
             self.publish(msg.clone()).await;
 
             // Generate certificate from an agreement
-            let cert = aggr.agreement.generate_certificate(msg.header.step);
+            let cert = aggr.agreement.generate_certificate();
 
             return self
                 .create_winning_block(&msg.header.block_hash, &cert)

--- a/consensus/src/selection/block_generator.rs
+++ b/consensus/src/selection/block_generator.rs
@@ -34,6 +34,7 @@ impl<T: Operations> Generator<T> {
         ru: &RoundUpdate,
         step: u8,
     ) -> Result<Message, crate::contract_state::Error> {
+        let iteration = step / 3 + 1;
         // Sign seed
         let seed = ru
             .secret_key
@@ -47,6 +48,7 @@ impl<T: Operations> Generator<T> {
                 Seed::from(seed),
                 ru.hash,
                 ru.timestamp,
+                iteration,
             )
             .await?;
 
@@ -78,6 +80,7 @@ impl<T: Operations> Generator<T> {
         seed: Seed,
         prev_block_hash: [u8; 32],
         prev_block_timestamp: i64,
+        iteration: u8,
     ) -> Result<Block, crate::contract_state::Error> {
         // Delay next iteration execution so we avoid consensus-split situation.
         tokio::time::sleep(Duration::from_millis(config::CONSENSUS_DELAY_MS))
@@ -111,6 +114,7 @@ impl<T: Operations> Generator<T> {
             state_hash: result.state_root,
             hash: [0; 32],
             cert: Certificate::default(),
+            iteration,
         };
 
         Ok(Block::new(blk_header, result.txs).expect("block should be valid"))

--- a/node-data/src/encoding.rs
+++ b/node-data/src/encoding.rs
@@ -126,7 +126,6 @@ impl Serializable for Certificate {
             &self.second_reduction.signature.inner()[..],
         )?;
 
-        w.write_all(&self.step.to_le_bytes())?;
         w.write_all(&self.first_reduction.bitset.to_le_bytes())?;
         w.write_all(&self.second_reduction.bitset.to_le_bytes())?;
 
@@ -145,10 +144,6 @@ impl Serializable for Certificate {
             .try_into()
             .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?;
 
-        let mut buf = [0u8; 1];
-        r.read_exact(&mut buf)?;
-        let step = buf[0];
-
         let mut buf = [0u8; 8];
         r.read_exact(&mut buf)?;
         let first_red_bitset = u64::from_le_bytes(buf);
@@ -166,7 +161,6 @@ impl Serializable for Certificate {
                 bitset: sec_red_bitset,
                 signature: Signature(second_red_signature),
             },
-            step,
         })
     }
 }

--- a/node-data/src/ledger.rs
+++ b/node-data/src/ledger.rs
@@ -95,7 +95,6 @@ impl Transaction {
 pub struct Certificate {
     pub first_reduction: StepVotes,
     pub second_reduction: StepVotes,
-    pub step: u8,
 }
 
 impl Header {

--- a/node-data/src/ledger.rs
+++ b/node-data/src/ledger.rs
@@ -33,6 +33,7 @@ pub struct Header {
     pub state_hash: Hash,
     pub generator_bls_pubkey: bls::PublicKeyBytes,
     pub gas_limit: u64,
+    pub iteration: u8,
 
     // Block hash
     pub hash: Hash,
@@ -122,6 +123,7 @@ impl Header {
         w.write_all(&self.state_hash[..])?;
         w.write_all(&self.generator_bls_pubkey.inner()[..])?;
         w.write_all(&self.gas_limit.to_le_bytes())?;
+        w.write_all(&self.iteration.to_le_bytes())?;
 
         Ok(())
     }
@@ -157,6 +159,10 @@ impl Header {
         r.read_exact(&mut buf[..])?;
         let gas_limit = u64::from_le_bytes(buf);
 
+        let mut buf = [0u8; 1];
+        r.read_exact(&mut buf[..])?;
+        let iteration = buf[0];
+
         Ok(Header {
             version,
             height,
@@ -165,6 +171,7 @@ impl Header {
             prev_block_hash,
             seed: Seed::from(seed),
             generator_bls_pubkey: bls::PublicKeyBytes(generator_bls_pubkey),
+            iteration,
             state_hash,
             hash: [0; 32],
             cert: Default::default(),

--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -974,6 +974,7 @@ mod tests {
                     second_reduction: ledger::StepVotes::new([7; 48], 3333333),
                     step: 234,
                 },
+                iteration: 1,
             },
             txs: vec![],
         };

--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -616,11 +616,10 @@ pub mod payload {
 
     impl Agreement {
         /// Generates a certificate from agreement.
-        pub fn generate_certificate(&self, step: u8) -> Certificate {
+        pub fn generate_certificate(&self) -> Certificate {
             Certificate {
                 first_reduction: self.first_step.clone(),
                 second_reduction: self.second_step.clone(),
-                step,
             }
         }
     }
@@ -972,7 +971,6 @@ mod tests {
                 cert: Certificate {
                     first_reduction: ledger::StepVotes::new([6; 48], 22222222),
                     second_reduction: ledger::StepVotes::new([7; 48], 3333333),
-                    step: 234,
                 },
                 iteration: 1,
             },

--- a/node/src/chain/mod.rs
+++ b/node/src/chain/mod.rs
@@ -235,7 +235,7 @@ impl ChainSrv {
                 t.store_block(blk, true)?;
 
                 // Accept block transactions into the VM
-                if blk.header.cert.step == 3 {
+                if blk.header.iteration == 1 {
                     return vm.finalize(blk);
                 }
 
@@ -315,6 +315,7 @@ impl ChainSrv {
             blk_header.height,
             &prev_block_header.seed,
             &blk_header.cert,
+            blk_header.iteration,
         )
         .await
     }
@@ -325,6 +326,7 @@ impl ChainSrv {
         height: u64,
         seed: &ledger::Seed,
         cert: &ledger::Certificate,
+        iteration: u8,
     ) -> anyhow::Result<()> {
         let (_, public_key) = &self.upper.keys;
 
@@ -337,7 +339,7 @@ impl ChainSrv {
             topic: 0,
             pubkey_bls: public_key.clone(),
             round: height,
-            step: cert.step,
+            step: iteration * 3,
             block_hash,
         };
 


### PR DESCRIPTION
- Add `iteration` to block header
- Remove `step` from header's certificate

Ps: This is needed in order to reflect protocol changes made in dusk-network/dusk-blockchain#1500

Resolves #848 