### PR TITLE
Split transaction execution in three parts 

### DIFF
--- a/contracts/stake/src/lib.rs
+++ b/contracts/stake/src/lib.rs
@@ -30,22 +30,34 @@ static mut STATE: StakeState = StakeState::new();
 
 #[no_mangle]
 unsafe fn stake(arg_len: u32) -> u32 {
-    rusk_abi::wrap_call(arg_len, |arg| STATE.stake(arg))
+    rusk_abi::wrap_call(arg_len, |arg| {
+        assert_external_caller();
+        STATE.stake(arg)
+    })
 }
 
 #[no_mangle]
 unsafe fn unstake(arg_len: u32) -> u32 {
-    rusk_abi::wrap_call(arg_len, |arg| STATE.unstake(arg))
+    rusk_abi::wrap_call(arg_len, |arg| {
+        assert_external_caller();
+        STATE.unstake(arg)
+    })
 }
 
 #[no_mangle]
 unsafe fn withdraw(arg_len: u32) -> u32 {
-    rusk_abi::wrap_call(arg_len, |arg| STATE.withdraw(arg))
+    rusk_abi::wrap_call(arg_len, |arg| {
+        assert_external_caller();
+        STATE.withdraw(arg)
+    })
 }
 
 #[no_mangle]
 unsafe fn allow(arg_len: u32) -> u32 {
-    rusk_abi::wrap_call(arg_len, |arg| STATE.allow(arg))
+    rusk_abi::wrap_call(arg_len, |arg| {
+        assert_external_caller();
+        STATE.allow(arg)
+    })
 }
 
 // Queries

--- a/contracts/stake/src/state.rs
+++ b/contracts/stake/src/state.rs
@@ -117,10 +117,6 @@ impl StakeState {
     }
 
     pub fn stake(&mut self, stake: Stake) {
-        if rusk_abi::caller() != TRANSFER_CONTRACT {
-            panic!("Can only be called from the transfer contract!");
-        }
-
         if stake.value < MINIMUM_STAKE {
             panic!("The staked value is lower than the minimum amount!");
         }
@@ -157,10 +153,6 @@ impl StakeState {
     }
 
     pub fn unstake(&mut self, unstake: Unstake) {
-        if rusk_abi::caller() != TRANSFER_CONTRACT {
-            panic!("Can only be called from the transfer contract!");
-        }
-
         // remove the stake from a key and increment the signature counter
         let loaded_stake = self
             .get_stake_mut(&unstake.public_key)
@@ -195,10 +187,6 @@ impl StakeState {
     }
 
     pub fn withdraw(&mut self, withdraw: Withdraw) {
-        if rusk_abi::caller() != TRANSFER_CONTRACT {
-            panic!("Can only be called from the transfer contract!");
-        }
-
         // deplete the stake from a key and increment the signature counter
         let loaded_stake = self
             .get_stake_mut(&withdraw.public_key)
@@ -246,10 +234,6 @@ impl StakeState {
     }
 
     pub fn allow(&mut self, allow: Allow) {
-        if rusk_abi::caller() != TRANSFER_CONTRACT {
-            panic!("Can only be called from the transfer contract!");
-        }
-
         if self.is_allowlisted(&allow.public_key) {
             panic!("Address already allowed!");
         }

--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -26,11 +26,6 @@ static mut STATE: TransferState = TransferState::new();
 // Transactions
 
 #[no_mangle]
-unsafe fn execute(arg_len: u32) -> u32 {
-    rusk_abi::wrap_call(arg_len, |arg| STATE.execute(arg))
-}
-
-#[no_mangle]
 unsafe fn mint(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |arg| STATE.mint(arg))
 }
@@ -103,6 +98,22 @@ unsafe fn existing_nullifiers(arg_len: u32) -> u32 {
 }
 
 // "Management" transactions
+
+#[no_mangle]
+unsafe fn spend(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |tx| {
+        assert_external_caller();
+        STATE.spend(tx)
+    })
+}
+
+#[no_mangle]
+unsafe fn refund(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |(fee, gas_spent)| {
+        assert_external_caller();
+        STATE.refund(fee, gas_spent)
+    })
+}
 
 #[no_mangle]
 unsafe fn push_note(arg_len: u32) -> u32 {

--- a/contracts/transfer/src/tree.rs
+++ b/contracts/transfer/src/tree.rs
@@ -10,6 +10,7 @@ use alloc::vec::Vec;
 
 use dusk_bls12_381::BlsScalar;
 use phoenix_core::transaction::*;
+use phoenix_core::Note;
 
 use dusk_merkle::poseidon::{
     Item as PoseidonItem, Opening as PoseidonOpening, Tree as PoseidonTree,
@@ -49,6 +50,17 @@ impl Tree {
         self.leaves.push(leaf);
 
         pos
+    }
+
+    pub fn extend_notes<I: IntoIterator<Item = Note>>(
+        &mut self,
+        block_height: u64,
+        notes: I,
+    ) {
+        for note in notes {
+            let leaf = TreeLeaf { block_height, note };
+            self.push(leaf);
+        }
     }
 
     pub fn root(&self) -> BlsScalar {

--- a/rusk/src/lib/lib.rs
+++ b/rusk/src/lib/lib.rs
@@ -8,7 +8,6 @@ use crate::error::Error;
 use crate::services::prover::RuskProver;
 use crate::transaction::SpentTransaction;
 
-use std::collections::BTreeSet;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -28,13 +27,12 @@ use once_cell::sync::Lazy;
 use parking_lot::{Mutex, MutexGuard};
 use phoenix_core::transaction::*;
 use phoenix_core::Message;
-use piecrust::{Session, VM};
+use piecrust::{Error as PiecrustError, Session, VM};
 use rkyv::validation::validators::DefaultValidator;
 use rkyv::{Archive, Deserialize, Infallible, Serialize};
 use rusk_abi::dusk::{dusk, Dusk};
 use rusk_abi::{
-    ContractError, ContractId, RawResult, StandardBufSerializer,
-    STAKE_CONTRACT, TRANSFER_CONTRACT,
+    ContractId, StandardBufSerializer, STAKE_CONTRACT, TRANSFER_CONTRACT,
 };
 use rusk_profile::to_rusk_state_id_path;
 use rusk_recovery_tools::provisioners::DUSK_KEY;
@@ -51,20 +49,6 @@ pub static PUB_PARAMS: Lazy<PublicParameters> = Lazy::new(|| unsafe {
 });
 
 const STREAM_BUF_SIZE: usize = 64;
-
-/// The gas grace is a magic number denoting the amount of gas that is spent by
-/// a transaction after the charging code has been executed.
-const GAS_GRACE: u64 = 24_858_000;
-
-/// Computes the gas limit to apply to a transaction, given the limit imposed by
-/// the fee limit and the block gas limit.
-///
-/// The result will be the minimum between the block gas limit and the fee limit
-/// plus the [`GAS_GRACE`].
-fn compute_gas_limit(fee_limit: u64, block_limit: u64) -> u64 {
-    let min = cmp::min(fee_limit, block_limit);
-    min + GAS_GRACE
-}
 
 pub struct RuskInner {
     pub current_commit: [u8; 32],
@@ -133,80 +117,68 @@ impl Rusk {
 
         let mut dusk_spent = 0;
 
-        let mut nullifiers = BTreeSet::new();
-
-        // Here we discard transactions that:
-        // - Use nullifiers that are already use by previous TXs
-        // - Fail for any reason other than out of gas due to hitting the block
-        //   gas limit
-        'tx_loop: for tx in txs {
-            for nullifier in &tx.nullifiers {
-                if !nullifiers.insert(*nullifier) {
-                    discarded_txs.push(tx);
-                    continue 'tx_loop;
-                }
-            }
-
-            // The gas limit set for a transaction is either the limit it sets,
-            // or the gas left in the block, whichever is smallest.
-            let gas_limit = compute_gas_limit(tx.fee.gas_limit, block_gas_left);
-            session.set_point_limit(gas_limit);
-
-            let (gas_spent, call_result): (
-                u64,
-                Option<Result<RawResult, ContractError>>,
-            ) = match session.call(TRANSFER_CONTRACT, "execute", &tx) {
-                Ok(call_result) => call_result,
+        for tx in txs {
+            let (call_result, gas_spent) = match execute(
+                &mut session,
+                &tx,
+                block_gas_left,
+            ) {
+                // We're currently ignoring the result of a call.
+                Ok((_ret, gas_spent)) => (None, gas_spent),
                 Err(err) => match err {
-                    piecrust::Error::OutOfPoints => {
-                        let fee_limit =
-                            compute_gas_limit(tx.fee.gas_limit, u64::MAX);
-
-                        // If the transaction would have been out of points
-                        // with its own gas limit, it is invalid and should
-                        // be discarded.
-                        if gas_limit == fee_limit {
-                            discarded_txs.push(tx);
-                        }
+                    // An unspendable transaction should be discarded
+                    TxError::Unspendable(_) => {
+                        discarded_txs.push(tx);
                         continue;
                     }
-                    _ => {
-                        discarded_txs.push(tx);
+                    // This transaction was given its own gas limit, so it
+                    // should be included with the error.
+                    TxError::TxLimit { err, gas_spent } => {
+                        (Some(err), gas_spent)
+                    }
+                    // A transaction that errors due to hitting the block
+                    // gas limit is not included,
+                    // but not dicarded either.
+                    TxError::BlockLimit(_) => continue,
+                    // A transaction that hit the block gas limit after
+                    // execution leaves the transaction in a spent state,
+                    // therefore re-execution is required. It also is not
+                    // discarded.
+                    TxError::BlockLimitAfter(_) => {
+                        session = rusk_abi::new_session(
+                            &inner.vm,
+                            current_commit,
+                            block_height,
+                        )?;
+
+                        let mut block_gas_left = block_gas_limit;
+
+                        for spent_tx in &spent_txs {
+                            let gas_spent = execute(
+                                    &mut session,
+                                    &spent_tx.0,
+                                    block_gas_left,
+                                )
+                                .map(|(_, gas_spent)| gas_spent)
+                                .unwrap_or_else(|err| match err {
+                                    TxError::TxLimit { gas_spent, .. } => {
+                                        gas_spent
+                                    }
+                                    _ => unreachable!("Spent transactions are either succeeding or TxError"),
+                                });
+
+                            block_gas_left -= gas_spent;
+                        }
+
                         continue;
                     }
                 },
             };
 
-            // If the gas spent is larger that the remaining block gas, then we
-            // re-execute the transactions with a new session. We can ignore the
-            // results since we know they will be valid.
-            if gas_spent > block_gas_left {
-                session = rusk_abi::new_session(
-                    &inner.vm,
-                    current_commit,
-                    block_height,
-                )?;
-
-                for spent_tx in &spent_txs {
-                    let _: (
-                        u64,
-                        Option<Result<RawResult, ContractError>>,
-                    ) =
-                    session.call(TRANSFER_CONTRACT, "execute", &spent_tx.0)
-                        .expect("Re-execution of spent transactions should never fail");
-                }
-
-                continue;
-            }
-
             block_gas_left -= gas_spent;
             dusk_spent += gas_spent * tx.fee.gas_price;
 
-            spent_txs.push(SpentTransaction(
-                tx,
-                gas_spent,
-                call_result.and_then(|result| result.err()),
-            ));
+            spent_txs.push(SpentTransaction(tx, gas_spent, call_result));
 
             // No need to keep executing if there is no gas left in the
             // block
@@ -508,39 +480,167 @@ fn accept(
     let mut spent_txs = Vec::with_capacity(txs.len());
     let mut dusk_spent = 0;
 
-    let mut nullifiers = BTreeSet::new();
-
     for tx in txs {
-        for input in &tx.nullifiers {
-            if !nullifiers.insert(*input) {
-                return Err(Error::RepeatingNullifiers(vec![*input]));
-            }
-        }
-
-        let gas_limit = compute_gas_limit(tx.fee.gas_limit, block_gas_left);
-        session.set_point_limit(gas_limit);
-
-        let (gas_spent, call_result): (
-            u64,
-            Option<Result<RawResult, ContractError>>,
-        ) = session.call(TRANSFER_CONTRACT, "execute", &tx)?;
+        let (call_result, gas_spent) =
+            match execute(session, &tx, block_gas_left) {
+                // We're currently ignoring the result of a call.
+                Ok((_ret, gas_spent)) => (None, gas_spent),
+                Err(err) => match err {
+                    TxError::TxLimit { err, gas_spent } => {
+                        (Some(err), gas_spent)
+                    }
+                    TxError::Unspendable(err)
+                    | TxError::BlockLimit(err)
+                    | TxError::BlockLimitAfter(err) => {
+                        return Err(err.into());
+                    }
+                },
+            };
 
         dusk_spent += gas_spent * tx.fee.gas_price;
         block_gas_left = block_gas_left
             .checked_sub(gas_spent)
             .ok_or(Error::OutOfGas)?;
 
-        spent_txs.push(SpentTransaction(
-            tx,
-            gas_spent,
-            call_result.and_then(|result| result.err()),
-        ));
+        spent_txs.push(SpentTransaction(tx, gas_spent, call_result));
     }
 
     reward_and_update_root(session, block_height, dusk_spent, generator)?;
     let state_root = session.root();
 
     Ok((spent_txs, state_root))
+}
+
+/// Executes a transaction, returning the result of the call and the gas spent.
+/// The following steps are executed:
+///
+/// 0. Pre-flight checks, i.e. the transaction gas limit must be at least the
+///    same as what is minimally charged for a transaction of its type, and the
+///    transaction must fit in the remaining block gas.
+///
+/// 1. Call the "spend" function on the transfer contract with unlimited gas. If
+///    this fails, the transaction should be considered invalid, or unspendable,
+///    and an error is returned.
+///
+/// 2. If the transaction includes a contract call, execute it with the gas
+///    limit given in the transaction, or with the block gas remaining,
+///    whichever is smallest. If this fails with an out of gas, two possible
+///    things happen:
+///        * We use the transaction gas limit and will treat this as any other
+///          transaction.
+///        * We used the block gas remaining and can't be sure of what to do. In
+///          this case we return early with an [TxError::BlockLimitAfter], since
+///          we are in a bad state, and can't be sure of what to do.
+///    For any other transaction error we proceed to step 3.
+///
+/// 3. Call the "refund" function on the transfer contract with unlimited gas.
+///    The amount charged depends on if the transaction has executed a call or
+///    not. If it has there are two cases:
+///        * The call succeeded and the transaction will be charged for gas used
+///          plus the amount charged by a transaction of its type.
+///        * The call errored and the transaction will be charged the full gas
+///          given.
+///    If the transaction has not executed a call only be the amount charged for
+///    a transaction of its type.
+fn execute(
+    session: &mut Session,
+    tx: &Transaction,
+    block_gas_left: u64,
+) -> Result<(Vec<u8>, u64), TxError> {
+    let gas_for_spend = spent_gas_per_input(tx.nullifiers.len());
+
+    // If the gas given is less than the amount the node charges per input, then
+    // the transaction is unspendable.
+    if tx.fee.gas_limit < gas_for_spend {
+        return Err(TxError::Unspendable(PiecrustError::OutOfPoints));
+    }
+
+    // If the gas to spend is more than the amount remaining in a block, then
+    // the transaction can't be spent at this spot in the block.
+    if block_gas_left < gas_for_spend {
+        return Err(TxError::BlockLimit(PiecrustError::OutOfPoints));
+    }
+
+    // Spend the transaction. If this error the transaction is unspendable.
+    session.set_point_limit(u64::MAX);
+    session
+        .call(TRANSFER_CONTRACT, "spend", tx)
+        .map_err(TxError::Unspendable)?;
+
+    let mut gas_spent = gas_for_spend;
+
+    let block_gas_left = block_gas_left - gas_spent;
+    let tx_gas_left = block_gas_left - gas_spent;
+
+    let res = tx
+        .call
+        .as_ref()
+        .map(|(contract_id_bytes, fn_name, fn_data)| {
+            let contract_id = ContractId::from_bytes(*contract_id_bytes);
+            let gas_remaining = cmp::min(block_gas_left, tx_gas_left);
+
+            session.set_point_limit(gas_remaining);
+
+            match session.call_raw(contract_id, fn_name, fn_data.clone()) {
+                Ok(vec) => {
+                    gas_spent += session.spent();
+                    Ok(vec)
+                }
+                Err(err) => match err {
+                    err @ PiecrustError::OutOfPoints => {
+                        // If the transaction failed with an OUT_OF_GAS, and
+                        // we're using the block gas remaining as a limit, then
+                        // we can't be sure that the transaction would fail if
+                        // it was given the full gas it gave as a limit.
+                        if gas_remaining == block_gas_left {
+                            return Err(TxError::BlockLimitAfter(err));
+                        }
+
+                        // Otherwise we should spend the maximum available gas
+                        gas_spent = tx.fee.gas_limit;
+                        Err(TxError::TxLimit { gas_spent, err })
+                    }
+                    err => {
+                        // On any other error we should spent the maximum
+                        // available gas
+                        gas_spent = tx.fee.gas_limit;
+                        Err(TxError::TxLimit { gas_spent, err })
+                    }
+                },
+            }
+        });
+
+    // Refund the appropriate amount to the transaction. This call is guaranteed
+    // to never error. If it does, then a programming error has occurred. As
+    // such, the call to `Result::expect` is warranted.
+    session.set_point_limit(u64::MAX);
+    let _: () = session
+        .call(TRANSFER_CONTRACT, "refund", &(tx.fee, gas_spent))
+        .expect("Refunding must succeed");
+
+    res.map(|res| res.map(|data| (data, gas_spent)))
+        .unwrap_or(Ok((vec![], gas_spent)))
+}
+
+/// The gas spent per input of a transaction.
+const fn spent_gas_per_input(n_inputs: usize) -> u64 {
+    const GAS_PER_INPUT: u64 = 1_000_000;
+    n_inputs as u64 * GAS_PER_INPUT
+}
+
+/// The error returned when executing a transaction.
+enum TxError {
+    /// A transaction can't be spent.
+    Unspendable(PiecrustError),
+    /// The error was produced by executing the transaction's call with its own
+    /// given gas limit.
+    TxLimit { gas_spent: u64, err: PiecrustError },
+    /// The error was produced by executing the transaction's call with the
+    /// remaining block gas limit.
+    BlockLimit(PiecrustError),
+    /// The error was produced by executing the transaction's call with the
+    /// remaining block gas limit, and after execution of a call.
+    BlockLimitAfter(PiecrustError),
 }
 
 fn reward_and_update_root(

--- a/rusk/src/lib/lib.rs
+++ b/rusk/src/lib/lib.rs
@@ -622,9 +622,11 @@ fn execute(
         .unwrap_or(Ok((vec![], gas_spent)))
 }
 
-/// The gas spent per input of a transaction.
+/// The gas charged per input of a transaction.
+pub const GAS_PER_INPUT: u64 = 1_000_000;
+
+/// The gas charged given the number of inputs of a transaction.
 const fn spent_gas_per_input(n_inputs: usize) -> u64 {
-    const GAS_PER_INPUT: u64 = 1_000_000;
     n_inputs as u64 * GAS_PER_INPUT
 }
 

--- a/rusk/src/lib/transaction.rs
+++ b/rusk/src/lib/transaction.rs
@@ -8,11 +8,13 @@ use std::ops::Deref;
 
 use dusk_bytes::{Error as BytesError, Serializable};
 use phoenix_core::Transaction;
-use rusk_abi::{ContractError, TRANSFER_CONTRACT};
+use rusk_abi::TRANSFER_CONTRACT;
 
 use rusk_schema::executed_transaction::error::Code;
 use rusk_schema::executed_transaction::Error;
 use rusk_schema::{TX_TYPE_TRANSFER, TX_VERSION};
+
+use piecrust::Error as PiecrustError;
 
 /// The payload for a transfer transaction.
 ///
@@ -61,11 +63,11 @@ impl From<TransferPayload> for rusk_schema::Transaction {
 pub struct SpentTransaction(
     pub Transaction,
     pub u64,
-    pub Option<ContractError>,
+    pub Option<PiecrustError>,
 );
 
 impl SpentTransaction {
-    pub fn into_inner(self) -> (Transaction, u64, Option<ContractError>) {
+    pub fn into_inner(self) -> (Transaction, u64, Option<PiecrustError>) {
         (self.0, self.1, self.2)
     }
 }
@@ -78,20 +80,15 @@ impl From<SpentTransaction> for rusk_schema::ExecutedTransaction {
         let tx_hash = rusk_abi::hash(tx_hash_input_bytes);
 
         let error = error.map(|e| match e {
-            ContractError::PANIC => Error {
-                code: Code::ContractPanic.into(),
-                contract_id: TRANSFER_CONTRACT.to_bytes().to_vec(),
-                data: String::from("PANIC"),
-            },
-            ContractError::OUTOFGAS => Error {
+            PiecrustError::OutOfPoints => Error {
                 code: Code::OutOfGas.into(),
                 contract_id: TRANSFER_CONTRACT.to_bytes().to_vec(),
                 data: String::from("OUT_OF_GAS"),
             },
-            ContractError::OTHER(code) => Error {
+            _ => Error {
                 code: Code::Other.into(),
                 contract_id: TRANSFER_CONTRACT.to_bytes().to_vec(),
-                data: format!("OTHER: {code}"),
+                data: "".to_string(),
             },
         });
 

--- a/rusk/tests/config/gas-behavior.toml
+++ b/rusk/tests/config/gas-behavior.toml
@@ -1,0 +1,14 @@
+[acl.stake]
+owners = []
+allowlist = []
+
+[[balance]]
+address = "ivmscertKgRyX8wNMJJsQcSVEyPsfSMUQXSAgeAPQXsndqFq9Pmknzhm61QvcEEdxPaGgxDS4RHpb6KKccrnSKN"
+seed = 57005
+notes = [10_000_000_000]
+
+[[balance]]
+address = "3MoVQ6VfGNu8fJ5GeHPRDVUfxcsDEmGXpWhvKhXY7F2dKCp7QWRw8RqPcbuJGdRqeTtxpuiwETnGAJLnhT4Kq4e8"
+seed = 57005
+notes = [10_000_000_000]
+

--- a/rusk/tests/services/gas_behavior.rs
+++ b/rusk/tests/services/gas_behavior.rs
@@ -1,0 +1,448 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::path::Path;
+
+use dusk_bls12_381::BlsScalar;
+use dusk_bls12_381_sign::PublicKey;
+use dusk_bytes::Error::InvalidData;
+use dusk_bytes::{DeserializableSlice, Serializable};
+use dusk_jubjub::{JubJubAffine, JubJubScalar};
+use dusk_merkle::poseidon::Opening as PoseidonOpening;
+use dusk_pki::ViewKey;
+use dusk_plonk::proof_system::Proof;
+use dusk_schnorr::Signature;
+use dusk_wallet_core::{
+    self as wallet, StakeInfo, Store, Transaction, UnprovenTransaction,
+};
+use futures::StreamExt;
+use phoenix_core::{Crossover, Fee, Note};
+use rand::prelude::*;
+use rand::rngs::StdRng;
+use rusk::error::Error;
+use rusk::services::network::{KadcastDispatcher, NetworkServer};
+use rusk::services::prover::ExecuteProverRequest;
+use rusk::services::prover::{ProverServer, RuskProver};
+use rusk::services::state::StateServer;
+use rusk::services::state::{
+    ExecuteStateTransitionRequest, FindExistingNullifiersRequest,
+    GetAnchorRequest, GetNotesRequest, GetOpeningRequest, PreverifyRequest,
+    StateTransitionRequest, VerifyStateTransitionRequest,
+};
+use rusk::{Result, Rusk};
+use rusk_abi::{ContractId, POSEIDON_TREE_DEPTH};
+use rusk_schema::network_client::NetworkClient;
+use rusk_schema::prover_client::ProverClient;
+use rusk_schema::state_client::StateClient;
+use rusk_schema::{PropagateMessage, Transaction as TransactionProto};
+use tempfile::tempdir;
+use tonic::transport::Server;
+use tracing::info;
+
+use crate::common::keys::BLS_SK;
+use crate::common::state::new_state;
+use crate::common::*;
+
+const BLOCK_HEIGHT: u64 = 1;
+const BLOCK_GAS_LIMIT: u64 = 2_500_000;
+const GAS_LIMIT: u64 = 1_000_000;
+const INITIAL_BALANCE: u64 = 10_000_000_000;
+
+// Creates the Rusk initial state for the tests below
+fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
+    let snapshot = toml::from_str(include_str!("../config/gas-behavior.toml"))
+        .expect("Cannot deserialize config");
+
+    new_state(dir, &snapshot)
+}
+
+const SENDER_INDEX: u64 = 0;
+
+/// Execute a transaction that will error during a contract call, and checks
+/// that it was indeed charged the full amount it provides.
+fn erroring_call(
+    wallet: &wallet::Wallet<TestStore, TestStateClient, TestProverClient>,
+    channel: tonic::transport::Channel,
+) {
+    // We will refund the transaction to ourselves.
+    let refund = wallet
+        .public_spend_key(SENDER_INDEX)
+        .expect("Getting a public spend key should succeed");
+
+    let initial_balance = wallet
+        .get_balance(SENDER_INDEX)
+        .expect("Getting initial balance should succeed")
+        .value;
+
+    assert_eq!(
+        initial_balance, INITIAL_BALANCE,
+        "The sender should have the given initial balance"
+    );
+
+    let mut rng = StdRng::seed_from_u64(0xdead);
+
+    // The transaction will be a `wallet.execute` to a contract that is not
+    // deployed. This will produce an error in call execution and should
+    // consume all the gas provided.
+    let tx = wallet
+        .execute(
+            &mut rng,
+            ContractId::from([0x42; 32]),
+            String::from("nonsense"),
+            (),
+            SENDER_INDEX,
+            &refund,
+            GAS_LIMIT,
+            1,
+        )
+        .expect("Making the transaction should succeed");
+
+    generator_procedure(channel, tx.clone())
+        .expect("generator procedure should succeed");
+
+    let final_balance = wallet
+        .get_balance(SENDER_INDEX)
+        .expect("Getting final balance should succeed")
+        .value;
+
+    assert_eq!(
+        final_balance,
+        initial_balance - GAS_LIMIT,
+        "Transaction should consume all the gas"
+    );
+}
+
+/// Executes the procedure a block generator will go through to generate a block
+/// including the contract call in the block.
+fn generator_procedure(
+    channel: tonic::transport::Channel,
+    tx: Transaction,
+) -> Result<()> {
+    let mut client = StateClient::new(channel);
+
+    let proto = TransactionProto {
+        version: 1,
+        r#type: 1,
+        payload: tx.to_var_bytes(),
+    };
+
+    // Run pre-verification
+    let preverify_response = client
+        .preverify(PreverifyRequest {
+            tx: Some(proto.clone()),
+        })
+        .wait()?
+        .into_inner();
+
+    let tx_hash_input_bytes = tx.to_hash_input_bytes();
+    let tx_hash = rusk_abi::hash(tx_hash_input_bytes);
+
+    assert_eq!(
+        preverify_response.tx_hash,
+        tx_hash.to_bytes().to_vec(),
+        "Transaction hashes should match in pre-verification response"
+    );
+
+    // Execute state transition
+    let generator = PublicKey::from(&*BLS_SK);
+
+    let response = client
+        .execute_state_transition(ExecuteStateTransitionRequest {
+            txs: vec![proto],
+            block_height: BLOCK_HEIGHT,
+            block_gas_limit: BLOCK_GAS_LIMIT,
+            generator: generator.to_bytes().to_vec(),
+        })
+        .wait()?
+        .into_inner();
+
+    assert_eq!(
+        response.txs.len(),
+        1,
+        "The transaction should be included in the block"
+    );
+
+    let transfer_txs: Vec<_> = response
+        .txs
+        .iter()
+        .filter(|etx| etx.tx.as_ref().unwrap().r#type == 1)
+        .collect();
+
+    let execute_state_root = response.state_root.clone();
+
+    info!(
+        "execute_state_transition new root: {}",
+        hex::encode(&execute_state_root)
+    );
+
+    let mut txs = vec![];
+    txs.extend(transfer_txs);
+
+    let txs: Vec<_> = txs
+        .iter()
+        .map(|tx| tx.tx.as_ref().unwrap())
+        .cloned()
+        .collect();
+
+    client
+        .verify_state_transition(VerifyStateTransitionRequest {
+            txs: txs.clone(),
+            block_height: BLOCK_HEIGHT,
+            block_gas_limit: BLOCK_GAS_LIMIT,
+            generator: generator.to_bytes().to_vec(),
+        })
+        .wait()?;
+
+    let response = client
+        .accept(StateTransitionRequest {
+            txs,
+            block_height: BLOCK_HEIGHT,
+            block_gas_limit: BLOCK_GAS_LIMIT,
+            state_root: execute_state_root.clone(),
+            generator: generator.to_bytes().to_vec(),
+        })
+        .wait()?
+        .into_inner();
+
+    assert_eq!(
+        response.txs.len(),
+        1,
+        "There should be one transaction in the block"
+    );
+
+    let accept_state_root = response.state_root;
+    info!("accept new root: {}", hex::encode(&accept_state_root));
+
+    assert_eq!(
+        accept_state_root, execute_state_root,
+        "Root should be equal"
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct TestStore;
+
+impl Store for TestStore {
+    type Error = ();
+
+    fn get_seed(&self) -> Result<[u8; 64], Self::Error> {
+        Ok([0; 64])
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TestStateClient {
+    channel: tonic::transport::Channel,
+}
+
+impl wallet::StateClient for TestStateClient {
+    type Error = Error;
+
+    /// Find notes for a view key, starting from the given block height.
+    fn fetch_notes(
+        &self,
+        vk: &ViewKey,
+    ) -> Result<Vec<(Note, u64)>, Self::Error> {
+        let mut client = StateClient::new(self.channel.clone());
+
+        let request = tonic::Request::new(GetNotesRequest {
+            height: 0,
+            vk: vk.to_bytes().to_vec(),
+        });
+
+        let stream = client.get_notes(request).wait()?.into_inner();
+
+        Ok(stream
+            .map(|response| {
+                let response = response.expect("Stream item should be Ok()");
+                let note = Note::from_slice(&response.note)
+                    .expect("Note should be valid");
+                let height = response.height;
+                (note, height)
+            })
+            .collect()
+            .wait())
+    }
+
+    /// Fetch the current anchor of the state.
+    fn fetch_anchor(&self) -> Result<BlsScalar, Self::Error> {
+        let mut client = StateClient::new(self.channel.clone());
+
+        let request = tonic::Request::new(GetAnchorRequest {});
+
+        let response = client.get_anchor(request).wait()?;
+
+        BlsScalar::from_slice(&response.into_inner().anchor)
+            .map_err(Error::Serialization)
+    }
+
+    fn fetch_existing_nullifiers(
+        &self,
+        nullifiers: &[BlsScalar],
+    ) -> Result<Vec<BlsScalar>, Self::Error> {
+        let mut client = StateClient::new(self.channel.clone());
+
+        let request = FindExistingNullifiersRequest {
+            nullifiers: nullifiers
+                .iter()
+                .map(|n| n.to_bytes().to_vec())
+                .collect(),
+        };
+
+        let response = client
+            .find_existing_nullifiers(request)
+            .wait()?
+            .into_inner();
+
+        let nullifiers = response
+            .nullifiers
+            .into_iter()
+            .map(|n| BlsScalar::from_slice(&n).map_err(Error::Serialization))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(nullifiers)
+    }
+
+    /// Queries the node to find the opening for a specific note.
+    fn fetch_opening(
+        &self,
+        note: &Note,
+    ) -> Result<PoseidonOpening<(), POSEIDON_TREE_DEPTH, 4>, Self::Error> {
+        let mut client = StateClient::new(self.channel.clone());
+
+        let request = tonic::Request::new(GetOpeningRequest {
+            note: note.to_bytes().to_vec(),
+        });
+
+        let response = client.get_opening(request).wait()?;
+        let response = response.into_inner();
+
+        Ok(rkyv::from_bytes(&response.branch)
+            .map_err(|_| Error::Serialization(InvalidData))?)
+    }
+
+    fn fetch_stake(&self, _pk: &PublicKey) -> Result<StakeInfo, Self::Error> {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TestProverClient {
+    channel: tonic::transport::Channel,
+}
+
+impl wallet::ProverClient for TestProverClient {
+    type Error = Error;
+    /// Requests that a node prove the given transaction and later propagates it
+    fn compute_proof_and_propagate(
+        &self,
+        utx: &UnprovenTransaction,
+    ) -> Result<Transaction, Self::Error> {
+        let mut client = ProverClient::new(self.channel.clone());
+
+        let response = client
+            .prove_execute(ExecuteProverRequest {
+                utx: utx.to_var_bytes(),
+            })
+            .wait()?
+            .into_inner();
+
+        let proof =
+            Proof::from_slice(&response.proof).map_err(Error::Serialization)?;
+        let tx = utx.clone().prove(proof);
+
+        let propagate_request = tonic::Request::new(PropagateMessage {
+            message: tx.to_var_bytes(),
+        });
+
+        let mut network_client = NetworkClient::new(self.channel.clone());
+        let _ = network_client.propagate(propagate_request).wait()?;
+
+        Ok(tx)
+    }
+
+    /// Requests an STCT proof.
+    fn request_stct_proof(
+        &self,
+        _fee: &Fee,
+        _crossover: &Crossover,
+        _value: u64,
+        _blinder: JubJubScalar,
+        _address: BlsScalar,
+        _signature: Signature,
+    ) -> Result<Proof, Self::Error> {
+        unimplemented!();
+    }
+
+    /// Request a WFCT proof.
+    fn request_wfct_proof(
+        &self,
+        _commitment: JubJubAffine,
+        _value: u64,
+        _blinder: JubJubScalar,
+    ) -> Result<Proof, Self::Error> {
+        unimplemented!();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn erroring_tx_charged_full() -> Result<()> {
+    // Setup the logger and gRPC channels
+    let (channel, incoming) = setup().await;
+
+    let tmp = tempdir().expect("Creating temporary directory should succeed");
+    let rusk =
+        initial_state(&tmp).expect("Creating initial state should succeed");
+
+    let state = StateServer::new(rusk.clone());
+    let prover = ProverServer::new(RuskProver::default());
+    let dispatcher = KadcastDispatcher::default();
+    let mut kadcast_recv = dispatcher.subscribe();
+    let network = NetworkServer::new(dispatcher);
+
+    // Build and Spawn the server
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(state)
+            .add_service(prover)
+            .add_service(network)
+            .serve_with_incoming(incoming)
+            .await
+    });
+
+    // Create a wallet
+    let wallet = wallet::Wallet::new(
+        TestStore,
+        TestStateClient {
+            channel: channel.clone(),
+        },
+        TestProverClient {
+            channel: channel.clone(),
+        },
+    );
+
+    let original_root = rusk.state_root();
+
+    info!("Original Root: {:?}", hex::encode(original_root));
+
+    erroring_call(&wallet, channel);
+
+    // Check the state's root is changed from the original one
+    let new_root = rusk.state_root();
+    info!(
+        "New root after the 1st transfer: {:?}",
+        hex::encode(new_root)
+    );
+    assert_ne!(original_root, new_root, "Root should have changed");
+
+    let recv = kadcast_recv.try_recv();
+    let (_, _, h) = recv.expect("Transaction has not been locally propagated");
+    assert_eq!(h, 0, "Transaction locally propagated with wrong height");
+
+    Ok(())
+}

--- a/rusk/tests/services/mod.rs
+++ b/rusk/tests/services/mod.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+pub mod gas_behavior;
 pub mod multi_transfer;
 pub mod prover_service;
 pub mod stake;

--- a/rusk/tests/services/multi_transfer.rs
+++ b/rusk/tests/services/multi_transfer.rs
@@ -50,8 +50,8 @@ use crate::common::*;
 const BLOCK_HEIGHT: u64 = 1;
 // This is purposefully chosen to be low to trigger the discarding of a
 // perfectly good transaction.
-const BLOCK_GAS_LIMIT: u64 = 1_000_000;
-const GAS_LIMIT: u64 = 350_000;
+const BLOCK_GAS_LIMIT: u64 = 2_500_000;
+const GAS_LIMIT: u64 = 1_000_000;
 const INITIAL_BALANCE: u64 = 10_000_000_000;
 
 // Creates the Rusk initial state for the tests below


### PR DESCRIPTION
Transactions are now executed in three steps:

1. Call to "spend" to spend inputs and generate outputs
2. Execute possible contract call
3. Call to "refund" to refund the transaction some amount

This allows the host to specify *exactly* the amount of gas it wants to
charge a transaction. In this case we choose to charge 1_000_000 per
input of a transaction.

Resolves: https://github.com/dusk-network/rusk/issues/939