### PR TITLE
License contract test upgrade to zk_citadel 0.5.0

### DIFF
--- a/contracts/license/Cargo.toml
+++ b/contracts/license/Cargo.toml
@@ -24,6 +24,7 @@ rusk-abi = { version = "0.11", path = "../../rusk-abi" }
 
 [dev-dependencies]
 rusk-abi = { version = "0.11", path = "../../rusk-abi", default-features = false, features = ["host"] }
+rusk-profile = { path = "../../rusk-profile" }
 license-circuits = { version = "0.1", path = "../../circuits/license" }
 rkyv = { version = "0.7", default-features = false }
 hex = "0.4"


### PR DESCRIPTION
License contract test upgrade to zk_citadel 0.5.0,
Fixes issue with setting public parameters in test.

Implements #1082
