### PR TITLE
Fix node compilation

### DIFF
--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -22,7 +22,7 @@ dusk-bytes = "0.1"
 bytecheck = { version = "0.6", default-features = false }
 dusk-plonk = { version = "0.14", default-features = false, features = ["rkyv-impl", "alloc"] }
 
-piecrust-uplink = "0.8.0-rc"
+piecrust-uplink = "=0.8.0-rc.0"
 piecrust = { version = "0.10.1-rc", optional = true }
 
 # These are patches since these crates don't seem to like semver.

--- a/rusk/src/bin/config/http.rs
+++ b/rusk/src/bin/config/http.rs
@@ -8,11 +8,24 @@ use serde::{Deserialize, Serialize};
 
 use crate::args::Args;
 
-#[derive(Serialize, Deserialize, Clone, Default)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct HttpConfig {
-    #[serde(default = "bool::default")]
+    #[serde(default = "default_listen")]
     pub listen: bool,
     listen_address: Option<String>,
+}
+
+impl Default for HttpConfig {
+    fn default() -> Self {
+        Self {
+            listen: default_listen(),
+            listen_address: None,
+        }
+    }
+}
+
+const fn default_listen() -> bool {
+    true
 }
 
 impl HttpConfig {


### PR DESCRIPTION
### rusk-abi
Force `piecrust-uplink` to be on RC #1088
### rusk
Fix default HTTP_Listener #1087
