### PR TITLE
Contract panic

### DIFF
--- a/contracts/license/Makefile
+++ b/contracts/license/Makefile
@@ -18,8 +18,7 @@ wasm: ## Generate the optimized WASM for the contract given
     	cargo build \
     		--release \
     		--color=always \
-    		-Z build-std=core,alloc,panic_abort \
-    		-Z build-std-features=panic_immediate_abort \
+			-Z build-std=core,alloc \
     		--target wasm32-unknown-unknown
 
 clippy: ## Run clippy

--- a/contracts/stake/Makefile
+++ b/contracts/stake/Makefile
@@ -18,8 +18,7 @@ wasm: ## Generate the optimized WASM for the contract given
     	cargo build \
     		--release \
     		--color=always \
-    		-Z build-std=core,alloc,panic_abort \
-    		-Z build-std-features=panic_immediate_abort \
+			-Z build-std=core,alloc \
     		--target wasm32-unknown-unknown
 			
 clippy: ## Run clippy

--- a/contracts/transfer/Makefile
+++ b/contracts/transfer/Makefile
@@ -18,8 +18,7 @@ wasm: ## Build the WASM files
 		cargo build \
 			--release \
 			--color=always \
-			-Z build-std=core,alloc,panic_abort \
-			-Z build-std-features=panic_immediate_abort \
+			-Z build-std=core,alloc \
 			--target wasm32-unknown-unknown
 			
 clippy: ## Run clippy

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -22,8 +22,8 @@ dusk-bytes = "0.1"
 bytecheck = { version = "0.6", default-features = false }
 dusk-plonk = { version = "0.14", default-features = false, features = ["rkyv-impl", "alloc"] }
 
-piecrust-uplink = "0.7"
-piecrust = { version = "0.10", optional = true }
+piecrust-uplink = "0.8.0-rc"
+piecrust = { version = "0.10.1-rc", optional = true }
 
 # These are patches since these crates don't seem to like semver.
 rkyv = { version = "=0.7.39", default-features = false }


### PR DESCRIPTION
license-contract: remove `panic` compilation flags
stake-contract: remove `panic` compilation flags
transfer-contract: remove `panic` compilation flags
rusk-abi: upgrade piecrust stack

- Upgrade `piecrust-uplink` to 0.8.0-rc
- Upgrade `piecrust` to 0.10.1-rc

Resolves dusk-network/wallet-cli#207