### PR TITLE
consensus: add tx_root to block header

### DIFF
--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -29,6 +29,7 @@ async-channel = "1.7.1"
 async-trait = "0.1"
 anyhow = "1.0"
 node-data = { version = "0.1", path = "../node-data" }
+dusk-merkle = "0.2.0"
 
 
 [dev-dependencies]

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -23,5 +23,7 @@ mod queue;
 mod secondstep;
 mod selection;
 
+pub mod merkle;
+
 #[cfg(test)]
 mod tests {}

--- a/consensus/src/merkle.rs
+++ b/consensus/src/merkle.rs
@@ -1,0 +1,220 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_merkle::{Aggregate, Tree};
+use sha3::{Digest, Sha3_256};
+
+pub const ARITY: usize = 2;
+
+#[derive(Clone, Copy)]
+pub struct Hash([u8; 32]);
+
+impl<I: Into<[u8; 32]>> From<I> for Hash {
+    fn from(bytes: I) -> Self {
+        Self(bytes.into())
+    }
+}
+
+pub const EMPTY_NODE: Hash = Hash([0; 32]);
+
+impl<const H: usize> Aggregate<H, ARITY> for Hash {
+    const EMPTY_SUBTREES: [Self; H] = [EMPTY_NODE; H];
+
+    /// old golang implementation duplicates the missing leaf
+    ///
+    /// E.g: for (H=3, A=2)
+    ///
+    /// if you have
+    /// 1 2 3 4 5
+    /// it will create duplicates
+    /// 1 2 3 4 5 5 5 5
+    ///
+    /// if you have
+    /// 1 2 3 4 5 6
+    /// it creates
+    /// 1 2 3 4 5 6 5 6
+    fn aggregate<'a, I>(items: I) -> Self
+    where
+        Self: 'a,
+        I: Iterator<Item = &'a Self>,
+    {
+        let mut hasher = Sha3_256::new();
+        let mut prev = &[0u8; 32];
+        for item in items {
+            if item.0 == EMPTY_NODE.0 {
+                hasher.update(prev);
+            } else {
+                hasher.update(item.0);
+                prev = &item.0;
+            };
+        }
+        Self::from(hasher.finalize())
+    }
+}
+
+struct BinaryMerkle<const H: usize> {
+    tree: Tree<Hash, H, ARITY>,
+}
+
+impl<const H: usize> BinaryMerkle<H> {
+    const fn new() -> Self {
+        Self { tree: Tree::new() }
+    }
+
+    fn insert<N: Into<Hash>>(&mut self, val: N) {
+        let val: [u8; 32] = Into::<Hash>::into(val).0;
+        self.tree.insert(self.tree.len(), val);
+    }
+
+    fn root(&self) -> [u8; 32] {
+        self.tree.root().0
+    }
+
+    fn root_from_values<N: Into<Hash> + Copy>(values: &[N]) -> [u8; 32] {
+        let mut tree = Self::new();
+        for &val in values {
+            tree.insert(val.into())
+        }
+        tree.root()
+    }
+}
+/// Caluclate the root of a dynamic merkle tree (containing up to 2^15 elements)
+/// in the same way of how dusk-blockchain does
+///
+/// For reference impl check here https://github.com/dusk-network/dusk-crypto/blob/master/merkletree/merkletree.go
+pub fn merkle_root<N: Into<Hash> + Copy>(values: &[N]) -> [u8; 32] {
+    let tree_height = match values.len() {
+        0 => return EMPTY_NODE.0,
+        v => (v as f64 - 1f64).sqrt().floor() as u64 + 1,
+    };
+
+    match tree_height {
+        1 => BinaryMerkle::<1>::root_from_values(values),
+        2 => BinaryMerkle::<2>::root_from_values(values),
+        3 => BinaryMerkle::<3>::root_from_values(values),
+        4 => BinaryMerkle::<4>::root_from_values(values),
+        5 => BinaryMerkle::<5>::root_from_values(values),
+        6 => BinaryMerkle::<6>::root_from_values(values),
+        7 => BinaryMerkle::<7>::root_from_values(values),
+        8 => BinaryMerkle::<8>::root_from_values(values),
+        9 => BinaryMerkle::<9>::root_from_values(values),
+        10 => BinaryMerkle::<10>::root_from_values(values),
+        11 => BinaryMerkle::<11>::root_from_values(values),
+        12 => BinaryMerkle::<12>::root_from_values(values),
+        13 => BinaryMerkle::<13>::root_from_values(values),
+        14 => BinaryMerkle::<14>::root_from_values(values),
+        15 => BinaryMerkle::<15>::root_from_values(values),
+        _ => panic!("unsupported"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    struct HashableStr(&'static str);
+
+    impl Into<Hash> for HashableStr {
+        fn into(self) -> Hash {
+            let mut hasher = Sha3_256::new();
+            hasher.update(self.0.as_bytes());
+            hasher.finalize().into()
+        }
+    }
+
+    #[test]
+    fn golang_compatibility() {
+        let mut test_vectors = vec![];
+
+        // Test merkle tree againt same vectors used by
+        // https://github.com/dusk-network/dusk-crypto/blob/more_fixtures/merkletree/merkletree_test.go
+        test_vectors.push((
+            vec![
+                HashableStr("Hello"),
+                HashableStr("Hi"),
+                HashableStr("Hey"),
+                HashableStr("Hola"),
+            ],
+            [
+                32, 188, 172, 153, 245, 171, 51, 156, 161, 201, 80, 58, 155,
+                97, 1, 79, 86, 175, 244, 91, 137, 105, 238, 155, 233, 126, 112,
+                151, 195, 101, 37, 220,
+            ],
+        ));
+
+        test_vectors.push((
+            vec![HashableStr("Bella")],
+            [
+                21, 37, 141, 144, 92, 108, 151, 168, 167, 108, 172, 79, 204,
+                99, 154, 196, 242, 247, 38, 145, 254, 228, 141, 104, 75, 210,
+                148, 101, 74, 166, 1, 65,
+            ],
+        ));
+
+        test_vectors.push((
+            vec![
+                HashableStr("Bella"),
+                HashableStr("Ciao"),
+                HashableStr("Stop"),
+            ],
+            [
+                237, 79, 47, 121, 34, 152, 157, 123, 29, 245, 148, 185, 242,
+                38, 186, 47, 27, 182, 232, 127, 84, 7, 77, 127, 146, 196, 83,
+                8, 245, 190, 21, 5,
+            ],
+        ));
+
+        test_vectors.push((
+            vec![
+                HashableStr("Bella"),
+                HashableStr("Ciao"),
+                HashableStr("Ndo"),
+                HashableStr("Scappi"),
+            ],
+            [
+                88, 206, 79, 67, 184, 243, 45, 145, 95, 208, 173, 187, 93, 119,
+                173, 216, 206, 250, 233, 54, 65, 0, 166, 185, 102, 156, 49,
+                227, 107, 3, 178, 119,
+            ],
+        ));
+        test_vectors.push((
+            vec![
+                HashableStr("Bella"),
+                HashableStr("Ciao"),
+                HashableStr("Ndo"),
+                HashableStr("Scappi"),
+                HashableStr("Stop"),
+            ],
+            [
+                254, 132, 247, 13, 76, 173, 142, 94, 29, 216, 48, 25, 120, 142,
+                205, 65, 160, 88, 186, 233, 10, 143, 123, 79, 53, 22, 24, 55,
+                47, 130, 228, 238,
+            ],
+        ));
+        test_vectors.push((
+            vec![
+                HashableStr("Bella"),
+                HashableStr("Ciao"),
+                HashableStr("Ndo"),
+                HashableStr("Scappi"),
+                HashableStr("Stop"),
+                HashableStr("Pari"),
+            ],
+            [
+                232, 216, 240, 248, 181, 80, 60, 110, 63, 103, 197, 226, 130,
+                128, 226, 245, 173, 218, 140, 195, 246, 109, 134, 119, 4, 192,
+                166, 120, 163, 2, 95, 230,
+            ],
+        ));
+
+        for (values, expected_hash) in test_vectors {
+            let actual = merkle_root(&values[..]);
+            assert_eq!(actual, expected_hash)
+        }
+    }
+}

--- a/consensus/src/selection/block_generator.rs
+++ b/consensus/src/selection/block_generator.rs
@@ -10,6 +10,7 @@ use node_data::ledger::{Block, Certificate, Seed};
 
 use crate::config;
 use crate::contract_state::Operations;
+use crate::merkle::merkle_root;
 
 use dusk_bytes::Serializable;
 use node_data::bls::PublicKey;
@@ -101,6 +102,9 @@ impl<T: Operations> Generator<T> {
             },
         )?;
 
+        let tx_hashes: Vec<_> = result.txs.iter().map(|t| t.hash()).collect();
+        let txroot = merkle_root(&tx_hashes[..]);
+
         let blk_header = ledger::Header {
             version: 0,
             height: round,
@@ -114,6 +118,7 @@ impl<T: Operations> Generator<T> {
             state_hash: result.state_root,
             hash: [0; 32],
             cert: Certificate::default(),
+            txroot,
             iteration,
         };
 

--- a/node-data/src/ledger.rs
+++ b/node-data/src/ledger.rs
@@ -32,6 +32,7 @@ pub struct Header {
     pub seed: Seed,
     pub state_hash: Hash,
     pub generator_bls_pubkey: bls::PublicKeyBytes,
+    pub txroot: Hash,
     pub gas_limit: u64,
     pub iteration: u8,
 
@@ -121,6 +122,7 @@ impl Header {
 
         w.write_all(&self.state_hash[..])?;
         w.write_all(&self.generator_bls_pubkey.inner()[..])?;
+        w.write_all(&self.txroot[..])?;
         w.write_all(&self.gas_limit.to_le_bytes())?;
         w.write_all(&self.iteration.to_le_bytes())?;
 
@@ -154,6 +156,9 @@ impl Header {
         let mut generator_bls_pubkey = [0u8; 96];
         r.read_exact(&mut generator_bls_pubkey[..])?;
 
+        let mut txroot = [0u8; 32];
+        r.read_exact(&mut txroot[..])?;
+
         let mut buf = [0u8; 8];
         r.read_exact(&mut buf[..])?;
         let gas_limit = u64::from_le_bytes(buf);
@@ -172,6 +177,7 @@ impl Header {
             generator_bls_pubkey: bls::PublicKeyBytes(generator_bls_pubkey),
             iteration,
             state_hash,
+            txroot,
             hash: [0; 32],
             cert: Default::default(),
         })

--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -128,9 +128,9 @@ impl Serializable for Message {
             Topics::Tx => {
                 Payload::Transaction(Box::new(ledger::Transaction::read(r)?))
             }
-            Topics::Candidate => {
-                Payload::CandidateResp(payload::CandidateResp::read(r)?)
-            }
+            Topics::Candidate => Payload::CandidateResp(Box::new(
+                payload::CandidateResp::read(r)?,
+            )),
             Topics::GetCandidate => {
                 Payload::GetCandidate(payload::GetCandidate::read(r)?)
             }
@@ -230,7 +230,7 @@ impl Message {
     }
 
     /// Creates topics.Candidate message
-    pub fn new_candidate_resp(p: payload::CandidateResp) -> Message {
+    pub fn new_candidate_resp(p: Box<payload::CandidateResp>) -> Message {
         Self {
             header: Header::new(Topics::Candidate),
             payload: Payload::CandidateResp(p),
@@ -455,7 +455,7 @@ pub enum Payload {
     GetInv(payload::Inv),
     GetBlocks(payload::GetBlocks),
     GetData(payload::GetData),
-    CandidateResp(payload::CandidateResp),
+    CandidateResp(Box<payload::CandidateResp>),
 
     #[default]
     Empty,
@@ -968,6 +968,7 @@ mod tests {
                 generator_bls_pubkey: bls::PublicKeyBytes([5; 96]),
                 state_hash: [4; 32],
                 hash: [5; 32],
+                txroot: [6; 32],
                 cert: Certificate {
                     first_reduction: ledger::StepVotes::new([6; 48], 22222222),
                     second_reduction: ledger::StepVotes::new([7; 48], 3333333),

--- a/node/src/databroker/mod.rs
+++ b/node/src/databroker/mod.rs
@@ -257,9 +257,9 @@ impl DataBrokerSrv {
         let block =
             res.ok_or_else(|| anyhow::anyhow!("could not find block"))?;
 
-        Ok(Message::new_candidate_resp(payload::CandidateResp {
-            candidate: block,
-        }))
+        Ok(Message::new_candidate_resp(Box::new(
+            payload::CandidateResp { candidate: block },
+        )))
     }
 
     /// Handles GetMempool requests.


### PR DESCRIPTION
### `node-data`
- Add `txroot` to block header


### `consensus`

- Add `dusk-merkle` dependency
- Add `fn consensus::merkle::merkle_root` wrapping `dusk-merkle` to guarantee compatibility with dusk-blockchain's merkle-tree
- Add block header's `txroot` creation/verification

Resolves #847