### PR TITLE
rusk: Add http request impl

### DIFF
--- a/rusk/src/lib/http/chain.rs
+++ b/rusk/src/lib/http/chain.rs
@@ -73,7 +73,6 @@ impl RuskNode {
             async_graphql::Request::new(gql_query).variables(variables);
 
         let gql_res = schema.execute(gql_query).await;
-        println!("{gql_res:?}");
         let async_graphql::Response { data, errors, .. } = gql_res;
 
         let data = match serde_json::to_string(&data) {

--- a/rusk/src/lib/http/event.rs
+++ b/rusk/src/lib/http/event.rs
@@ -132,10 +132,15 @@ impl MessageResponse {
         }
 
         let body = match binary {
-            true => self.to_bytes(),
-            false => serde_json::to_vec(&self.data)
-                .map_err(|e| anyhow::anyhow!("Cannot ser {e}")),
-        }?;
+            true => self.to_bytes()?,
+            false => match &self.data {
+                DataType::Binary(BinaryWrapper { inner }) => hex::encode(inner),
+                DataType::Text(text) => text.to_string(),
+                DataType::None => String::default(),
+            }
+            .as_bytes()
+            .to_vec(),
+        };
         Ok(hyper::Response::new(hyper::Body::from(body)))
     }
 }

--- a/rusk/src/lib/http/rusk.rs
+++ b/rusk/src/lib/http/rusk.rs
@@ -10,15 +10,18 @@ use rusk_abi::ContractId;
 
 use crate::Rusk;
 
-use super::event::{DataType, Request, Response, Target};
+use super::event::{DataType, Event, MessageRequest, MessageResponse, Target};
 
 impl Rusk {
-    pub(crate) async fn handle_request(&self, request: Request) -> Response {
-        match &request.target {
+    pub(crate) async fn handle_request(
+        &self,
+        request: MessageRequest,
+    ) -> MessageResponse {
+        match &request.event.target {
             Target::Contract(contract) => {
                 let contract_bytes = hex::decode(contract);
                 if let Err(e) = &contract_bytes {
-                    return Response {
+                    return MessageResponse {
                         data: DataType::None,
                         headers: request.x_headers(),
                         error: format!("{e}").into(),
@@ -27,7 +30,7 @@ impl Rusk {
                 let contract_bytes =
                     contract_bytes.expect("to be already checked").try_into();
                 if let Err(e) = &contract_bytes {
-                    return Response {
+                    return MessageResponse {
                         data: DataType::None,
                         headers: request.x_headers(),
                         error: "Invalid contract bytes".to_string().into(),
@@ -37,23 +40,23 @@ impl Rusk {
                     ContractId::from_bytes(
                         contract_bytes.expect("to be valid"),
                     ),
-                    request.topic.clone(),
-                    request.data.as_bytes(),
+                    request.event.topic.clone(),
+                    request.event.data.as_bytes(),
                 );
                 match response {
-                    Err(e) => Response {
+                    Err(e) => MessageResponse {
                         data: DataType::None,
                         headers: request.x_headers(),
                         error: format!("{e}").into(),
                     },
-                    Ok(data) => Response {
+                    Ok(data) => MessageResponse {
                         data: data.into(),
                         headers: request.x_headers(),
                         error: None,
                     },
                 }
             }
-            _ => Response {
+            _ => MessageResponse {
                 data: DataType::None,
                 headers: request.x_headers(),
                 error: Some("Unsupported".into()),


### PR DESCRIPTION
request http
```sh
curl --location --request POST 'http://127.0.0.1:8080/02/Chain' \
--header 'X-requestid: 3' \
--header 'Rusk-gqlvar-myvar: -1' \
--header 'X-asd: "asdasd"' \
--header 'Content-Type: application/json' \
--data-raw '{

    "topic": "gql",

    "data": "query ($myvar: Int) { block(height: $myvar) {header { height, prevBlockHash}, transactions {id}}}"
}' -v
```

response
```
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-asd: "asdasd"
< x-requestid: 3
< content-length: 149
< date: Fri, 28 Jul 2023 16:36:14 GMT
< 
* Connection #0 to host 127.0.0.1 left intact
{"block":{"header":{"height":621,"prevBlockHash":"76414e3bd73c4a351ae537fe441b9dfdeb8dc652311affe9e2b5a355435513a3"},"transactions":[]}}           
```