### PR TITLE
Migrate to `clap` 4.x

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -33,11 +33,7 @@ dusk-bls12_381-sign = { version = "0.4", default-features = false }
 console-subscriber = { version = "0.1.8", optional = true }
 smallvec = "1.10.0"
 
-## Binary dependencies
-clap = { version = "3.1", features = ["env"] }
-toml = "0.5"
 serde = "1.0"
-dirs = "4"
 
 [dev-dependencies]
 fake = { version = "2.5", features = ['derive'] }

--- a/node/src/databroker.rs
+++ b/node/src/databroker.rs
@@ -90,15 +90,13 @@ pub struct DataBrokerSrv {
 }
 
 impl DataBrokerSrv {
-    pub fn new(conf: &conf::Params) -> Self {
+    pub fn new(conf: conf::Params) -> Self {
         info!("DataBrokerSrv::new with conf: {}", conf);
-
+        let permits = conf.max_ongoing_requests;
         Self {
-            conf: conf.clone(),
+            conf,
             requests: AsyncQueue::default(),
-            limit_ongoing_requests: Arc::new(Semaphore::new(
-                conf.max_ongoing_requests,
-            )),
+            limit_ongoing_requests: Arc::new(Semaphore::new(permits)),
         }
     }
 }

--- a/node/src/databroker/conf.rs
+++ b/node/src/databroker/conf.rs
@@ -6,7 +6,6 @@
 
 use std::fmt::Formatter;
 
-use clap::{Arg, ArgMatches, Command};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -29,41 +28,12 @@ impl Default for Params {
     }
 }
 
-impl std::fmt::Display for &Params {
+impl std::fmt::Display for Params {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "max_inv_entries: {}, max_ongoing_requests: {}",
             self.max_inv_entries, self.max_ongoing_requests,
-        )
-    }
-}
-
-impl Params {
-    pub fn merge(&mut self, matches: &ArgMatches) {
-        if let Some(delay_on_resp_msg) = matches.value_of("delay_on_resp_msg") {
-            match delay_on_resp_msg.parse() {
-                Ok(delay_on_resp_msg) => {
-                    self.delay_on_resp_msg = Some(delay_on_resp_msg);
-                }
-                Err(e) => {
-                    tracing::error!(
-                        "Failed to parse delay_on_resp_msg: {:?}",
-                        e
-                    );
-                }
-            }
-        };
-    }
-
-    pub fn inject_args(command: Command<'_>) -> Command<'_> {
-        command.arg(
-            Arg::new("delay_on_resp_msg")
-                .long("delay_on_resp_msg")
-                .help("Delay in milliseconds to mitigate UDP drops for DataBroker service in localnet")
-                .env("DELAY_ON_RESP_MSG")
-                .takes_value(true)
-                .required(false),
         )
     }
 }

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -36,7 +36,7 @@ once_cell = "1.13"
 dusk-bytes = "0.1"
 dusk-bls12_381 = "0.11"
 dusk-bls12_381-sign = "0.4"
-clap = { version = "3.1", features = ["cargo", "env", "derive"] }
+clap = { version = "4", features = ["env", "derive"] }
 thiserror = "1.0"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.2.0", features = ["fmt"] }

--- a/rusk-recovery/src/bin/keys.rs
+++ b/rusk-recovery/src/bin/keys.rs
@@ -7,7 +7,8 @@
 mod task;
 mod version;
 
-use clap::Parser;
+use clap::builder::BoolishValueParser;
+use clap::{ArgAction, Parser};
 use std::path::PathBuf;
 use version::VERSION_BUILD;
 
@@ -19,18 +20,18 @@ struct Cli {
     #[clap(
         short,
         long,
-        parse(from_os_str),
+        value_parser,
         value_name = "PATH",
         env = "RUSK_PROFILE_PATH"
     )]
     profile: Option<PathBuf>,
 
     /// Keeps untracked keys
-    #[clap(short, long, env = "RUSK_KEEP_KEYS")]
+    #[clap(short, long, value_parser = BoolishValueParser::new(), env = "RUSK_KEEP_KEYS")]
     keep: bool,
 
     /// Sets different levels of verbosity
-    #[clap(short, long, parse(from_occurrences))]
+    #[clap(short, long, action = ArgAction::Count)]
     verbose: usize,
 }
 

--- a/rusk-recovery/src/bin/state.rs
+++ b/rusk-recovery/src/bin/state.rs
@@ -7,6 +7,7 @@
 mod task;
 mod version;
 
+use clap::builder::{ArgAction, BoolishValueParser};
 use clap::Parser;
 use rusk_recovery_tools::Theme;
 use std::error::Error;
@@ -25,27 +26,27 @@ struct Cli {
     #[clap(
         short,
         long,
-        parse(from_os_str),
+        value_parser,
         value_name = "PATH",
         env = "RUSK_PROFILE_PATH"
     )]
     profile: Option<PathBuf>,
 
     /// Forces a build/download even if the state is in the profile path.
-    #[clap(short = 'f', long, env = "RUSK_FORCE_STATE")]
+    #[clap(short = 'f', value_parser = BoolishValueParser::new(), long, env = "RUSK_FORCE_STATE")]
     force: bool,
 
     /// Create a state applying the init config specified in this file.
-    #[clap(short, long, parse(from_os_str), env = "RUSK_RECOVERY_INPUT")]
+    #[clap(short, long, value_parser, env = "RUSK_RECOVERY_INPUT")]
     init: Option<PathBuf>,
 
     /// Sets different levels of verbosity
-    #[clap(short, long, parse(from_occurrences))]
+    #[clap(short, long, action = ArgAction::Count)]
     verbose: usize,
 
     /// If specified, the generated state is written on this file instead of
     /// save the state in the profile path.
-    #[clap(short, long, parse(from_os_str), takes_value(true))]
+    #[clap(short, long, value_parser, num_args(1))]
     output: Option<PathBuf>,
 }
 

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -21,7 +21,7 @@ tracing-subscriber = { version = "0.3.0", features = [
   "env-filter",
   "json",
 ] }
-clap = { version = "3.1", features = ["env"] }
+clap = { version = "4", features = ["env", "string"] }
 semver = "1.0"
 anyhow = "1.0"
 rustc_tools_util = "0.3"

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -21,7 +21,7 @@ tracing-subscriber = { version = "0.3.0", features = [
   "env-filter",
   "json",
 ] }
-clap = { version = "4", features = ["env", "string"] }
+clap = { version = "4", features = ["env", "string", "derive"] }
 semver = "1.0"
 anyhow = "1.0"
 rustc_tools_util = "0.3"

--- a/rusk/src/bin/args.rs
+++ b/rusk/src/bin/args.rs
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::path::PathBuf;
+
+use clap::builder::PossibleValuesParser;
+use clap::Parser;
+
+use crate::version::VERSION_BUILD;
+
+#[derive(Parser, Debug)]
+#[command(
+    author="Dusk Network B.V. All Rights Reserved.",
+    version = &VERSION_BUILD[..],
+    about = "Rusk server node",
+)]
+pub struct Args {
+    /// Sets the profile path
+    #[clap(long, short, env = "RUSK_CONFIG_TOML", value_parser)]
+    pub config: Option<PathBuf>,
+
+    /// Output log level
+    #[clap(long)]
+    pub log_level: Option<tracing::Level>,
+
+    // Change the log format accordingly
+    #[clap(long, value_parser = PossibleValuesParser::new(["coloured", "plain", "json"]))]
+    pub log_type: Option<String>,
+
+    /// Add log filter(s)
+    #[clap(long)]
+    pub log_filter: Option<String>,
+
+    /// Sets the profile path
+    #[clap(long, value_parser)]
+    pub profile: Option<PathBuf>,
+
+    #[cfg(feature = "ephemeral")]
+    /// Ephemeral state file (archive)
+    #[clap(short, long = "state", value_parser)]
+    pub state_path: Option<PathBuf>,
+
+    #[clap(long, value_parser)]
+    /// path to blockchain database
+    pub db_path: Option<PathBuf>,
+
+    #[clap(long, value_parser)]
+    /// path to encrypted BLS keys
+    pub consensus_keys_path: Option<PathBuf>,
+
+    #[clap(long)]
+    /// Delay in milliseconds to mitigate UDP drops for DataBroker service in
+    /// localnet
+    pub delay_on_resp_msg: Option<u64>,
+
+    #[clap(long)]
+    /// Address http server should listen on
+    pub http_listen_addr: Option<String>,
+
+    #[clap(long, env = "KADCAST_BOOTSTRAP", verbatim_doc_comment)]
+    /// Kadcast list of bootstrapping server addresses
+    pub kadcast_bootstrap: Option<Vec<String>>,
+
+    #[clap(long, env = "KADCAST_PUBLIC_ADDRESS", verbatim_doc_comment)]
+    /// Public address you want to be identified with. Eg: 193.xxx.xxx.198:9999
+    ///
+    /// This is the address where other peer can contact you.
+    /// This address MUST be accessible from any peer of the network"
+    pub kadcast_public_address: Option<String>,
+
+    #[clap(long, env = "KADCAST_LISTEN_ADDRESS", verbatim_doc_comment)]
+    /// Optional internal address to listen incoming connections. Eg:
+    /// 127.0.0.1:9999
+    ///
+    /// This address is the one bound for the incoming connections.
+    /// Use this argument if your host is not publicly reachable from other
+    /// peer in the network (Eg: if you are behind a NAT)
+    /// If this is not specified, the public address is used for binding
+    /// incoming connection
+    pub kadcast_listen_address: Option<String>,
+}

--- a/rusk/src/bin/config/chain.rs
+++ b/rusk/src/bin/config/chain.rs
@@ -6,8 +6,9 @@
 
 use std::path::PathBuf;
 
-use clap::{Arg, ArgMatches, Command};
 use serde::{Deserialize, Serialize};
+
+use crate::args::Args;
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub(crate) struct ChainConfig {
@@ -16,36 +17,16 @@ pub(crate) struct ChainConfig {
 }
 
 impl ChainConfig {
-    pub(crate) fn merge(&mut self, matches: &ArgMatches) {
+    pub(crate) fn merge(&mut self, args: &Args) {
         // Overwrite config consensus-keys-path
-        if let Some(consensus_keys_path) =
-            matches.get_one::<String>("consensus-keys-path")
-        {
-            self.consensus_keys_path = Some(PathBuf::from(consensus_keys_path));
+        if let Some(consensus_keys_path) = args.consensus_keys_path.clone() {
+            self.consensus_keys_path = Some(consensus_keys_path);
         }
 
         // Overwrite config db-path
-        if let Some(db_path) = matches.get_one::<String>("db-path") {
-            self.db_path = Some(PathBuf::from(db_path));
+        if let Some(db_path) = args.db_path.clone() {
+            self.db_path = Some(db_path);
         }
-    }
-
-    pub fn inject_args(command: Command) -> Command {
-        command
-            .arg(
-                Arg::new("consensus-keys-path")
-                    .long("consensus-keys-path")
-                    .value_name("CONSENSUS_KEYS_PATH")
-                    .help("path to encrypted BLS keys")
-                    .num_args(1),
-            )
-            .arg(
-                Arg::new("db-path")
-                    .long("db-path")
-                    .value_name("DB_PATH")
-                    .help("path to blockchain database")
-                    .num_args(1),
-            )
     }
 
     pub(crate) fn db_path(&self) -> PathBuf {

--- a/rusk/src/bin/config/chain.rs
+++ b/rusk/src/bin/config/chain.rs
@@ -19,32 +19,32 @@ impl ChainConfig {
     pub(crate) fn merge(&mut self, matches: &ArgMatches) {
         // Overwrite config consensus-keys-path
         if let Some(consensus_keys_path) =
-            matches.value_of("consensus-keys-path")
+            matches.get_one::<String>("consensus-keys-path")
         {
             self.consensus_keys_path = Some(PathBuf::from(consensus_keys_path));
         }
 
         // Overwrite config db-path
-        if let Some(db_path) = matches.value_of("db-path") {
+        if let Some(db_path) = matches.get_one::<String>("db-path") {
             self.db_path = Some(PathBuf::from(db_path));
         }
     }
 
-    pub fn inject_args(command: Command<'_>) -> Command<'_> {
+    pub fn inject_args(command: Command) -> Command {
         command
             .arg(
                 Arg::new("consensus-keys-path")
                     .long("consensus-keys-path")
                     .value_name("CONSENSUS_KEYS_PATH")
                     .help("path to encrypted BLS keys")
-                    .takes_value(true),
+                    .num_args(1),
             )
             .arg(
                 Arg::new("db-path")
                     .long("db-path")
                     .value_name("DB_PATH")
                     .help("path to blockchain database")
-                    .takes_value(true),
+                    .num_args(1),
             )
     }
 

--- a/rusk/src/bin/config/databroker.rs
+++ b/rusk/src/bin/config/databroker.rs
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use clap::{Arg, ArgMatches, Command};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub(crate) struct DataBrokerConfig(node::databroker::conf::Params);
+
+impl From<DataBrokerConfig> for node::databroker::conf::Params {
+    fn from(conf: DataBrokerConfig) -> Self {
+        conf.0
+    }
+}
+
+impl DataBrokerConfig {
+    pub fn merge(&mut self, matches: &ArgMatches) {
+        if let Some(delay_on_resp_msg) =
+            matches.get_one::<String>("delay_on_resp_msg")
+        {
+            match delay_on_resp_msg.parse() {
+                Ok(delay_on_resp_msg) => {
+                    self.0.delay_on_resp_msg = Some(delay_on_resp_msg);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to parse delay_on_resp_msg: {:?}",
+                        e
+                    );
+                }
+            }
+        };
+    }
+
+    pub fn inject_args(command: Command) -> Command {
+        command.arg(
+                Arg::new("delay_on_resp_msg")
+                    .long("delay_on_resp_msg")
+                    .help("Delay in milliseconds to mitigate UDP drops for DataBroker service in localnet")
+                    .env("DELAY_ON_RESP_MSG")
+                    .num_args(1)
+            )
+    }
+}

--- a/rusk/src/bin/config/databroker.rs
+++ b/rusk/src/bin/config/databroker.rs
@@ -4,8 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use clap::{Arg, ArgMatches, Command};
 use serde::{Deserialize, Serialize};
+
+use crate::args::Args;
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub(crate) struct DataBrokerConfig(node::databroker::conf::Params);
@@ -17,31 +18,9 @@ impl From<DataBrokerConfig> for node::databroker::conf::Params {
 }
 
 impl DataBrokerConfig {
-    pub fn merge(&mut self, matches: &ArgMatches) {
-        if let Some(delay_on_resp_msg) =
-            matches.get_one::<String>("delay_on_resp_msg")
-        {
-            match delay_on_resp_msg.parse() {
-                Ok(delay_on_resp_msg) => {
-                    self.0.delay_on_resp_msg = Some(delay_on_resp_msg);
-                }
-                Err(e) => {
-                    tracing::error!(
-                        "Failed to parse delay_on_resp_msg: {:?}",
-                        e
-                    );
-                }
-            }
+    pub fn merge(&mut self, args: &Args) {
+        if let Some(delay_on_resp_msg) = args.delay_on_resp_msg {
+            self.0.delay_on_resp_msg = Some(delay_on_resp_msg);
         };
-    }
-
-    pub fn inject_args(command: Command) -> Command {
-        command.arg(
-                Arg::new("delay_on_resp_msg")
-                    .long("delay_on_resp_msg")
-                    .help("Delay in milliseconds to mitigate UDP drops for DataBroker service in localnet")
-                    .env("DELAY_ON_RESP_MSG")
-                    .num_args(1)
-            )
     }
 }

--- a/rusk/src/bin/config/http.rs
+++ b/rusk/src/bin/config/http.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -23,30 +23,20 @@ impl HttpConfig {
 
     pub(crate) fn merge(&mut self, matches: &ArgMatches) {
         // Overwrite config ws-listen-addr
-        if let Some(ws_listen_addr) = matches.value_of("ws-listen-addr") {
+        if let Some(ws_listen_addr) =
+            matches.get_one::<String>("ws-listen-addr")
+        {
             self.listen_address = Some(ws_listen_addr.into());
         }
-
-        // Overwrite config ws-listen
-        self.listen = self.listen || matches.get_flag("ws-listen");
     }
 
-    pub fn inject_args(command: Command<'_>) -> Command<'_> {
-        command
-            .arg(
-                Arg::new("ws-listen-addr")
-                    .long("ws-listen-addr")
-                    .value_name("WS_LISTEN_ADDR")
-                    .help("Address websocket should listen on")
-                    .takes_value(true),
-            )
-            .arg(
-                Arg::new("ws-listen")
-                    .action(ArgAction::SetTrue)
-                    .long("ws-listen")
-                    .value_name("WS_LISTEN")
-                    .help("Force the websocket to be active")
-                    .takes_value(false),
-            )
+    pub fn inject_args(command: Command) -> Command {
+        command.arg(
+            Arg::new("ws-listen-addr")
+                .long("ws-listen-addr")
+                .value_name("WS_LISTEN_ADDR")
+                .help("Address websocket should listen on")
+                .num_args(1),
+        )
     }
 }

--- a/rusk/src/bin/config/http.rs
+++ b/rusk/src/bin/config/http.rs
@@ -4,8 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use clap::{Arg, ArgMatches, Command};
 use serde::{Deserialize, Serialize};
+
+use crate::args::Args;
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct HttpConfig {
@@ -21,22 +22,10 @@ impl HttpConfig {
             .unwrap_or("127.0.0.1:8080".into())
     }
 
-    pub(crate) fn merge(&mut self, matches: &ArgMatches) {
+    pub(crate) fn merge(&mut self, args: &Args) {
         // Overwrite config ws-listen-addr
-        if let Some(ws_listen_addr) =
-            matches.get_one::<String>("ws-listen-addr")
-        {
-            self.listen_address = Some(ws_listen_addr.into());
+        if let Some(http_listen_addr) = &args.http_listen_addr {
+            self.listen_address = Some(http_listen_addr.into());
         }
-    }
-
-    pub fn inject_args(command: Command) -> Command {
-        command.arg(
-            Arg::new("ws-listen-addr")
-                .long("ws-listen-addr")
-                .value_name("WS_LISTEN_ADDR")
-                .help("Address websocket should listen on")
-                .num_args(1),
-        )
     }
 }

--- a/rusk/src/bin/config/kadcast.rs
+++ b/rusk/src/bin/config/kadcast.rs
@@ -4,9 +4,10 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use clap::{Arg, ArgAction, ArgMatches, Command};
 use kadcast::config::Config;
 use serde::{Deserialize, Serialize};
+
+use crate::args::Args;
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub(crate) struct KadcastConfig(Config);
@@ -18,55 +19,15 @@ impl From<KadcastConfig> for Config {
 }
 
 impl KadcastConfig {
-    pub(crate) fn merge(&mut self, matches: &ArgMatches) {
-        if let Some(public_address) =
-            matches.get_one::<String>("kadcast_public_address")
-        {
+    pub(crate) fn merge(&mut self, arg: &Args) {
+        if let Some(public_address) = &arg.kadcast_public_address {
             self.0.public_address = public_address.into();
         };
-        if let Some(listen_address) =
-            matches.get_one::<String>("kadcast_listen_address")
-        {
+        if let Some(listen_address) = &arg.kadcast_listen_address {
             self.0.listen_address = Some(listen_address.into());
         };
-        if let Some(bootstrapping_nodes) =
-            matches.get_many::<String>("kadcast_bootstrap")
-        {
-            self.0.bootstrapping_nodes =
-                bootstrapping_nodes.map(|s| s.into()).collect();
+        if let Some(bootstrapping_nodes) = arg.kadcast_bootstrap.clone() {
+            self.0.bootstrapping_nodes = bootstrapping_nodes
         };
-    }
-
-    pub fn inject_args(command: Command) -> Command {
-        command.arg(
-            Arg::new("kadcast_public_address")
-                .long("kadcast_public_address")
-                .long_help("This is the address where other peer can contact you. 
-    This address MUST be accessible from any peer of the network")
-                .help("Public address you want to be identified with. Eg: 193.xxx.xxx.198:9999")
-                .env("KADCAST_PUBLIC_ADDRESS")
-                .num_args(1)
-        )
-        .arg(
-            Arg::new("kadcast_listen_address")
-                .long("kadcast_listen_address")
-                .long_help("This address is the one bound for the incoming connections. 
-    Use this argument if your host is not publicly reachable from other peer in
-    the network (Eg: if you are behind a NAT)
-    If this is not specified, the public address is used for binding incoming connection")
-                .help("Optional internal address to listen incoming connections. Eg: 127.0.0.1:9999")
-                .env("KADCAST_LISTEN_ADDRESS")
-                .num_args(1)
-
-        )
-        .arg(
-            Arg::new("kadcast_bootstrap")
-                .long("kadcast_bootstrap")
-                .env("KADCAST_BOOTSTRAP")
-                .action(ArgAction::Append)
-                .help("Kadcast list of bootstrapping server addresses")
-                .num_args(1)
-
-        )
     }
 }

--- a/rusk/src/bin/config/kadcast.rs
+++ b/rusk/src/bin/config/kadcast.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use kadcast::config::Config;
 use serde::{Deserialize, Serialize};
 
@@ -19,24 +19,25 @@ impl From<KadcastConfig> for Config {
 
 impl KadcastConfig {
     pub(crate) fn merge(&mut self, matches: &ArgMatches) {
-        if let Some(public_address) = matches.value_of("kadcast_public_address")
+        if let Some(public_address) =
+            matches.get_one::<String>("kadcast_public_address")
         {
             self.0.public_address = public_address.into();
         };
-        if let Some(listen_address) = matches.value_of("kadcast_listen_address")
+        if let Some(listen_address) =
+            matches.get_one::<String>("kadcast_listen_address")
         {
             self.0.listen_address = Some(listen_address.into());
         };
         if let Some(bootstrapping_nodes) =
-            matches.values_of("kadcast_bootstrap")
+            matches.get_many::<String>("kadcast_bootstrap")
         {
             self.0.bootstrapping_nodes =
                 bootstrapping_nodes.map(|s| s.into()).collect();
         };
-        self.0.auto_propagate = matches.is_present("kadcast_autobroadcast");
     }
 
-    pub fn inject_args(command: Command<'_>) -> Command<'_> {
+    pub fn inject_args(command: Command) -> Command {
         command.arg(
             Arg::new("kadcast_public_address")
                 .long("kadcast_public_address")
@@ -44,8 +45,7 @@ impl KadcastConfig {
     This address MUST be accessible from any peer of the network")
                 .help("Public address you want to be identified with. Eg: 193.xxx.xxx.198:9999")
                 .env("KADCAST_PUBLIC_ADDRESS")
-                .takes_value(true)
-                .required(false),
+                .num_args(1)
         )
         .arg(
             Arg::new("kadcast_listen_address")
@@ -56,25 +56,17 @@ impl KadcastConfig {
     If this is not specified, the public address is used for binding incoming connection")
                 .help("Optional internal address to listen incoming connections. Eg: 127.0.0.1:9999")
                 .env("KADCAST_LISTEN_ADDRESS")
-                .takes_value(true)
-                .required(false),
+                .num_args(1)
+
         )
         .arg(
             Arg::new("kadcast_bootstrap")
                 .long("kadcast_bootstrap")
                 .env("KADCAST_BOOTSTRAP")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .help("Kadcast list of bootstrapping server addresses")
-                .takes_value(true)
-                .required(false),
-        )
-        .arg(
-            Arg::new("kadcast_autobroadcast")
-                .long("kadcast_autobroadcast")
-                .env("KADCAST_AUTOBROADCAST")
-                .help("If used then the received messages are automatically re-broadcasted")
-                .takes_value(false)
-                .required(false),
+                .num_args(1)
+
         )
     }
 }

--- a/rusk/src/bin/ephemeral.rs
+++ b/rusk/src/bin/ephemeral.rs
@@ -13,16 +13,15 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 use tracing::error;
 
-pub(crate) fn inject_args(command: Command<'_>) -> Command<'_> {
+pub(crate) fn inject_args(command: Command) -> Command {
     command.arg(
         Arg::new("state_file")
             .long("state")
             .short('s')
             .env("RUSK_STATE_FILE")
             .help("Ephemeral state file (archive)")
-            .takes_value(true)
-            .value_parser(value_parser!(PathBuf))
-            .required(false),
+            .num_args(1)
+            .value_parser(value_parser!(PathBuf)),
     )
 }
 

--- a/rusk/src/bin/ephemeral.rs
+++ b/rusk/src/bin/ephemeral.rs
@@ -4,7 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use clap::{value_parser, Arg, Command};
 use rusk_recovery_tools::state::tar;
 use std::env;
 use std::fs::File;
@@ -12,18 +11,6 @@ use std::io::{Read, Result};
 use std::path::PathBuf;
 use tempfile::TempDir;
 use tracing::error;
-
-pub(crate) fn inject_args(command: Command) -> Command {
-    command.arg(
-        Arg::new("state_file")
-            .long("state")
-            .short('s')
-            .env("RUSK_STATE_FILE")
-            .help("Ephemeral state file (archive)")
-            .num_args(1)
-            .value_parser(value_parser!(PathBuf)),
-    )
-}
 
 pub(crate) fn configure(state_zip: &PathBuf) -> Result<Option<TempDir>> {
     let tmpdir = tempfile::tempdir()?;

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let crate_name = &crate_info.crate_name.to_string();
     let version = show_version(crate_info);
     let command = Command::new(crate_name)
-        .version(version.as_str())
+        .version(version)
         .author("Dusk Network B.V. All Rights Reserved.")
         .about("Rusk Server node.")
         .arg(
@@ -47,8 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .short('c')
                 .env("RUSK_CONFIG_TOML")
                 .help("Configuration file path")
-                .takes_value(true)
-                .required(false),
+                .num_args(1),
         );
 
     #[cfg(feature = "ephemeral")]
@@ -111,7 +110,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let service_list: Vec<Box<Services>> = vec![
         Box::<MempoolSrv>::default(),
         Box::new(ChainSrv::new(config.chain.consensus_keys_path())),
-        Box::new(DataBrokerSrv::new(config.databroker())),
+        Box::new(DataBrokerSrv::new(config.clone().databroker.into())),
     ];
 
     #[cfg(feature = "ephemeral")]

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -4,19 +4,20 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![feature(lazy_cell)]
+
+mod args;
 mod config;
 #[cfg(feature = "ephemeral")]
 mod ephemeral;
 mod version;
 
-use clap::{Arg, Command};
+use clap::Parser;
 use node::database::rocksdb;
 use node::database::DB;
 use node::LongLivedService;
 use rusk::http::DataSources;
 use rusk::{Result, Rusk};
-use rustc_tools_util::get_version_info;
-use version::show_version;
 
 use tracing_subscriber::filter::EnvFilter;
 
@@ -34,26 +35,8 @@ use crate::config::Config;
 // `dusk_consensus::config`.
 #[tokio::main(flavor = "multi_thread", worker_threads = 8)]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let crate_info = get_version_info!();
-    let crate_name = &crate_info.crate_name.to_string();
-    let version = show_version(crate_info);
-    let command = Command::new(crate_name)
-        .version(version)
-        .author("Dusk Network B.V. All Rights Reserved.")
-        .about("Rusk Server node.")
-        .arg(
-            Arg::new("config")
-                .long("config")
-                .short('c')
-                .env("RUSK_CONFIG_TOML")
-                .help("Configuration file path")
-                .num_args(1),
-        );
+    let args = args::Args::parse();
 
-    #[cfg(feature = "ephemeral")]
-    let command = ephemeral::inject_args(command);
-    let command = Config::inject_args(command);
-    let args = command.get_matches();
     let config = Config::from(&args);
 
     let log = config.log_level();
@@ -90,8 +73,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     #[cfg(feature = "ephemeral")]
-    let tempdir = match args.get_one::<std::path::PathBuf>("state_file") {
-        Some(state_zip) => ephemeral::configure(state_zip)?,
+    let tempdir = match args.state_path {
+        Some(state_zip) => ephemeral::configure(&state_zip)?,
         None => None,
     };
 

--- a/rusk/src/bin/version.rs
+++ b/rusk/src/bin/version.rs
@@ -7,6 +7,8 @@
 //! Helper functions to get the proper version of the crate to be
 //! displayed.
 
+use std::sync::LazyLock;
+
 use rustc_tools_util::VersionInfo;
 
 #[inline]
@@ -24,3 +26,8 @@ pub(crate) fn show_version(info: VersionInfo) -> String {
         version
     }
 }
+
+pub static VERSION_BUILD: LazyLock<String> = LazyLock::new(|| {
+    let info = rustc_tools_util::get_version_info!();
+    show_version(info)
+});


### PR DESCRIPTION
### `node`
- remove `clap` dependencies

### `rusk-recovery`
- update `clap` to 4.x

### `rusk`
- update `clap` to 4.x
- use `clap` derive for CLI args

Resolves #778 