### PR TITLE
rusk: initial impl of request-response queries

### DIFF
--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -29,6 +29,7 @@ rand = "0.8"
 toml = "0.5"
 serde = "1"
 serde_json = "1"
+serde_with = { version = "3", features = ["hex"] }
 bs58 = "0.4"
 hex = "0.4"
 tempfile = "3.2"
@@ -67,6 +68,7 @@ dusk-consensus = { version = "0.1.1-rc.3", path = "../consensus" }
 node-data = { version = "0.1", path = "../node-data" }
 
 [dev-dependencies]
+tokio-tungstenite = { version = "0.19", default-features = false, features = ["connect"] }
 test-context = "0.1"
 async-trait = "0.1"
 hex = "0.4"

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -109,9 +109,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut _ws_server = None;
     if config.ws.listen {
-        _ws_server = Some(
-            WsServer::bind(rusk, node.clone(), config.ws.listen_addr()).await?,
-        );
+        _ws_server = Some(WsServer::bind(rusk, config.ws.listen_addr()).await?);
     }
 
     // node spawn_all is the entry point

--- a/rusk/src/lib/lib.rs
+++ b/rusk/src/lib/lib.rs
@@ -416,6 +416,29 @@ impl Rusk {
         self.query(STAKE_CONTRACT, "owners", &())
     }
 
+    pub fn query_raw<S, V>(
+        &self,
+        contract_id: ContractId,
+        fn_name: S,
+        fn_arg: V,
+    ) -> Result<Vec<u8>>
+    where
+        S: AsRef<str>,
+        V: Into<Vec<u8>>,
+    {
+        let inner = self.inner.lock();
+
+        // For queries we set a point limit of effectively infinite and a block
+        // height of zero since this doesn't affect the result.
+        let current_commit = inner.current_commit;
+        let mut session = rusk_abi::new_session(&inner.vm, current_commit, 0)?;
+        session.set_point_limit(u64::MAX);
+
+        session
+            .call_raw(contract_id, fn_name.as_ref(), fn_arg)
+            .map_err(Into::into)
+    }
+
     fn query<A, R>(
         &self,
         contract_id: ContractId,

--- a/rusk/src/lib/ws.rs
+++ b/rusk/src/lib/ws.rs
@@ -4,12 +4,13 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#![allow(unused)]
-
 use std::borrow::Cow;
 use std::convert::Infallible;
-use std::fmt::Formatter;
+use std::fmt::Display;
+use std::net::SocketAddr;
 use std::sync::Arc;
+
+use futures_util::{SinkExt, StreamExt};
 
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpListener, ToSocketAddrs};
@@ -19,53 +20,60 @@ use tokio::{io, task};
 use tokio_tungstenite::accept_async;
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use tokio_tungstenite::tungstenite::protocol::CloseFrame;
-
-use futures_util::{SinkExt, StreamExt};
-use serde::{
-    de::{self, Visitor},
-    Deserialize, Deserializer, Serialize, Serializer,
-};
 use tokio_tungstenite::tungstenite::Message;
 
-use node::database;
-use node::{Network, Node};
 use rusk_abi::ContractId;
-
-use crate::Rusk;
+use serde::{Deserialize, Serialize};
 
 /// This WebSocket server implements a very simple request-response protocol. It
 /// waits for [`Request`]s and then returns one [`Response`], depending on the
 /// result of the query to Rusk.
 pub struct WsServer {
-    shutdown: broadcast::Sender<Infallible>,
     handle: task::JoinHandle<()>,
+    local_addr: SocketAddr,
+    _shutdown: broadcast::Sender<Infallible>,
 }
 
 impl WsServer {
-    pub async fn bind<N: Network, DB: database::DB, A: ToSocketAddrs>(
-        rusk: Rusk,
-        node: Node<N, DB, Rusk>,
-        addr: A,
-    ) -> io::Result<Self> {
+    /// Bind the server to the given `addr`ess, using the given `vm` for
+    /// querying.
+    pub async fn bind<Q, A>(vm: Q, addr: A) -> io::Result<Self>
+    where
+        Q: QueryRaw,
+        A: ToSocketAddrs,
+    {
         let listener = TcpListener::bind(addr).await?;
         let (shutdown_sender, shutdown_receiver) = broadcast::channel(1);
 
+        let local_addr = listener.local_addr()?;
+
         let handle = task::spawn(listening_loop(
-            DataSources { rusk, node },
+            DataSources { vm },
             listener,
             shutdown_receiver,
         ));
 
         Ok(Self {
-            shutdown: shutdown_sender,
             handle,
+            local_addr,
+            _shutdown: shutdown_sender,
         })
+    }
+
+    /// Returns the address the server is listening on, or was listening on if
+    /// it has shutdown.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Returns a reference to the listening loop's join handle.
+    pub fn task_handle(&self) -> &task::JoinHandle<()> {
+        &self.handle
     }
 }
 
-struct DataSources<N: Network, DB: database::DB> {
-    rusk: Rusk,
-    node: Node<N, DB, Rusk>,
+struct DataSources<VM> {
+    vm: VM,
 }
 
 /// Accepts incoming streams and passes them to [`handle_stream`], together with
@@ -73,11 +81,13 @@ struct DataSources<N: Network, DB: database::DB> {
 ///
 /// When all [`mpsc::Sender`]s that are coupled to the `shutdown` receiver are
 /// dropped, the loop will exit and all streams will be closed.
-async fn listening_loop<N: Network, DB: database::DB>(
-    sources: DataSources<N, DB>,
+async fn listening_loop<VM>(
+    sources: DataSources<VM>,
     listener: TcpListener,
     mut shutdown: broadcast::Receiver<Infallible>,
-) {
+) where
+    VM: QueryRaw,
+{
     let sources = Arc::new(sources);
 
     loop {
@@ -102,15 +112,14 @@ async fn listening_loop<N: Network, DB: database::DB>(
 ///
 /// If a message is received that the server cannot parse, then the stream will
 /// be closed.
-async fn handle_stream<
-    N: Network,
-    DB: database::DB,
-    S: AsyncRead + AsyncWrite + Unpin,
->(
-    sources: Arc<DataSources<N, DB>>,
+async fn handle_stream<VM, S>(
+    sources: Arc<DataSources<VM>>,
     stream: S,
     mut shutdown: broadcast::Receiver<Infallible>,
-) {
+) where
+    VM: QueryRaw,
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     let (responder, mut responses) = mpsc::unbounded_channel::<Response>();
 
     if let Ok(mut stream) = accept_async(stream).await {
@@ -153,45 +162,43 @@ async fn handle_stream<
 
                 msg = stream.next() => {
                     match msg {
-                        Some(msg) => match msg {
-                            Ok(msg) => match msg {
-                                // We received a request and should spawn a new tas to handle it.
-                                Message::Text(msg) => {
-                                    match serde_json::from_str(&msg) {
-                                        Ok(req) => {
-                                            task::spawn(handle_request(
-                                                sources.clone(),
-                                                req,
-                                                responder.clone(),
-                                            ));
-                                        },
-                                        Err(err) => {
-                                            let _ = stream.close(Some(CloseFrame {
-                                                code: CloseCode::Error,
-                                                reason: Cow::from(format!("Failed deserializing request: {err}")),
-                                            })).await;
-                                            break;
-                                        }
+                        Some(Ok(msg)) => match msg {
+                            // We received a request and should spawn a new task to handle it.
+                            Message::Text(msg) => {
+                                match serde_json::from_str(&msg) {
+                                    Ok(req) => {
+                                        task::spawn(handle_request(
+                                            sources.clone(),
+                                            req,
+                                            responder.clone(),
+                                        ));
+                                    },
+                                    Err(err) => {
+                                        let _ = stream.close(Some(CloseFrame {
+                                            code: CloseCode::Error,
+                                            reason: Cow::from(format!("Failed deserializing request: {err}")),
+                                        })).await;
+                                        break;
                                     }
                                 }
-                                // Any other type of message is unsupported.
-                                _ => {
-                                    let _ = stream.close(Some(CloseFrame {
-                                        code: CloseCode::Unsupported,
-                                        reason: Cow::from("Only text messages are supported"),
-                                    })).await;
-                                    break;
-                                },
                             }
-                            // Errored while receiving the message, we will
-                            // close the stream and return a close frame.
-                            Err(err) => {
+                            // Any other type of message is unsupported.
+                            _ => {
                                 let _ = stream.close(Some(CloseFrame {
-                                    code: CloseCode::Error,
-                                    reason: Cow::from(format!("Failed serializing response: {err}")),
+                                    code: CloseCode::Unsupported,
+                                    reason: Cow::from("Only text messages are supported"),
                                 })).await;
                                 break;
-                            }
+                            },
+                        }
+                        // Errored while receiving the message, we will
+                        // close the stream and return a close frame.
+                        Some(Err(err)) => {
+                            let _ = stream.close(Some(CloseFrame {
+                                code: CloseCode::Error,
+                                reason: Cow::from(format!("Failed receiving message: {err}")),
+                            })).await;
+                            break;
                         }
                         // The stream has stopped producing messages, and we
                         // should close it and stop. The client likely has done
@@ -211,18 +218,18 @@ async fn handle_stream<
     }
 }
 
-async fn handle_request<N: Network, DB: database::DB>(
-    sources: Arc<DataSources<N, DB>>,
+async fn handle_request<VM>(
+    sources: Arc<DataSources<VM>>,
     request: Request,
     responder: mpsc::UnboundedSender<Response>,
-) {
-    let rusk = &sources.rusk;
+) where
+    VM: QueryRaw,
+{
+    let vm = &sources.vm;
 
-    let rsp = match rusk.query_raw(
-        request.contract.0,
-        request.fn_name,
-        request.fn_args,
-    ) {
+    let contract = ContractId::from_bytes(request.contract);
+
+    let rsp = match vm.query_raw(contract, request.fn_name, request.fn_args) {
         Ok(data) => Response {
             request_id: request.request_id,
             data,
@@ -238,73 +245,170 @@ async fn handle_request<N: Network, DB: database::DB>(
     let _ = responder.send(rsp);
 }
 
+/// Something that accepts queries whose type information is unknown.
+pub trait QueryRaw: 'static + Send + Sync {
+    /// The error returned by the raw query.
+    type Error: Display;
+
+    /// Performs a raw query.
+    fn query_raw<N, C>(
+        &self,
+        contract: ContractId,
+        fn_name: N,
+        fn_args: C,
+    ) -> Result<Vec<u8>, Self::Error>
+    where
+        N: AsRef<str>,
+        C: Into<Vec<u8>>;
+}
+
+impl QueryRaw for crate::Rusk {
+    type Error = crate::Error;
+
+    fn query_raw<N, C>(
+        &self,
+        contract: ContractId,
+        fn_name: N,
+        fn_args: C,
+    ) -> Result<Vec<u8>, Self::Error>
+    where
+        N: AsRef<str>,
+        C: Into<Vec<u8>>,
+    {
+        Self::query_raw(self, contract, fn_name, fn_args)
+    }
+}
+
 /// A request sent by the websocket client, asking for a specific contract
 /// function to be executed with the given arguments.
+#[serde_with::serde_as]
 #[derive(Debug, Deserialize, Serialize)]
 struct Request {
     /// The request ID, allowing for differentiating multiple in-flight
     /// requests.
     request_id: i32,
     /// The contract to call.
-    contract: WrappedContractId,
+    #[serde_as(as = "serde_with::hex::Hex")]
+    contract: [u8; 32],
     /// The function name to call in the contract.
     fn_name: String,
     /// The arguments to pass to the function.
+    #[serde_as(as = "serde_with::hex::Hex")]
     fn_args: Vec<u8>,
 }
 
 /// Response to a [`Request`] with the same `request_id`.
+#[serde_with::serde_as]
 #[derive(Debug, Deserialize, Serialize)]
 struct Response {
     /// The request ID, allowing for differentiating multiple in-flight
     /// requests.
     request_id: i32,
     /// The data returned by the contract call.
+    #[serde_as(as = "serde_with::hex::Hex")]
     data: Vec<u8>,
     /// A possible error happening during the contract call.
     error: Option<String>,
 }
 
-#[derive(Debug)]
-struct WrappedContractId(ContractId);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-impl Serialize for WrappedContractId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_bytes(self.0.as_bytes())
+    use tokio::net::TcpStream;
+    use tokio_tungstenite::client_async;
+
+    /// A [`QueryRaw`] implementation that returns the same data it is passed.
+    struct TestQueryRaw;
+
+    impl QueryRaw for TestQueryRaw {
+        type Error = Infallible;
+
+        fn query_raw<N, C>(
+            &self,
+            _contract: ContractId,
+            _fn_name: N,
+            fn_args: C,
+        ) -> Result<Vec<u8>, Self::Error>
+        where
+            N: AsRef<str>,
+            C: Into<Vec<u8>>,
+        {
+            Ok(fn_args.into())
+        }
     }
-}
 
-impl<'de> Deserialize<'de> for WrappedContractId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct WrappedContractIdVisitor;
-        impl<'de> Visitor<'de> for WrappedContractIdVisitor {
-            type Value = WrappedContractId;
+    #[tokio::test]
+    async fn multiple_queries() {
+        let server = WsServer::bind(TestQueryRaw, "localhost:0")
+            .await
+            .expect("Binding the server to the address should succeed");
 
-            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-                write!(formatter, "32 bytes")
-            }
+        let stream = TcpStream::connect(server.local_addr())
+            .await
+            .expect("Connecting to the server should succeed");
 
-            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                if v.len() != 32 {
-                    return Err(de::Error::invalid_length(v.len(), &Self));
-                }
+        let (mut stream, _) = client_async("ws://localhost", stream)
+            .await
+            .expect("Handshake with the server should succeed");
 
-                let mut bytes = [0u8; 32];
-                bytes.copy_from_slice(v);
+        let fn_args = [
+            Vec::from(&b"I am call data 0"[..]),
+            Vec::from(&b"I am call data 1"[..]),
+            Vec::from(&b"I am call data 2"[..]),
+            Vec::from(&b"I am call data 3"[..]),
+        ];
 
-                Ok(WrappedContractId(ContractId::from_bytes(bytes)))
-            }
+        let requests = fn_args
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(i, fn_args)| {
+                serde_json::to_string(&Request {
+                    request_id: i as i32,
+                    contract: [42; 32],
+                    fn_name: "test_function".to_string(),
+                    fn_args,
+                })
+                .expect("Serializing request should succeed")
+            })
+            .collect::<Vec<_>>();
+
+        let request_num = requests.len();
+
+        for request in requests {
+            stream
+                .send(Message::Text(request))
+                .await
+                .expect("Sending request to the server should succeed");
         }
 
-        deserializer.deserialize_bytes(WrappedContractIdVisitor)
+        let mut responses = Vec::<Response>::with_capacity(request_num);
+
+        while responses.len() < request_num {
+            let msg = stream
+                .next()
+                .await
+                .expect("Stream shouldn't close while awaiting responses")
+                .expect("Response should be received without error");
+
+            let msg = match msg {
+                Message::Text(msg) => msg,
+                _ => panic!("Shouldn't receive anything but text"),
+            };
+
+            let response = serde_json::from_str(&msg)
+                .expect("Response should deserialize successfully");
+            responses.push(response);
+        }
+
+        for response in responses {
+            let expected_data = &fn_args[response.request_id as usize];
+            assert_eq!(
+                &response.data, expected_data,
+                "Response data should be the same as the request `fn_args`"
+            );
+            assert!(matches!(response.error, None), "There should be no error");
+        }
     }
 }

--- a/rusk/src/lib/ws.rs
+++ b/rusk/src/lib/ws.rs
@@ -8,26 +8,36 @@
 
 use std::borrow::Cow;
 use std::convert::Infallible;
+use std::fmt::Formatter;
 use std::sync::Arc;
 
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpListener, ToSocketAddrs};
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc};
 use tokio::{io, task};
 
 use tokio_tungstenite::accept_async;
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 
-use futures_util::StreamExt;
+use futures_util::{SinkExt, StreamExt};
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use tokio_tungstenite::tungstenite::Message;
 
 use node::database;
 use node::{Network, Node};
+use rusk_abi::ContractId;
 
 use crate::Rusk;
 
+/// This WebSocket server implements a very simple request-response protocol. It
+/// waits for [`Request`]s and then returns one [`Response`], depending on the
+/// result of the query to Rusk.
 pub struct WsServer {
-    shutdown: mpsc::Sender<Infallible>,
+    shutdown: broadcast::Sender<Infallible>,
     handle: task::JoinHandle<()>,
 }
 
@@ -38,7 +48,7 @@ impl WsServer {
         addr: A,
     ) -> io::Result<Self> {
         let listener = TcpListener::bind(addr).await?;
-        let (shutdown_sender, shutdown_receiver) = mpsc::channel(1);
+        let (shutdown_sender, shutdown_receiver) = broadcast::channel(1);
 
         let handle = task::spawn(listening_loop(
             DataSources { rusk, node },
@@ -58,10 +68,15 @@ struct DataSources<N: Network, DB: database::DB> {
     node: Node<N, DB, Rusk>,
 }
 
+/// Accepts incoming streams and passes them to [`handle_stream`], together with
+/// the given data sources.
+///
+/// When all [`mpsc::Sender`]s that are coupled to the `shutdown` receiver are
+/// dropped, the loop will exit and all streams will be closed.
 async fn listening_loop<N: Network, DB: database::DB>(
     sources: DataSources<N, DB>,
     listener: TcpListener,
-    mut shutdown: mpsc::Receiver<Infallible>,
+    mut shutdown: broadcast::Receiver<Infallible>,
 ) {
     let sources = Arc::new(sources);
 
@@ -76,98 +91,17 @@ async fn listening_loop<N: Network, DB: database::DB>(
                 }
                 let (stream, _) = r.unwrap();
 
-                task::spawn(handle_stream(sources.clone(), stream));
+                task::spawn(handle_stream(sources.clone(), stream, shutdown.resubscribe()));
             }
         }
     }
 }
 
-/// A request sent by the websocket client.
-#[derive(Debug)]
-struct Request {
-    headers: serde_json::Map<String, serde_json::Value>,
-    target_type: u8,
-    target: String,
-    topic: String,
-    data: Vec<u8>,
-}
-
-impl Request {
-    fn parse(bytes: &[u8]) -> Result<Self, Box<dyn std::error::Error>> {
-        let (headers, bytes) = parse_header(bytes)?;
-        let (target_type, bytes) = parse_target_type(bytes)?;
-        let (target, bytes) = parse_string(bytes)?;
-        let (topic, bytes) = parse_string(bytes)?;
-        let data = bytes.to_vec();
-        Ok(Self {
-            headers,
-            target_type,
-            target,
-            topic,
-            data,
-        })
-    }
-}
-
-fn parse_len(
-    bytes: &[u8],
-) -> Result<(usize, &[u8]), Box<dyn std::error::Error>> {
-    if bytes.len() < 4 {
-        return Err("not enough bytes".to_string().into());
-    }
-
-    let len =
-        u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
-    let (_, left) = bytes.split_at(len);
-
-    Ok((len, left))
-}
-
-type Header<'a> = (serde_json::Map<String, serde_json::Value>, &'a [u8]);
-fn parse_header(bytes: &[u8]) -> Result<Header, Box<dyn std::error::Error>> {
-    let (len, bytes) = parse_len(bytes)?;
-    if bytes.len() < len {
-        return Err(format!("not enough bytes for parsed len {len}").into());
-    }
-
-    let (header_bytes, bytes) = bytes.split_at(len);
-    let header = serde_json::from_slice(header_bytes)?;
-
-    Ok((header, bytes))
-}
-
-fn parse_target_type(
-    bytes: &[u8],
-) -> Result<(u8, &[u8]), Box<dyn std::error::Error>> {
-    if bytes.is_empty() {
-        return Err("not enough bytes for target type".to_string().into());
-    }
-
-    let (target_type_bytes, bytes) = bytes.split_at(1);
-    let target_type = target_type_bytes[0];
-
-    Ok((target_type, bytes))
-}
-
-fn parse_string(
-    bytes: &[u8],
-) -> Result<(String, &[u8]), Box<dyn std::error::Error>> {
-    let (len, bytes) = parse_len(bytes)?;
-    if bytes.len() < len {
-        return Err(format!("not enough bytes for parsed len {len}").into());
-    }
-
-    let (string_bytes, bytes) = bytes.split_at(len);
-    let string = String::from_utf8(string_bytes.to_vec())?;
-
-    Ok((string, bytes))
-}
-
-#[allow(unused)]
-struct StateQuery {}
-#[allow(unused)]
-struct ChainQuery {}
-
+/// Receives a stream, performs the WebSocket handshake on it, and keeps
+/// receiving messages until either the stream closes, or the server shuts down.
+///
+/// If a message is received that the server cannot parse, then the stream will
+/// be closed.
 async fn handle_stream<
     N: Network,
     DB: database::DB,
@@ -175,23 +109,202 @@ async fn handle_stream<
 >(
     sources: Arc<DataSources<N, DB>>,
     stream: S,
+    mut shutdown: broadcast::Receiver<Infallible>,
 ) {
-    if let Ok(mut stream) = accept_async(stream).await {
-        while let Some(Ok(msg)) = stream.next().await {
-            let data = msg.into_data();
-            let r = Request::parse(&data);
+    let (responder, mut responses) = mpsc::unbounded_channel::<Response>();
 
-            if r.is_err() {
-                break;
+    if let Ok(mut stream) = accept_async(stream).await {
+        loop {
+            tokio::select! {
+                // If the server shuts down we send a close frame to the client
+                // and stop.
+                _ = shutdown.recv() => {
+                    let _ = stream.close(Some(CloseFrame {
+                        code: CloseCode::Away,
+                        reason: Cow::from("Shutting down"),
+                    })).await;
+                    break;
+                }
+
+                rsp = responses.recv() => {
+                    // `responder` is never dropped so this can never be `None`
+                    let rsp = rsp.unwrap();
+
+                    // Serialize the response to text. If this does not succeed,
+                    // we simply serialize an error response.
+                    let rsp = serde_json::to_string(&rsp).unwrap_or_else(|err| {
+                        serde_json::to_string(&Response {
+                            request_id: rsp.request_id,
+                            data: vec![],
+                            error: Some(format!("Failed serializing response: {err}")),
+                        }).expect("serializing error response should succeed")
+                    });
+
+                    // If we error in sending the message we send a close frame
+                    // to the client and stop.
+                    if stream.send(Message::Text(rsp)).await.is_err() {
+                        let _ = stream.close(Some(CloseFrame {
+                            code: CloseCode::Error,
+                            reason: Cow::from("Failed sending response"),
+                        })).await;
+                        break;
+                    }
+                }
+
+                msg = stream.next() => {
+                    match msg {
+                        Some(msg) => match msg {
+                            Ok(msg) => match msg {
+                                // We received a request and should spawn a new tas to handle it.
+                                Message::Text(msg) => {
+                                    match serde_json::from_str(&msg) {
+                                        Ok(req) => {
+                                            task::spawn(handle_request(
+                                                sources.clone(),
+                                                req,
+                                                responder.clone(),
+                                            ));
+                                        },
+                                        Err(err) => {
+                                            let _ = stream.close(Some(CloseFrame {
+                                                code: CloseCode::Error,
+                                                reason: Cow::from(format!("Failed deserializing request: {err}")),
+                                            })).await;
+                                            break;
+                                        }
+                                    }
+                                }
+                                // Any other type of message is unsupported.
+                                _ => {
+                                    let _ = stream.close(Some(CloseFrame {
+                                        code: CloseCode::Unsupported,
+                                        reason: Cow::from("Only text messages are supported"),
+                                    })).await;
+                                    break;
+                                },
+                            }
+                            // Errored while receiving the message, we will
+                            // close the stream and return a close frame.
+                            Err(err) => {
+                                let _ = stream.close(Some(CloseFrame {
+                                    code: CloseCode::Error,
+                                    reason: Cow::from(format!("Failed serializing response: {err}")),
+                                })).await;
+                                break;
+                            }
+                        }
+                        // The stream has stopped producing messages, and we
+                        // should close it and stop. The client likely has done
+                        // this on purpose, and it's a part of the normal
+                        // operation of the server.
+                        None => {
+                            let _ = stream.close(Some(CloseFrame {
+                                code: CloseCode::Normal,
+                                reason: Cow::from("Stream stopped"),
+                            })).await;
+                            break;
+                        }
+                    }
+                }
             }
-            let request = r.unwrap();
+        }
+    }
+}
+
+async fn handle_request<N: Network, DB: database::DB>(
+    sources: Arc<DataSources<N, DB>>,
+    request: Request,
+    responder: mpsc::UnboundedSender<Response>,
+) {
+    let rusk = &sources.rusk;
+
+    let rsp = match rusk.query_raw(
+        request.contract.0,
+        request.fn_name,
+        request.fn_args,
+    ) {
+        Ok(data) => Response {
+            request_id: request.request_id,
+            data,
+            error: None,
+        },
+        Err(err) => Response {
+            request_id: request.request_id,
+            data: vec![],
+            error: Some(format!("Query error: {err}")),
+        },
+    };
+
+    let _ = responder.send(rsp);
+}
+
+/// A request sent by the websocket client, asking for a specific contract
+/// function to be executed with the given arguments.
+#[derive(Debug, Deserialize, Serialize)]
+struct Request {
+    /// The request ID, allowing for differentiating multiple in-flight
+    /// requests.
+    request_id: i32,
+    /// The contract to call.
+    contract: WrappedContractId,
+    /// The function name to call in the contract.
+    fn_name: String,
+    /// The arguments to pass to the function.
+    fn_args: Vec<u8>,
+}
+
+/// Response to a [`Request`] with the same `request_id`.
+#[derive(Debug, Deserialize, Serialize)]
+struct Response {
+    /// The request ID, allowing for differentiating multiple in-flight
+    /// requests.
+    request_id: i32,
+    /// The data returned by the contract call.
+    data: Vec<u8>,
+    /// A possible error happening during the contract call.
+    error: Option<String>,
+}
+
+#[derive(Debug)]
+struct WrappedContractId(ContractId);
+
+impl Serialize for WrappedContractId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(self.0.as_bytes())
+    }
+}
+
+impl<'de> Deserialize<'de> for WrappedContractId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct WrappedContractIdVisitor;
+        impl<'de> Visitor<'de> for WrappedContractIdVisitor {
+            type Value = WrappedContractId;
+
+            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+                write!(formatter, "32 bytes")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if v.len() != 32 {
+                    return Err(de::Error::invalid_length(v.len(), &Self));
+                }
+
+                let mut bytes = [0u8; 32];
+                bytes.copy_from_slice(v);
+
+                Ok(WrappedContractId(ContractId::from_bytes(bytes)))
+            }
         }
 
-        let _ = stream
-            .close(Some(CloseFrame {
-                code: CloseCode::Normal,
-                reason: Cow::from("Client closed"),
-            }))
-            .await;
+        deserializer.deserialize_bytes(WrappedContractIdVisitor)
     }
 }


### PR DESCRIPTION
This is an implementation of a simple request-response protocol for querying the state of the chain over WebSockets.

When a stream is estabilished, a task is started to handle incoming requests. Once a request comes in we start a new task. This will report the result of the chain query which the request represents back to the stream handling task. This is done to ensure we don't block before another request can be received.

Resolves #933