### PR TITLE
Remove fixed fee

### DIFF
--- a/contracts/stake/src/lib.rs
+++ b/contracts/stake/src/lib.rs
@@ -31,7 +31,7 @@ static mut STATE: StakeState = StakeState::new();
 #[no_mangle]
 unsafe fn stake(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |arg| {
-        assert_external_caller();
+        assert_transfer_caller();
         STATE.stake(arg)
     })
 }
@@ -39,7 +39,7 @@ unsafe fn stake(arg_len: u32) -> u32 {
 #[no_mangle]
 unsafe fn unstake(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |arg| {
-        assert_external_caller();
+        assert_transfer_caller();
         STATE.unstake(arg)
     })
 }
@@ -47,7 +47,7 @@ unsafe fn unstake(arg_len: u32) -> u32 {
 #[no_mangle]
 unsafe fn withdraw(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |arg| {
-        assert_external_caller();
+        assert_transfer_caller();
         STATE.withdraw(arg)
     })
 }
@@ -55,7 +55,7 @@ unsafe fn withdraw(arg_len: u32) -> u32 {
 #[no_mangle]
 unsafe fn allow(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |arg| {
-        assert_external_caller();
+        assert_transfer_caller();
         STATE.allow(arg)
     })
 }
@@ -123,6 +123,16 @@ unsafe fn add_owner(arg_len: u32) -> u32 {
         assert_external_caller();
         STATE.add_owner(pk);
     })
+}
+
+/// Asserts the call is made via the transfer contract.
+///
+/// # Panics
+/// When the `caller` is not [`rusk_abi::TRANSFER_CONTRACT`].
+fn assert_transfer_caller() {
+    if rusk_abi::caller() != rusk_abi::TRANSFER_CONTRACT {
+        panic!("Can only be called from the transfer contract");
+    }
 }
 
 /// Asserts the call is made "from the outside", meaning that it's not an

--- a/contracts/stake/tests/stake.rs
+++ b/contracts/stake/tests/stake.rs
@@ -19,8 +19,8 @@ use poseidon_merkle::Opening as PoseidonOpening;
 use rand::rngs::StdRng;
 use rand::{CryptoRng, RngCore, SeedableRng};
 use rusk_abi::dusk::{dusk, LUX};
-use rusk_abi::{ContractData, Error, Session, VM};
-use rusk_abi::{ContractId, STAKE_CONTRACT, TRANSFER_CONTRACT};
+use rusk_abi::{ContractData, ContractError, Error, RawResult, Session, VM};
+use rusk_abi::{STAKE_CONTRACT, TRANSFER_CONTRACT};
 use transfer_circuits::{
     CircuitInput, CircuitInputSignature, ExecuteCircuitOneTwo,
     ExecuteCircuitThreeTwo, ExecuteCircuitTwoTwo,
@@ -29,7 +29,6 @@ use transfer_circuits::{
 
 const GENESIS_VALUE: u64 = dusk(1_000_000.0);
 const POINT_LIMIT: u64 = 0x100000000;
-const GAS_PER_TX: u64 = 10_000;
 
 type Result<T, E = Error> = core::result::Result<T, E>;
 
@@ -165,25 +164,14 @@ fn filter_notes_owned_by<I: IntoIterator<Item = Note>>(
 
 /// Executes a transaction, returning the gas spent.
 fn execute(session: &mut Session, tx: Transaction) -> Result<u64> {
-    session.call::<_, ()>(TRANSFER_CONTRACT, "spend", &tx, u64::MAX)?;
+    let receipt = session.call::<_, Result<RawResult, ContractError>>(
+        TRANSFER_CONTRACT,
+        "spend_and_execute",
+        &tx,
+        tx.fee.gas_limit,
+    )?;
 
-    let mut gas_spent = GAS_PER_TX;
-    if let Some((contract_id, fn_name, fn_data)) = &tx.call {
-        let gas_limit = tx.fee.gas_limit - GAS_PER_TX;
-
-        let contract_id = ContractId::from_bytes(*contract_id);
-        println!("Calling '{fn_name}' of {contract_id} with {gas_limit} gas");
-
-        let r = session.call_raw(
-            contract_id,
-            fn_name,
-            fn_data.clone(),
-            gas_limit,
-        )?;
-        println!("{r:?}");
-
-        gas_spent += r.points_spent;
-    }
+    let gas_spent = receipt.points_spent;
 
     session
         .call::<_, ()>(

--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -105,10 +105,10 @@ unsafe fn leaves_from_pos(arg_len: u32) -> u32 {
 // "Management" transactions
 
 #[no_mangle]
-unsafe fn spend(arg_len: u32) -> u32 {
+unsafe fn spend_and_execute(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |tx| {
         assert_external_caller();
-        STATE.spend(tx)
+        STATE.spend_and_execute(tx)
     })
 }
 

--- a/rusk/tests/services/gas_behavior.rs
+++ b/rusk/tests/services/gas_behavior.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, RwLock};
 use dusk_wallet_core::{self as wallet};
 use rand::prelude::*;
 use rand::rngs::StdRng;
-use rusk::{Result, Rusk, GAS_PER_INPUT};
+use rusk::{Result, Rusk};
 use rusk_abi::TRANSFER_CONTRACT;
 use tempfile::tempdir;
 use tracing::info;
@@ -21,11 +21,11 @@ use crate::common::state::{generator_procedure, new_state};
 use crate::common::wallet::{TestProverClient, TestStateClient, TestStore};
 
 const BLOCK_HEIGHT: u64 = 1;
-const BLOCK_GAS_LIMIT: u64 = 1_000_000_000;
+const BLOCK_GAS_LIMIT: u64 = 1_000_000_000_000;
 const INITIAL_BALANCE: u64 = 10_000_000_000;
 
-const GAS_LIMIT_0: u64 = 2_000_000;
-const GAS_LIMIT_1: u64 = 100_000_000;
+const GAS_LIMIT_0: u64 = 7_000_000;
+const GAS_LIMIT_1: u64 = 200_000_000;
 
 // Creates the Rusk initial state for the tests below
 fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
@@ -73,14 +73,14 @@ fn make_transactions(
 
     let mut rng = StdRng::seed_from_u64(0xdead);
 
-    // The first transaction will be a `wallet.execute` to a contract that is
-    // not deployed. This will produce an error in call execution and should
-    // consume all the gas provided.
+    // The first transaction will be a `wallet.execute` to the transfer
+    // contract, querying for the root of the tree. This will be given too
+    // little gas to execute correctly and error, consuming all gas provided.
     let tx_0 = wallet
         .execute(
             &mut rng,
-            [0x42; 32].into(),
-            String::from("nonsense"),
+            TRANSFER_CONTRACT.to_bytes().into(),
+            String::from("root"),
             (),
             SENDER_INDEX_0,
             &refund_0,
@@ -89,9 +89,9 @@ fn make_transactions(
         )
         .expect("Making the transaction should succeed");
 
-    // The second transaction will also be a `wallet.execute`, but this time to
-    // the transfer contract, querying for the root of the tree. This will be
-    // tested for gas cost.
+    // The second transaction will also be a `wallet.execute` to the transfer
+    // contract, querying for the root of the tree. This will be tested for
+    // gas cost.
     let tx_1 = wallet
         .execute(
             &mut rng,
@@ -105,7 +105,7 @@ fn make_transactions(
         )
         .expect("Making the transaction should succeed");
 
-    generator_procedure(
+    let spent_transactions = generator_procedure(
         rusk,
         &[tx_0, tx_1],
         BLOCK_HEIGHT,
@@ -114,31 +114,24 @@ fn make_transactions(
     )
     .expect("generator procedure should succeed");
 
-    let final_balance_0 = wallet
-        .get_balance(SENDER_INDEX_0)
-        .expect("Getting final balance should succeed")
-        .value;
+    let mut spent_transactions = spent_transactions.into_iter();
+    let tx_0 = spent_transactions
+        .next()
+        .expect("There should be two spent transactions");
+    let tx_1 = spent_transactions
+        .next()
+        .expect("There should be two spent transactions");
 
-    let final_balance_1 = wallet
-        .get_balance(SENDER_INDEX_1)
-        .expect("Getting final balance should succeed")
-        .value;
+    assert!(tx_0.err.is_some(), "The first transaction should error");
+    assert!(tx_1.err.is_none(), "The second transaction should succeed");
 
-    // The first transaction should consume all gas given, while the second one
-    // should consume a little more due to the root query.
     assert_eq!(
-        final_balance_0,
-        initial_balance_0 - GAS_LIMIT_0,
-        "Transaction should consume all the gas"
-    );
-
-    assert!(
-        final_balance_1 < initial_balance_1 - GAS_PER_INPUT,
-        "Transaction should consume more gas than just for one input"
+        tx_0.gas_spent, GAS_LIMIT_0,
+        "Erroring transaction should consume all gas"
     );
     assert!(
-        final_balance_1 > GAS_LIMIT_1,
-        "Transaction should consume less gas than all given"
+        tx_1.gas_spent < GAS_LIMIT_1,
+        "Successful transaction should consume less than provided"
     );
 }
 

--- a/rusk/tests/services/multi_transfer.rs
+++ b/rusk/tests/services/multi_transfer.rs
@@ -25,8 +25,8 @@ use crate::common::wallet::{TestProverClient, TestStateClient, TestStore};
 const BLOCK_HEIGHT: u64 = 1;
 // This is purposefully chosen to be low to trigger the discarding of a
 // perfectly good transaction.
-const BLOCK_GAS_LIMIT: u64 = 2_500_000;
-const GAS_LIMIT: u64 = 1_000_000;
+const BLOCK_GAS_LIMIT: u64 = 24_000_000;
+const GAS_LIMIT: u64 = 12_000_000; // Lowest value for a transfer
 const INITIAL_BALANCE: u64 = 10_000_000_000;
 
 // Creates the Rusk initial state for the tests below

--- a/rusk/tests/services/unspendable.rs
+++ b/rusk/tests/services/unspendable.rs
@@ -24,7 +24,7 @@ const BLOCK_HEIGHT: u64 = 1;
 const BLOCK_GAS_LIMIT: u64 = 1_000_000_000_000;
 const INITIAL_BALANCE: u64 = 10_000_000_000;
 
-const GAS_LIMIT_0: u64 = 1_000_000; // Enough to spend, but OOG during ICC
+const GAS_LIMIT_0: u64 = 20_000_000; // Enough to spend, but OOG during ICC
 const GAS_LIMIT_1: u64 = 1_000; // Not enough to spend
 const GAS_LIMIT_2: u64 = 200_000_000; // All ok
 


### PR DESCRIPTION
We substitute the `spend` function in the transfer contract for a `spend_and_execute` function, that also executes the contract call.

This fixes a bug where it was impossible to inform a genesis contract about whether they're being called in "management mode" by the VM - leading to sensitive functions being reachable by any contract call.

It also removes the fixed fee per transfer, since it was extremely artificial, and the regular transfer fee, while variable, is not much higher regardless.