### PR TITLE
consensus: Call VST once per a candidate block when this provisioner is extracted for both reductions

### DIFF
--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -18,6 +18,7 @@ use crate::{config, selection};
 use crate::{firststep, secondstep};
 use tracing::{error, Instrument};
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::{oneshot, Mutex};
 use tokio::task::JoinHandle;
@@ -175,6 +176,10 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
                 Phase::Reduction2(secondstep::step::Reduction::new(executor)),
             ];
 
+            // A list of hashes of candidate blocks already verified
+            let verified_candidates =
+                Arc::new(Mutex::new(HashSet::<[u8; 32]>::new()));
+
             // Consensus loop
             // Initialize and run consensus loop
             let mut step: u8 = 0;
@@ -197,6 +202,7 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
                         future_msgs.clone(),
                         &mut provisioners,
                         ru.clone(),
+                        verified_candidates.clone(),
                         step,
                     );
 

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -12,6 +12,7 @@ use crate::user::provisioners::Provisioners;
 use crate::user::sortition;
 use node_data::message::{AsyncQueue, Message};
 use std::cmp;
+use std::collections::HashSet;
 
 use crate::config::CONSENSUS_MAX_TIMEOUT_MS;
 use std::sync::Arc;
@@ -35,6 +36,12 @@ pub struct ExecutionCtx<'a> {
     // Round/Step parameters
     pub round_update: RoundUpdate,
     pub step: u8,
+
+    /// List of verified candidate hashes
+    ///
+    /// An optimization to call VST once per a candidate block when this
+    /// provisioner is extracted for both reductions.
+    pub verified_candidates: Arc<Mutex<HashSet<[u8; 32]>>>,
 }
 
 impl<'a> ExecutionCtx<'a> {
@@ -45,6 +52,7 @@ impl<'a> ExecutionCtx<'a> {
         future_msgs: Arc<Mutex<Queue<Message>>>,
         provisioners: &'a mut Provisioners,
         round_update: RoundUpdate,
+        verified_candidates: Arc<Mutex<HashSet<[u8; 32]>>>,
         step: u8,
     ) -> Self {
         Self {
@@ -54,6 +62,7 @@ impl<'a> ExecutionCtx<'a> {
             provisioners,
             round_update,
             step,
+            verified_candidates,
         }
     }
 

--- a/consensus/src/firststep/step.rs
+++ b/consensus/src/firststep/step.rs
@@ -51,6 +51,7 @@ impl<T: Operations + 'static, DB: Database> Reduction<T, DB> {
                 ctx.step,
                 ctx.outbound.clone(),
                 ctx.inbound.clone(),
+                ctx.verified_candidates.clone(),
                 self.executor.clone(),
             );
         }

--- a/consensus/src/secondstep/step.rs
+++ b/consensus/src/secondstep/step.rs
@@ -61,6 +61,7 @@ impl<T: Operations + 'static> Reduction<T> {
                     ctx.step,
                     ctx.outbound.clone(),
                     ctx.inbound.clone(),
+                    ctx.verified_candidates.clone(),
                     self.executor.clone(),
                 );
             }


### PR DESCRIPTION
fixe #951 