### PR TITLE
rusk-abi: Update dependencies

### DIFF
--- a/rusk-abi/CHANGELOG.md
+++ b/rusk-abi/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `dusk-bls12_381` from `0.11` to `0.12`
+- Update `dusk-bls12_381-sign` from `0.4` to `0.15`
+- Update `dusk-jubjub` from `0.12` to `0.13`
+- Update `dusk-poseidon` from `0.30` to `0.31`
+- Update `dusk-pki` from `0.12` to `0.13`
+- Update `dusk-plonk` from `0.14` to `0.16`
+
+### Added
+
+- Add `ff` dev-dependency `0.13`
+
+### Changed
+
 - Update `piecrust` from `0.8.0-rc` to `0.10`
 - Update `piecrust` from `0.7` to `0.8.0-rc`
 - Update `piecrust` from `0.6` to `0.7`

--- a/rusk-abi/CHANGELOG.md
+++ b/rusk-abi/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2023-10-12
+
 ### Changed
 
 - Update `dusk-bls12_381` from `0.11` to `0.12`
@@ -201,7 +203,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#227]: https://github.com/dusk-network/rusk/issues/227
 [#254]: https://github.com/dusk-network/rusk/issues/254
 
-[Unreleased]: https://github.com/dusk-network/dusk-abi/compare/rusk-abi-0.10.0-piecrust.0.6...HEAD
+[Unreleased]: https://github.com/dusk-network/dusk-abi/compare/rusk-abi-0.11.0...HEAD
+[0.11.0]: https://github.com/dusk-network/dusk-abi/compare/rusk-abi-0.10.0-piecrust.0.6...rusk-abi-0.11.0
 [0.10.0-piecrust.0.6]: https://github.com/dusk-network/dusk-abi/compare/rusk-abi-0.9.0-piecrust.0.6...rusk-abi-0.10.0-piecrust.0.6
 [0.9.0-piecrust.0.6]: https://github.com/dusk-network/dusk-abi/compare/rusk-abi-0.8.0-piecrust.0.5...rusk-abi-0.9.0-piecrust.0.6
 [0.8.0-piecrust.0.5]: https://github.com/dusk-network/dusk-abi/compare/rusk-abi-0.8.0-alpha...rusk-abi-0.8.0-piecrust.0.5

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -12,15 +12,15 @@ exclude = [".github/workflows/ci.yml", ".gitignore"]
 blake2b_simd = { version = "1", default-features = false }
 cfg-if = "1"
 
-dusk-poseidon = { version = "0.30", default-features = false }
-dusk-bls12_381 = { version = "0.11", default-features = false, features = ["rkyv-impl"] }
-dusk-bls12_381-sign = { version = "0.4", features = ["rkyv-impl"] }
-dusk-schnorr = { version = "0.13", default-features = false, features = ["rkyv-impl"] }
-dusk-pki = { version = "0.12", default-features = false, features = ["rkyv-impl"] }
-dusk-jubjub = { version = "0.12", default-features = false, features = ["rkyv-impl"] }
+dusk-poseidon = { version = "0.31", default-features = false }
+dusk-bls12_381 = { version = "0.12", default-features = false, features = ["rkyv-impl"] }
+dusk-bls12_381-sign = { version = "0.5", features = ["rkyv-impl"] }
+dusk-schnorr = { version = "0.14", default-features = false, features = ["rkyv-impl"] }
+dusk-pki = { version = "0.13", default-features = false, features = ["rkyv-impl"] }
+dusk-jubjub = { version = "0.13", default-features = false, features = ["rkyv-impl"] }
 dusk-bytes = "0.1"
 bytecheck = { version = "0.6", default-features = false }
-dusk-plonk = { version = "0.14", default-features = false, features = ["rkyv-impl", "alloc"] }
+dusk-plonk = { version = "0.16", default-features = false, features = ["rkyv-impl", "alloc"] }
 
 piecrust-uplink = "=0.8.0-rc.0"
 piecrust = { version = "0.10.1-rc", optional = true }
@@ -32,6 +32,7 @@ wasmer = { version = "=3.1", optional = true }
 [dev-dependencies]
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 once_cell = "1.15"
+ff = { version = "0.13", default-features = false }
 
 [features]
 # By default we include the contract writing features.

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-abi"
-version = "0.10.0-piecrust.0.6"
+version = "0.11.0"
 edition = "2021"
 
 repository = "https://github.com/dusk-network/rusk"

--- a/rusk-abi/src/host.rs
+++ b/rusk-abi/src/host.rs
@@ -151,7 +151,7 @@ pub fn verify_proof(
     let mut pis = Vec::with_capacity(n_pi);
 
     public_inputs.into_iter().for_each(|pi| match pi {
-        PublicInput::Point(p) => pis.extend([p.get_x(), p.get_y()]),
+        PublicInput::Point(p) => pis.extend([p.get_u(), p.get_v()]),
         PublicInput::BlsScalar(s) => pis.push(s),
         PublicInput::JubJubScalar(s) => {
             let s: BlsScalar = s.into();

--- a/rusk-abi/tests/contracts/host_fn/Cargo.toml
+++ b/rusk-abi/tests/contracts/host_fn/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-dusk-bls12_381 = { version = "0.11", default-features = false, features = ["rkyv-impl"] }
-dusk-bls12_381-sign = { version = "0.4", default-features = false, features = ["rkyv-impl"] }
-dusk-jubjub = { version = "0.12", default-features = false, features = ["rkyv-impl"] }
-dusk-schnorr = { version = "0.13", default-features = false, features = ["rkyv-impl"] }
-dusk-pki = { version = "0.12", default-features = false, features = ["rkyv-impl"] }
+dusk-bls12_381 = { version = "0.12", default-features = false, features = ["rkyv-impl"] }
+dusk-bls12_381-sign = { version = "0.5", default-features = false, features = ["rkyv-impl"] }
+dusk-jubjub = { version = "0.13", default-features = false, features = ["rkyv-impl"] }
+dusk-schnorr = { version = "0.14", default-features = false, features = ["rkyv-impl"] }
+dusk-pki = { version = "0.13", default-features = false, features = ["rkyv-impl"] }
 dusk-bytes = "0.1"
-dusk-plonk = { version = "0.14", default-features = false, features = ["rkyv-impl", "alloc"] }
+dusk-plonk = { version = "0.16", default-features = false, features = ["rkyv-impl", "alloc"] }
 rusk-abi = { version = "0.10.0-piecrust.0.6", path = "../../.." }

--- a/rusk-abi/tests/lib.rs
+++ b/rusk-abi/tests/lib.rs
@@ -19,6 +19,7 @@ use dusk_bytes::{ParseHexStr, Serializable};
 use dusk_pki::{PublicKey, PublicSpendKey, SecretKey, SecretSpendKey};
 use dusk_plonk::prelude::*;
 use dusk_schnorr::Signature;
+use ff::Field;
 use rusk_abi::hash::Hasher;
 use rusk_abi::PublicInput;
 use rusk_abi::{ContractData, ContractId, Session, VM};
@@ -44,8 +45,8 @@ fn hash_host() {
     }
 
     assert_eq!(
-        "0xb9cd735f1296d450b8c5c4b49b07e036b3086ee0e206d22325ecc30467c5170e",
-        format!("{:#x}", Hasher::digest(input))
+        "0x0e17c56704c3ec2523d206e2e06e08b336e0079bb4c4c5b850d496125f73cdb9",
+        format!("{:?}", Hasher::digest(input))
     );
 }
 
@@ -100,8 +101,8 @@ fn hash() {
         .data;
 
     assert_eq!(
-        "0xb9cd735f1296d450b8c5c4b49b07e036b3086ee0e206d22325ecc30467c5170e",
-        format!("{scalar:#x}")
+        "0x0e17c56704c3ec2523d206e2e06e08b336e0079bb4c4c5b850d496125f73cdb9",
+        format!("{scalar:?}")
     );
 }
 
@@ -128,8 +129,8 @@ fn poseidon_hash() {
         .data;
 
     assert_eq!(
-        "0xe36f4ea9b858d5c85b02770823c7c5d8253c28787d17f283ca348b906dca8528",
-        format!("{scalar:#x}")
+        "0x2885ca6d908b34ca83f2177d78283c25d8c5c7230877025bc8d558b8a94e6fe3",
+        format!("{scalar:?}")
     );
 }
 


### PR DESCRIPTION
- Update `dusk-bls12_381` from `0.11` to `0.12`
- Update `dusk-bls12_381-sign` from `0.4` to `0.15`
- Update `dusk-jubjub` from `0.12` to `0.13`
- Update `dusk-poseidon` from `0.30` to `0.31`
- Update `dusk-pki` from `0.12` to `0.13`
- Update `dusk-plonk` from `0.14` to `0.16`
- Update `piecrust` from `0.10` to `0.11`
- Update `piecrust-uplink` from `0.7` to `0.8`
- Add `ff` dev-dependency `0.13`