### PR TITLE
rusk: add hash header to the CRS-via-HTTP api

### DIFF
--- a/rusk-profile/src/lib.rs
+++ b/rusk-profile/src/lib.rs
@@ -19,7 +19,8 @@ pub use theme::Theme;
 mod circuit;
 pub use circuit::Circuit;
 
-static CRS_17: &str =
+/// HEX representaion of the SHA-256 hash of the CRS uncompressed bytes.
+pub static CRS_17_HASH: &str =
     "18b48f588fd4d1e88ef9e7b3cacfa29046f6f489c5c237a4b01ee4f0334772a5";
 
 const CRS_FNAME: &str = "dev-piecrust.crs";
@@ -179,7 +180,7 @@ pub fn verify_common_reference_string(buff: &[u8]) -> bool {
     hasher.update(buff);
     let hash = format!("{:x}", hasher.finalize());
 
-    hash == CRS_17
+    hash == CRS_17_HASH
 }
 
 pub fn clean_outdated(circuits: &[Circuit]) -> io::Result<()> {

--- a/rusk/src/lib/http/chain.rs
+++ b/rusk/src/lib/http/chain.rs
@@ -23,7 +23,8 @@ use async_graphql::{
 use serde_json::json;
 
 use super::event::{
-    Event, MessageRequest, MessageResponse, RequestData, ResponseData, Target,
+    DataType, Event, MessageRequest, MessageResponse, RequestData,
+    ResponseData, Target,
 };
 use crate::http::RuskNode;
 use crate::{VERSION, VERSION_BUILD};
@@ -78,7 +79,7 @@ impl RuskNode {
             .finish();
 
         if gql_query.trim().is_empty() {
-            return Ok(schema.sdl().into());
+            return Ok(ResponseData::new(schema.sdl()));
         }
 
         let variables = variables_from_request(request);
@@ -92,7 +93,7 @@ impl RuskNode {
         }
         let data = serde_json::to_value(&data)
             .map_err(|e| anyhow::anyhow!("Cannot parse response {e}"))?;
-        Ok(data.into())
+        Ok(ResponseData::new(data))
     }
 
     async fn propagate_tx(&self, tx: &[u8]) -> anyhow::Result<ResponseData> {
@@ -104,13 +105,13 @@ impl RuskNode {
         let network = self.0.network();
         network.read().await.route_internal(tx_message);
 
-        Ok(ResponseData::None)
+        Ok(ResponseData::new(DataType::None))
     }
 
     async fn alive_nodes(&self, amount: usize) -> anyhow::Result<ResponseData> {
         let nodes = self.0.network().read().await.alive_nodes(amount).await;
         let nodes: Vec<_> = nodes.iter().map(|n| n.to_string()).collect();
-        Ok(serde_json::to_value(nodes)?.into())
+        Ok(ResponseData::new(serde_json::to_value(nodes)?))
     }
 
     async fn get_info(&self) -> anyhow::Result<ResponseData> {
@@ -123,6 +124,6 @@ impl RuskNode {
         info.insert("chain_id", n_conf.kadcast_id.into());
         info.insert("kadcast_address", n_conf.public_address.into());
 
-        Ok(serde_json::to_value(&info)?.into())
+        Ok(ResponseData::new(serde_json::to_value(&info)?))
     }
 }

--- a/rusk/src/lib/http/rusk.rs
+++ b/rusk/src/lib/http/rusk.rs
@@ -17,7 +17,8 @@ use rusk_abi::ContractId;
 use crate::Rusk;
 
 use super::event::{
-    Event, MessageRequest, MessageResponse, RequestData, ResponseData, Target,
+    DataType, Event, MessageRequest, MessageResponse, RequestData,
+    ResponseData, Target,
 };
 
 const RUSK_FEEDER_HEADER: &str = "Rusk-Feeder";
@@ -36,20 +37,22 @@ impl Rusk {
                 self.handle_preverify(request.event_data())
             }
             (Target::Host(_), "rusk", "prove_execute") => {
-                Ok(LocalProver.prove_execute(request.event_data())?.into())
+                Ok(ResponseData::new(
+                    LocalProver.prove_execute(request.event_data())?,
+                ))
             }
-            (Target::Host(_), "rusk", "prove_stct") => {
-                Ok(LocalProver.prove_stct(request.event_data())?.into())
-            }
-            (Target::Host(_), "rusk", "prove_stco") => {
-                Ok(LocalProver.prove_stco(request.event_data())?.into())
-            }
-            (Target::Host(_), "rusk", "prove_wfct") => {
-                Ok(LocalProver.prove_wfct(request.event_data())?.into())
-            }
-            (Target::Host(_), "rusk", "prove_wfco") => {
-                Ok(LocalProver.prove_wfco(request.event_data())?.into())
-            }
+            (Target::Host(_), "rusk", "prove_stct") => Ok(ResponseData::new(
+                LocalProver.prove_stct(request.event_data())?,
+            )),
+            (Target::Host(_), "rusk", "prove_stco") => Ok(ResponseData::new(
+                LocalProver.prove_stco(request.event_data())?,
+            )),
+            (Target::Host(_), "rusk", "prove_wfct") => Ok(ResponseData::new(
+                LocalProver.prove_wfct(request.event_data())?,
+            )),
+            (Target::Host(_), "rusk", "prove_wfco") => Ok(ResponseData::new(
+                LocalProver.prove_wfco(request.event_data())?,
+            )),
 
             (Target::Host(_), "rusk", "provisioners") => {
                 self.get_provisioners()
@@ -86,7 +89,7 @@ impl Rusk {
                     sender,
                 );
             });
-            Ok(ResponseData::Channel(receiver))
+            Ok(ResponseData::new(receiver))
         } else {
             let data = self
                 .query_raw(
@@ -95,7 +98,7 @@ impl Rusk {
                     event.data.as_bytes(),
                 )
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
-            Ok(data.into())
+            Ok(ResponseData::new(data))
         }
     }
 
@@ -103,7 +106,7 @@ impl Rusk {
         let tx = phoenix_core::Transaction::from_slice(data)
             .map_err(|e| anyhow::anyhow!("Invalid Data {e:?}"))?;
         self.preverify(&tx.into())?;
-        Ok(ResponseData::None)
+        Ok(ResponseData::new(DataType::None))
     }
 
     fn get_provisioners(&self) -> anyhow::Result<ResponseData> {
@@ -122,12 +125,12 @@ impl Rusk {
             })
             .collect();
 
-        Ok(serde_json::to_value(prov)?.into())
+        Ok(ResponseData::new(serde_json::to_value(prov)?))
     }
 
     fn get_crs(&self) -> anyhow::Result<ResponseData> {
         let crs = rusk_profile::get_common_reference_string()?;
-        Ok(crs.into())
+        Ok(ResponseData::new(crs))
     }
 }
 

--- a/rusk/src/lib/http/rusk.rs
+++ b/rusk/src/lib/http/rusk.rs
@@ -6,6 +6,7 @@
 
 use dusk_bytes::Serializable;
 use node::vm::VMExecution;
+use rusk_profile::CRS_17_HASH;
 use rusk_prover::{LocalProver, Prover};
 use serde::Serialize;
 use std::sync::{mpsc, Arc};
@@ -130,7 +131,7 @@ impl Rusk {
 
     fn get_crs(&self) -> anyhow::Result<ResponseData> {
         let crs = rusk_profile::get_common_reference_string()?;
-        Ok(ResponseData::new(crs))
+        Ok(ResponseData::new(crs).with_header("crs-hash", CRS_17_HASH))
     }
 }
 


### PR DESCRIPTION
Below the example with the new header

```sh 
curl --location --request POST 'http://127.0.0.1:8080/02/rusk' \
--header 'Accept: application/octet-stream' \
--data-raw '{"topic": "crs","data": ""}' \
-v --output setup.crs

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:8080...
* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
> POST /02/rusk HTTP/1.1
> Host: 127.0.0.1:8080
> User-Agent: curl/7.87.0
> Accept: application/octet-stream
> Content-Length: 27
> Content-Type: application/x-www-form-urlencoded
> 
} [27 bytes data]
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< rusk-version: 0.7.0-rc.0
< crs-hash: 18b48f588fd4d1e88ef9e7b3cacfa29046f6f489c5c237a4b01ee4f0334772a5
< content-length: 12714911
< date: Tue, 14 Nov 2023 09:39:35 GMT
< 
{ [102216 bytes data]
100 12.1M  100 12.1M  100    27   561M   1250 --:--:-- --:--:-- --:--:--  757M
* Connection #0 to host 127.0.0.1 left intact
```

Resolves #1135 