### PR TITLE
License contract changes

### DIFF
--- a/contract-helpers/src/collection.rs
+++ b/contract-helpers/src/collection.rs
@@ -68,6 +68,16 @@ impl<K: PartialEq, V: PartialEq> Map<K, V> {
             .filter_map(|(_, v)| f(v).then_some(v))
             .collect()
     }
+
+    pub fn entries_filter<F>(&self, f: F) -> Vec<(&K, &V)>
+    where
+        F: Fn((&K, &V)) -> bool,
+    {
+        self.data
+            .iter()
+            .filter_map(|(k, v)| f((k, v)).then_some((k, v)))
+            .collect()
+    }
 }
 
 #[allow(dead_code)]

--- a/contract-helpers/src/collection.rs
+++ b/contract-helpers/src/collection.rs
@@ -59,24 +59,18 @@ impl<K: PartialEq, V: PartialEq> Map<K, V> {
         self.data.iter().find_map(|(_, v)| f(v).then_some(v))
     }
 
-    pub fn filter<F>(&self, f: F) -> Vec<&V>
+    pub fn filter<F>(&self, f: F) -> impl Iterator<Item = &V>
     where
         F: Fn(&V) -> bool,
     {
-        self.data
-            .iter()
-            .filter_map(|(_, v)| f(v).then_some(v))
-            .collect()
+        self.data.iter().filter_map(move |(_, v)| f(v).then_some(v))
     }
 
-    pub fn entries_filter<F>(&self, f: F) -> Vec<(&K, &V)>
+    pub fn entries_filter<F>(&self, f: F) -> impl Iterator<Item = &(K, V)>
     where
         F: Fn((&K, &V)) -> bool,
     {
-        self.data
-            .iter()
-            .filter_map(|(k, v)| f((k, v)).then_some((k, v)))
-            .collect()
+        self.data.iter().filter(move |(k, v)| f((k, v)))
     }
 }
 

--- a/contracts/license/CHANGELOG.md
+++ b/contracts/license/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Changed
+
+- Changed 'get_licenses' return values by adding 'pos' to every license returned [#1040]
+- Changed 'issue_license' by removing the 'pos' argument and self position determination [#1039]
+
+## [0.1.0] - 2023-07-13
+
+### Added
+
+- Add `license` contract to Rusk [#960]
+
+[#1040]: https://github.com/dusk-network/rusk/issues/1040
+[#1039]: https://github.com/dusk-network/rusk/issues/1039
+[#960]: https://github.com/dusk-network/rusk/issues/960

--- a/contracts/license/CHANGELOG.md
+++ b/contracts/license/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added method 'get_info' [#1052]
+
 ### Changed
 
 - Changed 'use_license' to check if license already nullified [#1051]
@@ -19,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `license` contract to Rusk [#960]
 
+[#1052]: https://github.com/dusk-network/rusk/issues/1052
 [#1051]: https://github.com/dusk-network/rusk/issues/1051
 [#1040]: https://github.com/dusk-network/rusk/issues/1040
 [#1039]: https://github.com/dusk-network/rusk/issues/1039

--- a/contracts/license/CHANGELOG.md
+++ b/contracts/license/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Changed 'get_licenses' return values by adding 'pos' to every license returned [#1040]
+- Changed 'use_license' to check if license already nullified [#1051]
+- Changed 'get_licenses' to return values by adding 'pos' to every license returned [#1040]
 - Changed 'issue_license' by removing the 'pos' argument and self position determination [#1039]
 
 ## [0.1.0] - 2023-07-13
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `license` contract to Rusk [#960]
 
+[#1051]: https://github.com/dusk-network/rusk/issues/1051
 [#1040]: https://github.com/dusk-network/rusk/issues/1040
 [#1039]: https://github.com/dusk-network/rusk/issues/1039
 [#960]: https://github.com/dusk-network/rusk/issues/960

--- a/contracts/license/CHANGELOG.md
+++ b/contracts/license/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed 'get_licenses' to use feeder for passing return values [#1054]
 - Changed 'use_license' to check if license already nullified [#1051]
 - Changed 'get_licenses' to return values by adding 'pos' to every license returned [#1040]
 - Changed 'issue_license' by removing the 'pos' argument and self position determination [#1039]
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `license` contract to Rusk [#960]
 
+[#1054]: https://github.com/dusk-network/rusk/issues/1054
 [#1052]: https://github.com/dusk-network/rusk/issues/1052
 [#1051]: https://github.com/dusk-network/rusk/issues/1051
 [#1040]: https://github.com/dusk-network/rusk/issues/1040

--- a/contracts/license/Cargo.toml
+++ b/contracts/license/Cargo.toml
@@ -11,8 +11,8 @@ dusk-bls12_381 = { version = "0.11", default-features = false, features = ["rkyv
 dusk-bytes = "0.1"
 dusk-jubjub = { version = "0.12", default-features = false, features = ["rkyv-impl"] }
 dusk-pki = { version = "0.12", default-features = false, features = ["rkyv-impl"] }
-dusk-poseidon = { version = "0.30", default-features = false, features = ["alloc"] }
-poseidon-merkle = { version = "0.2.1-rc.0", features = ["rkyv-impl"] }
+dusk-poseidon = { version = "0.30", default-features = false, features = ["rkyv-impl", "alloc"] }
+poseidon-merkle = { version = "0.2", features = ["rkyv-impl", "zk", "size_32"] }
 dusk-plonk = { version = "0.14", default-features = false, features = ["rkyv-impl", "alloc"] }
 rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
 bytecheck = { version = "0.6", default-features = false }

--- a/contracts/license/src/lib.rs
+++ b/contracts/license/src/lib.rs
@@ -35,8 +35,8 @@ mod wasm {
 
     #[no_mangle]
     unsafe fn issue_license(arg_len: u32) -> u32 {
-        rusk_abi::wrap_call(arg_len, |(license, pos, hash)| {
-            STATE.issue_license(license, pos, hash)
+        rusk_abi::wrap_call(arg_len, |(license, hash)| {
+            STATE.issue_license(license, hash)
         })
     }
 

--- a/contracts/license/src/lib.rs
+++ b/contracts/license/src/lib.rs
@@ -70,4 +70,9 @@ mod wasm {
     unsafe fn noop(arg_len: u32) -> u32 {
         rusk_abi::wrap_call(arg_len, |_: ()| STATE.noop())
     }
+
+    #[no_mangle]
+    unsafe fn get_info(arg_len: u32) -> u32 {
+        rusk_abi::wrap_call(arg_len, |_: ()| STATE.get_info())
+    }
 }

--- a/contracts/license/src/state.rs
+++ b/contracts/license/src/state.rs
@@ -78,14 +78,14 @@ impl LicenseContractState {
 
     /// Returns licenses for a given range of block-heights.
     /// Method intended to be called by the user.
-    pub fn get_licenses(
-        &mut self,
-        block_heights: Range<u64>,
-    ) -> Vec<(u64, Vec<u8>)> {
-        self.licenses
+    pub fn get_licenses(&mut self, block_heights: Range<u64>) {
+        for pos_license_pair in self
+            .licenses
             .entries_filter(|(_, le)| block_heights.contains(&le.block_height))
             .map(|(pos, le)| (*pos, le.license.clone()))
-            .collect()
+        {
+            rusk_abi::feed(pos_license_pair);
+        }
     }
 
     /// Returns merkle opening for a given position in the merkle tree of

--- a/contracts/license/src/state.rs
+++ b/contracts/license/src/state.rs
@@ -105,7 +105,7 @@ impl LicenseContractState {
     pub fn use_license(
         &mut self,
         use_license_arg: UseLicenseArg,
-    ) -> LicenseSessionId {
+    ) {
         let mut pi = Vec::new();
         for scalar in use_license_arg.public_inputs.iter() {
             pi.push(PublicInput::BlsScalar(*scalar));
@@ -120,8 +120,10 @@ impl LicenseContractState {
             public_inputs: use_license_arg.public_inputs,
         };
         let session_id = license_session.session_id();
+        if self.sessions.get(&session_id).is_some() {
+            panic!("License already nullified");
+        }
         self.sessions.insert(session_id, license_session);
-        session_id
     }
 
     /// Returns session with a given session id.

--- a/contracts/license/src/state.rs
+++ b/contracts/license/src/state.rs
@@ -84,7 +84,6 @@ impl LicenseContractState {
     ) -> Vec<(u64, Vec<u8>)> {
         self.licenses
             .entries_filter(|(_, le)| block_heights.contains(&le.block_height))
-            .into_iter()
             .map(|(pos, le)| (*pos, le.license.clone()))
             .collect()
     }

--- a/contracts/license/src/state.rs
+++ b/contracts/license/src/state.rs
@@ -102,10 +102,7 @@ impl LicenseContractState {
     /// Verifies the proof of a given license, if successful,
     /// creates a session with the corresponding session id.
     /// Method intended to be called by the user.
-    pub fn use_license(
-        &mut self,
-        use_license_arg: UseLicenseArg,
-    ) {
+    pub fn use_license(&mut self, use_license_arg: UseLicenseArg) {
         let mut pi = Vec::new();
         for scalar in use_license_arg.public_inputs.iter() {
             pi.push(PublicInput::BlsScalar(*scalar));
@@ -146,5 +143,14 @@ impl LicenseContractState {
         rusk_abi::verify_proof(verifier_data.to_vec(), proof, public_inputs)
             .then_some(())
             .ok_or(Error::ProofVerification)
+    }
+
+    /// Info about contract state
+    pub fn get_info(&self) -> (u32, u32, u32) {
+        (
+            self.licenses.len() as u32,
+            self.tree.len() as u32,
+            self.sessions.len() as u32,
+        )
     }
 }

--- a/contracts/license/tests/license.rs
+++ b/contracts/license/tests/license.rs
@@ -19,6 +19,7 @@ use std::ops::Range;
 use poseidon_merkle::Opening;
 use rand::rngs::StdRng;
 use rand::{CryptoRng, RngCore, SeedableRng};
+use rkyv::{check_archived_root, Deserialize, Infallible};
 
 #[path = "../src/license_types.rs"]
 mod license_types;
@@ -27,8 +28,9 @@ use license_types::*;
 use ::license_circuits::LicenseCircuit;
 
 use rusk_abi::{ContractData, ContractId, Session};
-use zk_citadel::license::{License, Request};
-use zk_citadel::utils::CitadelUtils;
+use zk_citadel::license::{
+    CitadelProverParameters, License, Request, SessionCookie,
+};
 
 const LICENSE_CONTRACT_ID: ContractId = {
     let mut bytes = [0u8; 32];
@@ -78,6 +80,70 @@ fn initialize() -> Session {
     session
 }
 
+/// Deserializes license, panics if deserialization fails.
+fn deserialise_license(v: &Vec<u8>) -> License {
+    let response_data = check_archived_root::<License>(v.as_slice())
+        .expect("License should deserialize correctly");
+    let license: License = response_data
+        .deserialize(&mut Infallible)
+        .expect("Infallible");
+    license
+}
+
+/// Finds owned license in a collection of licenses.
+/// It searches in a reverse order to return a newest license.
+fn find_owned_license(
+    ssk_user: SecretSpendKey,
+    licenses: &Vec<(u64, Vec<u8>)>,
+) -> Option<(u64, License)> {
+    for (pos, license) in licenses.iter().rev() {
+        let license = deserialise_license(&license);
+        if ssk_user.view_key().owns(&license.lsa) {
+            return Some((pos.clone(), license));
+        }
+    }
+    None
+}
+
+/// Computes prover parameters and a session cookie
+/// This function should be moved to CitadelUtils
+fn compute_citadel_parameters(
+    rng: &mut StdRng,
+    ssk: SecretSpendKey,
+    psk_lp: PublicSpendKey,
+    lic: &License,
+    merkle_proof: Opening<(), DEPTH, ARITY>,
+) -> (CitadelProverParameters<DEPTH, ARITY>, SessionCookie) {
+    const CHALLENGE: u64 = 20221126u64;
+    let c = JubJubScalar::from(CHALLENGE);
+    let (cpp, sc) = CitadelProverParameters::compute_parameters(
+        &ssk,
+        &lic,
+        &psk_lp,
+        &psk_lp,
+        &c,
+        rng,
+        merkle_proof,
+    );
+    (cpp, sc)
+}
+
+/// Creates the Citadel request object
+/// This function should be moved to CitadelUtils
+fn create_request<R: RngCore + CryptoRng>(
+    ssk_user: &SecretSpendKey,
+    psk_lp: &PublicSpendKey,
+    rng: &mut R,
+) -> Request {
+    let psk = ssk_user.public_spend_key();
+    let lsa = psk.gen_stealth_address(&JubJubScalar::random(rng));
+    let lsk = ssk_user.sk_r(&lsa);
+    let k_lic = JubJubAffine::from(
+        GENERATOR_EXTENDED * sponge::truncated::hash(&[(*lsk.as_ref()).into()]),
+    );
+    Request::new(psk_lp, &lsa, &k_lic, rng)
+}
+
 #[test]
 fn license_issue_get_merkle() {
     let rng = &mut StdRng::seed_from_u64(0xcafe);
@@ -96,9 +162,8 @@ fn license_issue_get_merkle() {
 
     let attr = JubJubScalar::from(USER_ATTRIBUTES);
 
-    let mut license =
+    let license =
         create_test_license(&attr, &ssk_lp, &psk_lp, &sa_user, &k_lic, rng);
-    license.pos = 1u64;
     let license_blob = rkyv::to_bytes::<_, 4096>(&license)
         .expect("Request should serialize correctly")
         .to_vec();
@@ -107,18 +172,18 @@ fn license_issue_get_merkle() {
     let license_hash = sponge::hash(&[lpk.get_x(), lpk.get_y()]);
 
     session
-        .call::<(Vec<u8>, u64, BlsScalar), ()>(
+        .call::<(Vec<u8>, BlsScalar), ()>(
             LICENSE_CONTRACT_ID,
             "issue_license",
-            &(license_blob, license.pos, license_hash),
+            &(license_blob, license_hash),
             POINT_LIMIT,
         )
         .expect("Issuing license should succeed");
 
-    let bh_range = 0..1u64;
+    let bh_range = 0..10000u64;
 
-    let licenses = session
-        .call::<Range<u64>, Vec<Vec<u8>>>(
+    let license_pos_pairs = session
+        .call::<Range<u64>, Vec<(u64, Vec<u8>)>>(
             LICENSE_CONTRACT_ID,
             "get_licenses",
             &bh_range,
@@ -127,26 +192,27 @@ fn license_issue_get_merkle() {
         .expect("Querying the licenses should succeed")
         .data;
 
-    assert_eq!(
-        licenses.len(),
-        1,
+    assert!(
+        !license_pos_pairs.is_empty(),
         "Call to getting a license request should return some licenses"
     );
 
-    let merkle_opening = session
+    let owned_license = find_owned_license(ssk_user, &license_pos_pairs);
+    assert!(
+        owned_license.is_some(),
+        "Some license should be owned by the user"
+    );
+    let (pos, _) = owned_license.unwrap();
+
+    let _merkle_opening = session
         .call::<u64, Opening<(), DEPTH, ARITY>>(
             LICENSE_CONTRACT_ID,
             "get_merkle_opening",
-            &license.pos,
+            &pos,
             POINT_LIMIT,
         )
         .expect("Querying the merkle opening should succeed")
         .data;
-
-    const EXPECTED_POSITIONS: [usize; DEPTH] =
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
-
-    assert_eq!(merkle_opening.positions(), &EXPECTED_POSITIONS);
 }
 
 #[test]
@@ -166,10 +232,10 @@ fn multiple_licenses_issue_get_merkle() {
     let attr = JubJubScalar::from(USER_ATTRIBUTES);
 
     const NUM_LICENSES: usize = ARITY + 1;
-    for pos in 0..NUM_LICENSES {
+    for _ in 0..NUM_LICENSES {
         let k_lic =
             JubJubAffine::from(GENERATOR_EXTENDED * JubJubScalar::random(rng));
-        let mut license =
+        let license =
             create_test_license(&attr, &ssk_lp, &psk_lp, &sa_user, &k_lic, rng);
         let license_blob = rkyv::to_bytes::<_, 4096>(&license)
             .expect("Request should serialize correctly")
@@ -177,12 +243,11 @@ fn multiple_licenses_issue_get_merkle() {
 
         let lpk = JubJubAffine::from(license.lsa.pk_r().as_ref());
         let license_hash = sponge::hash(&[lpk.get_x(), lpk.get_y()]);
-        license.pos = pos as u64 + 1;
         session
-            .call::<(Vec<u8>, u64, BlsScalar), ()>(
+            .call::<(Vec<u8>, BlsScalar), ()>(
                 LICENSE_CONTRACT_ID,
                 "issue_license",
-                &(license_blob, license.pos, license_hash),
+                &(license_blob, license_hash),
                 POINT_LIMIT,
             )
             .expect("Issuing license should succeed");
@@ -190,8 +255,8 @@ fn multiple_licenses_issue_get_merkle() {
 
     let bh_range = 0..NUM_LICENSES as u64;
 
-    let licenses = session
-        .call::<Range<u64>, Vec<Vec<u8>>>(
+    let license_pos_pairs = session
+        .call::<Range<u64>, Vec<(u64, Vec<u8>)>>(
             LICENSE_CONTRACT_ID,
             "get_licenses",
             &bh_range,
@@ -201,23 +266,27 @@ fn multiple_licenses_issue_get_merkle() {
         .data;
 
     assert_eq!(
-        licenses.len(),
+        license_pos_pairs.len(),
         NUM_LICENSES,
         "Call to getting license requests should return licenses"
     );
 
-    let merkle_opening = session
+    let owned_license = find_owned_license(ssk_user, &license_pos_pairs);
+    assert!(
+        owned_license.is_some(),
+        "Some license should be owned by the user"
+    );
+    let (pos, _) = owned_license.unwrap();
+
+    let _merkle_opening = session
         .call::<u64, Opening<(), DEPTH, ARITY>>(
             LICENSE_CONTRACT_ID,
             "get_merkle_opening",
-            &(NUM_LICENSES as u64),
+            &pos,
             POINT_LIMIT,
         )
         .expect("Querying the merkle opening should succeed")
         .data;
-
-    assert!(merkle_opening.positions()[DEPTH - 1] > 0);
-    assert!(merkle_opening.positions()[DEPTH - 2] > 0);
 }
 
 #[test]
@@ -248,6 +317,7 @@ fn use_license_get_session() {
     // NOTE: it is important that the seed is the same as in the recovery
     // PUB_PARAMS initialization code
     let rng = &mut StdRng::seed_from_u64(0xbeef);
+
     let pp = PublicParameters::setup(1 << CAPACITY, rng).unwrap();
 
     let (prover, verifier) = Compiler::compile::<LicenseCircuit>(&pp, LABEL)
@@ -255,20 +325,15 @@ fn use_license_get_session() {
 
     // user
     let ssk_user = SecretSpendKey::random(rng);
-    let psk_user = ssk_user.public_spend_key();
-    let sa_user = psk_user.gen_stealth_address(&JubJubScalar::random(rng));
 
     // license provider
     let ssk_lp = SecretSpendKey::random(rng);
     let psk_lp = ssk_lp.public_spend_key();
-    let k_lic =
-        JubJubAffine::from(GENERATOR_EXTENDED * JubJubScalar::random(rng));
 
+    let request = create_request(&ssk_user, &psk_lp, rng);
     let attr = JubJubScalar::from(USER_ATTRIBUTES);
+    let license = License::new(&attr, &ssk_lp, &request, rng);
 
-    let mut license =
-        create_test_license(&attr, &ssk_lp, &psk_lp, &sa_user, &k_lic, rng);
-    license.pos = 1u64;
     let license_blob = rkyv::to_bytes::<_, 4096>(&license)
         .expect("Request should serialize correctly")
         .to_vec();
@@ -277,22 +342,62 @@ fn use_license_get_session() {
     let license_hash = sponge::hash(&[lpk.get_x(), lpk.get_y()]);
 
     session
-        .call::<(Vec<u8>, u64, BlsScalar), ()>(
+        .call::<(Vec<u8>, BlsScalar), ()>(
             LICENSE_CONTRACT_ID,
             "issue_license",
-            &(license_blob, license.pos, license_hash),
+            &(license_blob, license_hash),
             POINT_LIMIT,
         )
         .expect("Issuing license should succeed");
 
-    let (cpp, sc) =
-        CitadelUtils::compute_citadel_parameters::<StdRng, DEPTH, ARITY>(
-            rng, ssk_user, psk_user, ssk_lp, psk_lp,
-        );
+    let bh_range = 0..10000u64;
+
+    let license_pos_pairs = session
+        .call::<Range<u64>, Vec<(u64, Vec<u8>)>>(
+            LICENSE_CONTRACT_ID,
+            "get_licenses",
+            &bh_range,
+            POINT_LIMIT,
+        )
+        .expect("Querying the license should succeed")
+        .data;
+    assert!(
+        !license_pos_pairs.is_empty(),
+        "Call to getting license requests should return licenses"
+    );
+
+    let owned_license = find_owned_license(ssk_user, &license_pos_pairs);
+    assert!(
+        owned_license.is_some(),
+        "Some license should be owned by the user"
+    );
+    let (pos, owned_license) = owned_license.unwrap();
+
+    let merkle_opening = session
+        .call::<u64, Opening<(), DEPTH, ARITY>>(
+            LICENSE_CONTRACT_ID,
+            "get_merkle_opening",
+            &pos,
+            POINT_LIMIT,
+        )
+        .expect("Querying the merkle opening should succeed")
+        .data;
+
+    let (cpp, sc) = compute_citadel_parameters(
+        rng,
+        ssk_user,
+        psk_lp,
+        &owned_license,
+        merkle_opening,
+    );
     let circuit = LicenseCircuit::new(&cpp, &sc);
 
     let (proof, public_inputs) =
         prover.prove(rng, &circuit).expect("Proving should succeed");
+
+    let session_id = LicenseSessionId {
+        id: public_inputs[0],
+    };
 
     verifier
         .verify(&proof, &public_inputs)
@@ -303,15 +408,14 @@ fn use_license_get_session() {
         public_inputs,
     };
 
-    let session_id = session
-        .call::<UseLicenseArg, LicenseSessionId>(
+    session
+        .call::<UseLicenseArg, ()>(
             LICENSE_CONTRACT_ID,
             "use_license",
             &use_license_arg,
             POINT_LIMIT,
         )
-        .expect("Use license should succeed")
-        .data;
+        .expect("Use license should succeed");
 
     assert!(
         session


### PR DESCRIPTION
The following changes have been made to the license contract:

- Changed 'use_license' to check if license already nullified
- Changed 'get_licenses' to return values by adding 'pos' to every license returned
- Changed 'issue_license' by removing the 'pos' argument and self position determination
- Added method 'get_info'
- Converted get_licenses to use feeder

This PR implements the following issues: #1051, #1040, #1039, #1052, #1054
