### PR TITLE
Add `--profile` cli argument

### DIFF
--- a/rusk-recovery/src/bin/keys.rs
+++ b/rusk-recovery/src/bin/keys.rs
@@ -8,12 +8,23 @@ mod task;
 mod version;
 
 use clap::Parser;
+use std::path::PathBuf;
 use version::VERSION_BUILD;
 
 #[derive(Parser, Debug)]
 #[clap(name = "rusk-recovery-keys")]
 #[clap(author, version = &VERSION_BUILD[..], about, long_about = None)]
 struct Cli {
+    /// Sets the profile path
+    #[clap(
+        short,
+        long,
+        parse(from_os_str),
+        value_name = "PATH",
+        env = "RUSK_PROFILE_PATH"
+    )]
+    profile: Option<PathBuf>,
+
     /// Keeps untracked keys
     #[clap(short, long, env = "RUSK_KEEP_KEYS")]
     keep: bool,
@@ -27,6 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Cli::parse();
     task::run(
         || Ok(rusk_recovery_tools::keys::exec(args.keep)?),
+        args.profile,
         args.verbose,
     )
 }

--- a/rusk-recovery/src/bin/state.rs
+++ b/rusk-recovery/src/bin/state.rs
@@ -21,6 +21,16 @@ use rusk_recovery_tools::state::{deploy, restore_state, tar, Snapshot};
 #[clap(name = "rusk-recovery-state")]
 #[clap(author, version = &VERSION_BUILD[..], about, long_about = None)]
 struct Cli {
+    /// Sets the profile path
+    #[clap(
+        short,
+        long,
+        parse(from_os_str),
+        value_name = "PATH",
+        env = "RUSK_PROFILE_PATH"
+    )]
+    profile: Option<PathBuf>,
+
     /// Forces a build/download even if the state is in the profile path.
     #[clap(short = 'f', long, env = "RUSK_FORCE_STATE")]
     force: bool,
@@ -56,6 +66,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 output_file: args.output.clone(),
             })
         },
+        args.profile,
         args.verbose,
     )
 }

--- a/rusk-recovery/src/bin/task.rs
+++ b/rusk-recovery/src/bin/task.rs
@@ -5,15 +5,22 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use rusk_recovery_tools::Theme;
+use std::env;
+use std::path::PathBuf;
 use std::time::Instant;
 use tracing::info;
 use tracing_subscriber::prelude::*;
 
 pub fn run(
     task: impl Fn() -> Result<(), Box<dyn std::error::Error>>,
+    profile: Option<PathBuf>,
     verbose: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let begin = Instant::now();
+
+    if let Some(profile) = profile {
+        env::set_var("RUSK_PROFILE_PATH", profile.to_str().unwrap());
+    }
 
     if verbose > 0 {
         let fmt_layer = tracing_subscriber::fmt::layer()

--- a/rusk/src/bin/config.rs
+++ b/rusk/src/bin/config.rs
@@ -8,12 +8,16 @@ pub mod chain;
 pub mod http;
 pub mod kadcast;
 
+use std::env;
+use std::path::PathBuf;
 use std::str::FromStr;
 
-use clap::{Arg, ArgMatches, Command};
+use clap::{value_parser, Arg, ArgMatches, Command};
 use serde::{Deserialize, Serialize};
 
-use self::{chain::ChainConfig, http::HttpConfig, kadcast::KadcastConfig};
+use self::chain::ChainConfig;
+use self::http::HttpConfig;
+use self::kadcast::KadcastConfig;
 
 type DataBrokerConfig = node::databroker::conf::Params;
 
@@ -62,6 +66,13 @@ impl From<&ArgMatches> for Config {
             rusk_config.log_filter = Some(log_filter.into());
         }
 
+        // Set profile path if specified
+        if let Some(profile) = matches.value_of("profile-path") {
+            // Since the profile path is resolved by the rusk_profile library,
+            // there is the need to set the env variable
+            env::set_var("RUSK_PROFILE_PATH", profile);
+        }
+
         rusk_config.kadcast.merge(matches);
         rusk_config.chain.merge(matches);
         rusk_config.http.merge(matches);
@@ -101,6 +112,14 @@ impl Config {
                     .value_name("LOG_FILTER")
                     .help("Add log filter(s)")
                     .takes_value(true),
+            )
+            .arg(
+                Arg::new("profile-path")
+                    .long("profile")
+                    .help("Sets the profile path")
+                    .takes_value(true)
+                    .value_parser(value_parser!(PathBuf))
+                    .required(false),
             )
     }
 


### PR DESCRIPTION
With #1057 the rusk-recovery `--profile` argument was removed.

This PR partially revert the removal, but still keeps the argument optional.

In the same way, a new `--profile` arg has been added to `rusk` too 