### PR TITLE
HTTP: add API for CRS retrieval

### DIFF
--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -348,7 +348,7 @@ where
 
         Ok(response)
     } else {
-        let (execution_request, is_binary) =
+        let (execution_request, binary_resp) =
             MessageRequest::from_request(req).await?;
 
         let mut resp_headers = execution_request.x_headers();
@@ -361,7 +361,7 @@ where
             .await
             .expect("An execution should always return a response");
         resp_headers.extend(execution_response.headers.clone());
-        let mut resp = execution_response.into_http(is_binary)?;
+        let mut resp = execution_response.into_http(binary_resp)?;
 
         for (k, v) in resp_headers {
             let k = HeaderName::from_str(&k)?;

--- a/rusk/src/lib/http/rusk.rs
+++ b/rusk/src/lib/http/rusk.rs
@@ -54,6 +54,7 @@ impl Rusk {
             (Target::Host(_), "rusk", "provisioners") => {
                 self.get_provisioners()
             }
+            (Target::Host(_), "rusk", "crs") => self.get_crs(),
             _ => Err(anyhow::anyhow!("Unsupported")),
         }
     }
@@ -122,6 +123,11 @@ impl Rusk {
             .collect();
 
         Ok(serde_json::to_value(prov)?.into())
+    }
+
+    fn get_crs(&self) -> anyhow::Result<ResponseData> {
+        let crs = rusk_profile::get_common_reference_string()?;
+        Ok(crs.into())
     }
 }
 


### PR DESCRIPTION
A new topic `crs` has been added under the `rusk` target.
Like all other binary response, if the request is in json format instead of [binary format](https://github.com/dusk-network/rusk/wiki/Rusk-Event-System#messages-serialization), the crs is returned as hex representation.

However, with the current PR, this mechanism can be override using `Accept: application/octet-stream'` request header
When the aforementioned header is specified, `BinaryResponse`s are not converted to hex

Below an example to properly download a setup crs from a running node

```shell
curl --location --request POST 'http://127.0.0.1:8080/02/rusk' \
--header 'Accept: application/octet-stream' \
--data-raw '{"topic": "crs","data": ""}' \
--output setup.crs
```


Resolves #1119 