### PR TITLE
Upgrade to `piecrust@0.9`

### DIFF
--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -23,7 +23,7 @@ bytecheck = { version = "0.6", default-features = false }
 dusk-plonk = { version = "0.14", default-features = false, features = ["rkyv-impl", "alloc"] }
 
 piecrust-uplink = "0.7"
-piecrust = { version = "0.8.0-rc", optional = true }
+piecrust = { version = "0.9", optional = true }
 
 # These are patches since these crates don't seem to like semver.
 rkyv = { version = "=0.7.39", default-features = false }

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -291,7 +291,6 @@ pub fn deploy<P: AsRef<Path>>(
 
     if old_commit_id != commit_id {
         vm.delete_commit(old_commit_id)?;
-        vm.squash_commit(commit_id)?;
     }
 
     info!("{} {}", theme.action("Init Root"), hex::encode(commit_id));

--- a/rusk/src/lib/lib.rs
+++ b/rusk/src/lib/lib.rs
@@ -323,9 +323,6 @@ impl Rusk {
             inner.vm.delete_commit(commit)?;
         }
 
-        // Squash the current commit
-        inner.vm.squash_commit(inner.current_commit)?;
-
         let commit_id_path = to_rusk_state_id_path(&self.dir);
         fs::write(commit_id_path, commit_id)?;
 


### PR DESCRIPTION
Upgrading was a simple process. Just bump the version and remove squashing. That and the hours spent debugging together with @herr-seppia and @miloszm to figure out the last things in `piecrust`.

Big thanks to them.