### PR TITLE
Make RUSK_PROFILE_PATH optional

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-export RUSK_PROFILE_PATH=$PWD

--- a/README.md
+++ b/README.md
@@ -33,14 +33,12 @@ is in development.
 To build `rusk` from source, Rust, GCC and Clang are required. Once the dependencies are installed, you can simply run the following command to compile everything:
 
 ```bash
-source .env
 make
 ```
 
 To run tests:
 
 ```bash
-source .env
 make test
 ```
 
@@ -51,9 +49,6 @@ That will also compile all the genesis contracts and its associated circuits.
 Prerequisites:
 
 ```bash
-# Required for the generation of the keys
-source .env
-
 # Generate the keys used by the circuits
 make keys
 

--- a/circuits/storage/src/lib.rs
+++ b/circuits/storage/src/lib.rs
@@ -10,7 +10,6 @@ use once_cell::sync::Lazy;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use rusk_profile::{Circuit as CircuitProfile, Theme};
-use std::env;
 use std::io::{self, ErrorKind};
 use tracing::{info, warn};
 use tracing_subscriber::prelude::*;
@@ -43,14 +42,6 @@ pub fn store_circuit<C>(name: Option<String>) -> io::Result<()>
 where
     C: Circuit,
 {
-    // check whether the veriable `RUSK_PROFILE_PATH` is set
-    if env::var("RUSK_PROFILE_PATH").is_err() {
-        return Err(io::Error::new(
-            ErrorKind::Other,
-            "RUSK_PROFILE_PATH variable not set",
-        ));
-    };
-
     // This force init is needed to check CRS and create it (if not available)
     // See also: https://github.com/dusk-network/rusk/issues/767
     Lazy::force(&PUB_PARAMS);

--- a/contracts/license/Cargo.toml
+++ b/contracts/license/Cargo.toml
@@ -29,3 +29,6 @@ rkyv = { version = "0.7", default-features = false }
 hex = "0.4"
 rand = "0.8"
 zk-citadel = "0.4"
+
+[build-dependencies]
+rusk-profile = { version = "0.6", path = "../../rusk-profile"}

--- a/contracts/license/build.rs
+++ b/contracts/license/build.rs
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+/// Buildfile for the rusk crate.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let keys_dir = rusk_profile::get_rusk_keys_dir()?;
+
+    println!("Keys dir is {keys_dir:?}");
+    // Ensure we run the build script again even if we change just the build.rs
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=../Cargo.lock");
+
+    // Set RUSK_BUILT_KEYS_PATH for `.vd` resolver
+    println!(
+        "cargo:rustc-env=RUSK_BUILT_KEYS_PATH={}",
+        keys_dir.to_str().unwrap()
+    );
+
+    Ok(())
+}

--- a/contracts/license/src/lib.rs
+++ b/contracts/license/src/lib.rs
@@ -19,7 +19,10 @@ pub use license_types::{
     LicenseSession, LicenseSessionId, PoseidonItem, UseLicenseArg,
 };
 
-const VD_LICENSE_CIRCUIT: &[u8] = include_bytes!(concat!(env!("RUSK_PROFILE_PATH"), "/.rusk/keys/b4395f9a50ee374393166d57d8f062e9191f259678dbafca5b6279abb215f1db.vd"));
+const VD_LICENSE_CIRCUIT: &[u8] = include_bytes!(concat!(
+    env!("RUSK_BUILT_KEYS_PATH"),
+    "/b4395f9a50ee374393166d57d8f062e9191f259678dbafca5b6279abb215f1db.vd"
+));
 
 /// Verifier data for the `License` circuit.
 #[allow(dead_code)]

--- a/contracts/transfer/Cargo.toml
+++ b/contracts/transfer/Cargo.toml
@@ -28,3 +28,6 @@ transfer-circuits = { version = "0.5", path = "../../circuits/transfer" }
 rkyv = { version = "0.7", default-features = false }
 hex = "0.4"
 rand = "0.8"
+
+[build-dependencies]
+rusk-profile = { version = "0.6", path = "../../rusk-profile"}

--- a/contracts/transfer/build.rs
+++ b/contracts/transfer/build.rs
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+/// Buildfile for the rusk crate.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let keys_dir = rusk_profile::get_rusk_keys_dir()?;
+
+    println!("Keys dir is {keys_dir:?}");
+    // Ensure we run the build script again even if we change just the build.rs
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=../Cargo.lock");
+
+    // Set RUSK_BUILT_KEYS_PATH for `.vd` resolver
+    println!(
+        "cargo:rustc-env=RUSK_BUILT_KEYS_PATH={}",
+        keys_dir.to_str().unwrap()
+    );
+
+    Ok(())
+}

--- a/contracts/transfer/src/circuits.rs
+++ b/contracts/transfer/src/circuits.rs
@@ -5,37 +5,37 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 const VD_STCT: &[u8] = include_bytes!(concat!(
-    env!("RUSK_PROFILE_PATH"),
-    "/.rusk/keys/1e826837c2de377128fc73ebfac77d84f3a334fe8310ff5b316d8f55e2ff3661.vd"
+    env!("RUSK_BUILT_KEYS_PATH"),
+    "/1e826837c2de377128fc73ebfac77d84f3a334fe8310ff5b316d8f55e2ff3661.vd"
 ));
 const VD_STCO: &[u8] = include_bytes!(concat!(
-    env!("RUSK_PROFILE_PATH"),
-    "/.rusk/keys/8878bbe32b52953022d1b4895d77d325429715c9a69f90f46d80b543c4348728.vd"
+    env!("RUSK_BUILT_KEYS_PATH"),
+    "/8878bbe32b52953022d1b4895d77d325429715c9a69f90f46d80b543c4348728.vd"
 ));
 const VD_WFCT: &[u8] = include_bytes!(concat!(
-    env!("RUSK_PROFILE_PATH"),
-    "/.rusk/keys/a56c87dcd43402dcae9aa719d378dc91b8e93c5fbe2cfbda099d0eeb75b5c628.vd"
+    env!("RUSK_BUILT_KEYS_PATH"),
+    "/a56c87dcd43402dcae9aa719d378dc91b8e93c5fbe2cfbda099d0eeb75b5c628.vd"
 ));
 const VD_WFCO: &[u8] = include_bytes!(concat!(
-    env!("RUSK_PROFILE_PATH"),
-    "/.rusk/keys/01f4bc9da62145d1e28ac7947cd6428fc4127a046e449a6583b56443d180a689.vd"
+    env!("RUSK_BUILT_KEYS_PATH"),
+    "/01f4bc9da62145d1e28ac7947cd6428fc4127a046e449a6583b56443d180a689.vd"
 ));
 
 const VD_EXEC_1_2: &[u8] = include_bytes!(concat!(
-    env!("RUSK_PROFILE_PATH"),
-    "/.rusk/keys/90ed94f311a94d6401df61f1a4e98328ed029f42340537bc1661d551eab3319e.vd"
+    env!("RUSK_BUILT_KEYS_PATH"),
+    "/90ed94f311a94d6401df61f1a4e98328ed029f42340537bc1661d551eab3319e.vd"
 ));
 const VD_EXEC_2_2: &[u8] = include_bytes!(concat!(
-    env!("RUSK_PROFILE_PATH"),
-    "/.rusk/keys/2dcb577684657c0b0e10d32938cca7396cfcb579ed044aa6c9d3bad31fe5c005.vd"
+    env!("RUSK_BUILT_KEYS_PATH"),
+    "/2dcb577684657c0b0e10d32938cca7396cfcb579ed044aa6c9d3bad31fe5c005.vd"
 ));
 const VD_EXEC_3_2: &[u8] = include_bytes!(concat!(
-    env!("RUSK_PROFILE_PATH"),
-    "/.rusk/keys/cba6ad03bbe9f53bdeddef0256ffad331652b3380b7996cd670fd7d92670fd53.vd"
+    env!("RUSK_BUILT_KEYS_PATH"),
+    "/cba6ad03bbe9f53bdeddef0256ffad331652b3380b7996cd670fd7d92670fd53.vd"
 ));
 const VD_EXEC_4_2: &[u8] = include_bytes!(concat!(
-    env!("RUSK_PROFILE_PATH"),
-    "/.rusk/keys/728a4c412d7a5651f1c530a855f40f2ebed120446fb7a87fa17f82164b789a17.vd"
+    env!("RUSK_BUILT_KEYS_PATH"),
+    "/728a4c412d7a5651f1c530a855f40f2ebed120446fb7a87fa17f82164b789a17.vd"
 ));
 
 /// Verifier data for the execute circuits.

--- a/rusk-profile/src/lib.rs
+++ b/rusk-profile/src/lib.rs
@@ -36,6 +36,18 @@ fn file_name(p: &Path) -> Option<&str> {
     p.file_name()?.to_str()
 }
 
+/// Return Rusk profile directory, ensuring that all parents directory are
+/// created
+///
+/// Default to [`home_dir`]/.dusk/rusk
+///
+/// `RUSK_PROFILE_PATH` env can be used to override
+///
+/// E.g:
+/// RUSK_PROFILE_PATH | result
+/// -- | --
+/// None | $HOME/.dusk/rusk
+/// Set | $RUSK_PROFILE_PATH
 pub fn get_rusk_profile_dir() -> io::Result<PathBuf> {
     env::var("RUSK_PROFILE_PATH")
         .map_or_else(
@@ -53,6 +65,19 @@ pub fn get_rusk_profile_dir() -> io::Result<PathBuf> {
         })
 }
 
+/// Return Rusk circuits directory, ensuring that all parents directory are
+/// created
+///
+/// Default to [`get_rusk_profile_dir`]/circuits
+///
+/// `RUSK_CIRCUITS_PATH` env can be used to override
+///
+/// E.g:
+/// RUSK_PROFILE_PATH | RUSK_CIRCUITS_PATH | result
+/// -- | -- | --
+/// None | None | $HOME/.dusk/rusk/circuits
+/// Set | None | $RUSK_PROFILE_PATH/circuits
+/// _ | Set | $RUSK_CIRCUITS_PATH
 pub fn get_rusk_circuits_dir() -> io::Result<PathBuf> {
     env::var("RUSK_CIRCUITS_PATH")
         .map_or_else(
@@ -66,6 +91,18 @@ pub fn get_rusk_circuits_dir() -> io::Result<PathBuf> {
         })
 }
 
+/// Return Rusk keys directory, ensuring that all parents directory are created
+///
+/// Default to [`get_rusk_profile_dir`]/keys
+///
+/// `RUSK_KEYS_PATH` env can be used to override
+///
+/// E.g:
+/// RUSK_PROFILE_PATH | RUSK_KEYS_PATH | result
+/// -- | -- | --
+/// None | None | $HOME/.dusk/rusk/keys
+/// Set | None | $RUSK_PROFILE_PATH/keys
+/// _ | Set | $RUSK_KEYS_PATH
 pub fn get_rusk_keys_dir() -> io::Result<PathBuf> {
     env::var("RUSK_KEYS_PATH")
         .map_or_else(
@@ -79,6 +116,18 @@ pub fn get_rusk_keys_dir() -> io::Result<PathBuf> {
         })
 }
 
+/// Return Rusk keys directory, ensuring that all parents directory are created
+///
+/// Default  to [get_rusk_profile_dir]/state
+///
+/// `RUSK_STATE_PATH` env can be used to override
+///
+/// E.g:
+/// RUSK_PROFILE_PATH | RUSK_STATE_PATH | result
+/// -- | -- | --
+/// None | None | $HOME/.dusk/rusk/state
+/// Set | None | $RUSK_PROFILE_PATH/state
+/// _ | Set | $RUSK_STATE_PATH
 pub fn get_rusk_state_dir() -> io::Result<PathBuf> {
     env::var("RUSK_STATE_PATH")
         .map_or_else(

--- a/rusk-recovery/src/bin/keys.rs
+++ b/rusk-recovery/src/bin/keys.rs
@@ -8,23 +8,12 @@ mod task;
 mod version;
 
 use clap::Parser;
-use std::path::PathBuf;
 use version::VERSION_BUILD;
 
 #[derive(Parser, Debug)]
 #[clap(name = "rusk-recovery-keys")]
 #[clap(author, version = &VERSION_BUILD[..], about, long_about = None)]
 struct Cli {
-    /// Sets the profile path
-    #[clap(
-        short,
-        long,
-        parse(from_os_str),
-        value_name = "PATH",
-        env = "RUSK_PROFILE_PATH"
-    )]
-    profile: PathBuf,
-
     /// Keeps untracked keys
     #[clap(short, long, env = "RUSK_KEEP_KEYS")]
     keep: bool,
@@ -38,7 +27,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Cli::parse();
     task::run(
         || Ok(rusk_recovery_tools::keys::exec(args.keep)?),
-        args.profile,
         args.verbose,
     )
 }

--- a/rusk-recovery/src/bin/state.rs
+++ b/rusk-recovery/src/bin/state.rs
@@ -21,16 +21,6 @@ use rusk_recovery_tools::state::{deploy, restore_state, tar, Snapshot};
 #[clap(name = "rusk-recovery-state")]
 #[clap(author, version = &VERSION_BUILD[..], about, long_about = None)]
 struct Cli {
-    /// Sets the profile path
-    #[clap(
-        short,
-        long,
-        parse(from_os_str),
-        value_name = "PATH",
-        env = "RUSK_PROFILE_PATH"
-    )]
-    profile: PathBuf,
-
     /// Forces a build/download even if the state is in the profile path.
     #[clap(short = 'f', long, env = "RUSK_FORCE_STATE")]
     force: bool,
@@ -66,7 +56,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                 output_file: args.output.clone(),
             })
         },
-        args.profile,
         args.verbose,
     )
 }

--- a/rusk-recovery/src/bin/task.rs
+++ b/rusk-recovery/src/bin/task.rs
@@ -5,20 +5,15 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use rusk_recovery_tools::Theme;
-use std::env;
-use std::path::PathBuf;
 use std::time::Instant;
 use tracing::info;
 use tracing_subscriber::prelude::*;
 
 pub fn run(
     task: impl Fn() -> Result<(), Box<dyn std::error::Error>>,
-    profile: PathBuf,
     verbose: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let begin = Instant::now();
-
-    env::set_var("RUSK_PROFILE_PATH", profile.to_str().unwrap());
 
     if verbose > 0 {
         let fmt_layer = tracing_subscriber::fmt::layer()
@@ -42,6 +37,24 @@ pub fn run(
         "{} {} as profile path",
         theme.action("Using"),
         rusk_profile::get_rusk_profile_dir()?.to_str().unwrap()
+    );
+
+    info!(
+        "{} {} as circuits path",
+        theme.action("Using"),
+        rusk_profile::get_rusk_circuits_dir()?.to_str().unwrap()
+    );
+
+    info!(
+        "{} {} as keys path",
+        theme.action("Using"),
+        rusk_profile::get_rusk_keys_dir()?.to_str().unwrap()
+    );
+
+    info!(
+        "{} {} as state path",
+        theme.action("Using"),
+        rusk_profile::get_rusk_state_dir()?.to_str().unwrap()
     );
 
     task()?;

--- a/rusk/build.rs
+++ b/rusk/build.rs
@@ -25,8 +25,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rustc_tools_util::get_channel().unwrap_or_default()
     );
 
-    assert!(option_env!("RUSK_PROFILE_PATH").is_some(),
-        "RUSK_PROFILE_PATH env var is not set. Please run `source .env` to set it");
-
     Ok(())
 }


### PR DESCRIPTION
Additionally, fix the profile folders resolution to be the following

#### `rusk_profile::get_rusk_profile_dir()`
RUSK_PROFILE_PATH | result
-- | -- 
None | $HOME/.dusk/rusk
Set | $RUSK_PROFILE_PATH


#### `rusk_profile::get_rusk_keys_dir()`
RUSK_PROFILE_PATH | RUSK_KEYS_PATH | result
-- | -- | --
None | None | $HOME/.dusk/rusk/keys
Set | None | $RUSK_PROFILE_PATH/keys
_ | Set | $RUSK_KEYS_PATH


#### `rusk_profile::get_rusk_circuits_dir()`
RUSK_PROFILE_PATH | RUSK_CIRCUITS_PATH | result
-- | -- | --
None | None | $HOME/.dusk/rusk/circuits
Set | None | $RUSK_PROFILE_PATH/circuits
_ | Set | $RUSK_CIRCUITS_PATH


#### `rusk_profile::get_rusk_state_dir()`
RUSK_PROFILE_PATH | RUSK_STATE_PATH | result
-- | -- | --
None | None | $HOME/.dusk/rusk/state
Set | None | $RUSK_PROFILE_PATH/state
_ | Set | $RUSK_STATE_PATH


Resolves #1057
