### PR TITLE
Rusk prover 0.2.0

### DIFF
--- a/rusk-prover/Cargo.toml
+++ b/rusk-prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-prover"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 autobins = false
 

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -62,7 +62,7 @@ async-trait = "0.1"
 transfer-circuits = { version = "0.5", path = "../circuits/transfer" }
 rusk-profile = { version = "0.6", path = "../rusk-profile" }
 rusk-abi = { version = "0.10.0-piecrust.0.6", path = "../rusk-abi", default-features = false, features = ["host"] }
-rusk-prover = { version = "0.1", path = "../rusk-prover" }
+rusk-prover = { version = "0.2", path = "../rusk-prover" }
 node = { version = "0.1", path = "../node" }
 dusk-consensus = { version = "0.1.1-rc.3", path = "../consensus" }
 node-data = { version = "0.1", path = "../node-data", features = ["graphql"] }


### PR DESCRIPTION
Upgrade and tag new rusk-prover version required by https://github.com/dusk-network/dusk-prover