### PR TITLE
Add missing graphql handlers

### DIFF
--- a/node/src/database/rocksdb.rs
+++ b/node/src/database/rocksdb.rs
@@ -387,11 +387,12 @@ impl<'db, DB: DBAccess> Ledger for DBTransaction<'db, DB> {
         &self,
         height: u64,
     ) -> Result<Option<ledger::Block>> {
-        let hash = self
-            .fetch_block_hash_by_height(height)?
-            .ok_or_else(|| anyhow::anyhow!("could not find hash by height"))?;
-
-        self.fetch_block(&hash)
+        let hash = self.fetch_block_hash_by_height(height)?;
+        let block = match hash {
+            Some(hash) => self.fetch_block(&hash)?,
+            None => None,
+        };
+        Ok(block)
     }
 }
 

--- a/node/src/database/rocksdb.rs
+++ b/node/src/database/rocksdb.rs
@@ -310,8 +310,9 @@ impl<'db, DB: DBAccess> Ledger for DBTransaction<'db, DB> {
                 let mut txs = vec![];
                 for buf in txs_buffers {
                     let mut buf = buf?.unwrap();
-                    let tx = ledger::Transaction::read(&mut &buf.to_vec()[..])?;
-                    txs.push(tx);
+                    let tx =
+                        ledger::SpentTransaction::read(&mut &buf.to_vec()[..])?;
+                    txs.push(tx.inner);
                 }
 
                 Ok(Some(ledger::Block {

--- a/rusk/src/lib/http/chain/graphql.rs
+++ b/rusk/src/lib/http/chain/graphql.rs
@@ -13,7 +13,7 @@ use tx::*;
 use async_graphql::{Context, FieldError, FieldResult, Object};
 use node::database::rocksdb::Backend;
 use node::database::{Ledger, Register, DB};
-use node_data::ledger::{Block, SpentTransaction};
+use node_data::ledger::{Block, SpentTransaction, Transaction};
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -39,32 +39,57 @@ impl Query {
             _ => Err(FieldError::new("Specify heigth or hash")),
         }
     }
+
     async fn tx(
         &self,
         ctx: &Context<'_>,
         hash: String,
     ) -> OptResult<SpentTransaction> {
         let ctx = ctx.data::<Ctx>()?;
-
         tx_by_hash(ctx, hash).await
+    }
+
+    async fn block_txs(
+        &self,
+        ctx: &Context<'_>,
+        last: Option<i32>,
+        range: Option<[i32; 2]>,
+        contract: Option<String>,
+    ) -> FieldResult<Vec<Transaction>> {
+        let blocks = self.blocks(ctx, last, range).await?;
+        let txs = blocks.into_iter().flat_map(|Block { txs, .. }| txs);
+
+        let txs =
+            match contract {
+                None => txs.collect(),
+                Some(contract) => {
+                    let contract = hex::decode(contract)?;
+                    txs.filter(|t| {
+                        let tx_contract =
+                            t.inner.call.as_ref().map(|(c, ..)| *c).unwrap_or(
+                                rusk_abi::TRANSFER_CONTRACT.to_bytes(),
+                            );
+
+                        tx_contract == contract[..]
+                    })
+                    .collect()
+                }
+            };
+
+        Ok(txs)
     }
 
     async fn blocks(
         &self,
         ctx: &Context<'_>,
         last: Option<i32>,
-        range: Option<Vec<i32>>,
+        range: Option<[i32; 2]>,
     ) -> FieldResult<Vec<Block>> {
         let ctx = ctx.data::<Ctx>()?;
 
         match (last, range) {
             (Some(count), None) => last_blocks(ctx, count).await,
-            (None, Some(range)) => {
-                let range: [i32; 2] = range.try_into().map_err(|_| {
-                    FieldError::new("You have to specify a range")
-                })?;
-                blocks_range(ctx, range[0], range[1]).await
-            }
+            (None, Some([from, to])) => blocks_range(ctx, from, to).await,
             _ => Err(FieldError::new("")),
         }
     }

--- a/rusk/src/lib/http/chain/graphql/block.rs
+++ b/rusk/src/lib/http/chain/graphql/block.rs
@@ -59,5 +59,15 @@ pub async fn blocks_range(
     from: i32,
     to: i32,
 ) -> FieldResult<Vec<Block>> {
-    unimplemented!()
+    let blocks = ctx.read().await.view(|t| {
+        let mut blocks = vec![];
+        for i in (from..=to) {
+            match t.fetch_block_by_height(i as u64)? {
+                None => break,
+                Some(b) => blocks.push(b),
+            }
+        }
+        Ok::<_, anyhow::Error>(blocks)
+    })?;
+    Ok(blocks)
 }


### PR DESCRIPTION
### rusk: 
- Add blocks by range
- Add transactions by block range


### node:
- Fix `block_by_height` to return Option if no block is found
- Fix Transaction deserialization



```graphql
# By range

query { blockTxs(range: [288,10000], contract: "0100000000000000000000000000000000000000000000000000000000000000" ) { id, callData {fnName}}}
query { blockTxs(range: [288,10000] ) { id, callData {fnName}}}


# By last

query { blockTxs(last: 10, contract: "0100000000000000000000000000000000000000000000000000000000000000" ) { id, callData {fnName}}}
query { blockTxs(last: 10) { id, callData {fnName}}}


```
