### PR TITLE
rusk: fix http listener activation

### DIFF
--- a/rusk/src/bin/config/http.rs
+++ b/rusk/src/bin/config/http.rs
@@ -28,7 +28,7 @@ impl HttpConfig {
         }
 
         // Overwrite config ws-listen
-        self.listen = matches.get_flag("ws-listen");
+        self.listen = self.listen || matches.get_flag("ws-listen");
     }
 
     pub fn inject_args(command: Command<'_>) -> Command<'_> {
@@ -45,7 +45,7 @@ impl HttpConfig {
                     .action(ArgAction::SetTrue)
                     .long("ws-listen")
                     .value_name("WS_LISTEN")
-                    .help("If the websocket server should be active")
+                    .help("Force the websocket to be active")
                     .takes_value(false),
             )
     }

--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -64,6 +64,8 @@ impl HttpServer {
 
         let local_addr = listener.local_addr()?;
 
+        info!("Starting HTTP Listener to {local_addr}");
+
         let handle =
             task::spawn(listening_loop(handler, listener, shutdown_receiver));
 


### PR DESCRIPTION
This PR allows the HTTP listener to be activated using configuration file.
This fixes the wrong behaviour where the activation flag was read using only the CLI args