### PR TITLE
Add benchmark for certificate verification

### DIFF
--- a/consensus/src/agreement/verifiers.rs
+++ b/consensus/src/agreement/verifiers.rs
@@ -193,13 +193,13 @@ pub async fn verify_votes(
 
 impl Cluster<PublicKey> {
     fn aggregate_pks(&self) -> Result<dusk_bls12_381_sign::APK, Error> {
-        let pks: Vec<&dusk_bls12_381_sign::PublicKey> =
-            self.iter().map(|(pubkey, _)| pubkey.inner()).collect();
+        let pks: Vec<_> =
+            self.iter().map(|(pubkey, _)| *pubkey.inner()).collect();
 
         match pks.split_first() {
-            Some((&first, rest)) => {
+            Some((first, rest)) => {
                 let mut apk = dusk_bls12_381_sign::APK::from(first);
-                rest.iter().for_each(|&&p| apk.aggregate(&[p]));
+                apk.aggregate(rest);
                 Ok(apk)
             }
             None => Err(Error::EmptyApk),

--- a/consensus/src/user/cluster.rs
+++ b/consensus/src/user/cluster.rs
@@ -7,7 +7,7 @@
 use std::collections::btree_map::Iter;
 use std::collections::BTreeMap;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Cluster<T>(BTreeMap<T, usize>);
 
 impl<T> Cluster<T>

--- a/consensus/src/user/committee.rs
+++ b/consensus/src/user/committee.rs
@@ -22,14 +22,9 @@ pub struct Committee {
     cfg: sortition::Config,
 }
 
-impl Iterator for Committee {
-    type Item = PublicKey;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.members
-            .iter()
-            .next()
-            .map(|(public_key, _)| public_key.clone())
+impl Committee {
+    pub fn iter(&self) -> impl Iterator<Item = &PublicKey> {
+        self.members.keys()
     }
 }
 

--- a/consensus/src/user/provisioners.rs
+++ b/consensus/src/user/provisioners.rs
@@ -147,7 +147,7 @@ impl Provisioners {
     /// committee members for a given round, step and seed.
     ///
     /// Returns a vector of provisioners public keys.
-    pub fn create_committee(
+    pub(crate) fn create_committee(
         &mut self,
         cfg: &sortition::Config,
     ) -> Vec<PublicKey> {

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -41,9 +41,15 @@ node-data = { version = "0.1", path = "../node-data", features = ["faker"] }
 rand = "0.8"
 rand_core = "0.6"
 tempdir = "0.3"
+criterion = { version = "0.5", features = ["async_futures"] }
 
 [build-dependencies]
 rustc_tools_util = "=0.2.0"
 
 [features]
 with_telemetry = ["dep:console-subscriber"]
+
+
+[[bench]]
+name = "accept"
+harness = false

--- a/node/benches/accept.rs
+++ b/node/benches/accept.rs
@@ -1,0 +1,176 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::time::Duration;
+
+use node::chain;
+
+use criterion::async_executor::FuturesExecutor;
+use criterion::measurement::WallTime;
+use criterion::{
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion,
+};
+
+use dusk_bls12_381_sign::{
+    PublicKey as BlsPublicKey, SecretKey as BlsSecretKey,
+    Signature as BlsSignature,
+};
+use dusk_bytes::Serializable;
+use dusk_consensus::user::{
+    cluster::Cluster, committee::Committee, provisioners::Provisioners,
+    sortition::Config as SortitionConfig,
+};
+use node_data::{
+    bls::PublicKey,
+    ledger::{Certificate, Signature, StepVotes},
+    message,
+};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+fn create_step_votes(
+    seed: Signature,
+    round: u64,
+    block_hash: [u8; 32],
+    step: u8,
+    iteration: u8,
+    provisioners: Provisioners,
+    keys: &[(PublicKey, BlsSecretKey)],
+) -> StepVotes {
+    let sortition_config =
+        SortitionConfig::new(seed, round, iteration * 3 + step, 64);
+
+    let committee = Committee::new(
+        PublicKey::default(),
+        &mut provisioners.clone(),
+        sortition_config,
+    );
+
+    let hdr = message::Header {
+        round,
+        step: step % 3,
+        block_hash,
+        ..Default::default()
+    };
+    let mut signatures = vec![];
+    let mut cluster = Cluster::<PublicKey>::default();
+    for (pk, sk) in keys.iter() {
+        if let Some(weight) = committee.votes_for(pk) {
+            let sig = hdr.sign(sk, pk.inner());
+            signatures.push(BlsSignature::from_bytes(&sig).unwrap());
+            cluster.set_weight(pk, weight);
+        }
+    }
+
+    let bitset = committee.bits(&cluster);
+
+    let (first, rest) = signatures.split_first().unwrap();
+    let aggregate_signature = first.aggregate(rest).to_bytes();
+    StepVotes::new(aggregate_signature, bitset)
+}
+
+pub fn with_group<T, F>(name: &str, c: &mut Criterion, closure: F) -> T
+where
+    F: FnOnce(&mut BenchmarkGroup<WallTime>) -> T,
+{
+    let mut group = c.benchmark_group(name);
+    let r = closure(&mut group);
+    group.finish();
+    r
+}
+
+pub fn verify_block_cert(c: &mut Criterion) {
+    with_group("verify_block_cert", c, |group| {
+        for input in INPUTS {
+            group.measurement_time(Duration::from_secs(input.measurement_time));
+            let mut keys = vec![];
+            let mut provisioners = Provisioners::new();
+            let rng = &mut StdRng::seed_from_u64(0xbeef);
+            for _ in 0..input.provisioners {
+                let sk = BlsSecretKey::random(rng);
+                let pk = BlsPublicKey::from(&sk);
+                let pk = PublicKey::new(pk);
+                keys.push((pk.clone(), sk));
+                provisioners.add_member_with_value(pk, 1000000000000)
+            }
+            let height = 1;
+            let seed = Signature([5; 48]);
+            let block_hash = [1; 32];
+            let curr_public_key = keys.first().unwrap().0.clone();
+            let iteration = 0;
+            let mut cert = Certificate::default();
+
+            cert.first_reduction = create_step_votes(
+                seed,
+                height,
+                block_hash,
+                1,
+                iteration,
+                provisioners.clone(),
+                &keys[..],
+            );
+            cert.second_reduction = create_step_votes(
+                seed,
+                height,
+                block_hash,
+                2,
+                iteration,
+                provisioners.clone(),
+                &keys[..],
+            );
+            group.bench_function(
+                BenchmarkId::new(
+                    "verify_block_cert",
+                    format!("{} prov", input.provisioners),
+                ),
+                move |b| {
+                    b.to_async(FuturesExecutor).iter(|| {
+                        chain::verify_block_cert(
+                            seed,
+                            &provisioners,
+                            &curr_public_key,
+                            block_hash,
+                            height,
+                            &cert,
+                            iteration,
+                            true,
+                        )
+                    })
+                },
+            );
+        }
+    })
+}
+
+struct Input {
+    provisioners: usize,
+    measurement_time: u64, // secs
+}
+
+const INPUTS: &[Input] = &[
+    Input {
+        provisioners: 1,
+        measurement_time: 10,
+    },
+    Input {
+        provisioners: 30,
+        measurement_time: 10,
+    },
+    Input {
+        provisioners: 64,
+        measurement_time: 10,
+    },
+    Input {
+        provisioners: 256,
+        measurement_time: 15,
+    },
+    Input {
+        provisioners: 1000,
+        measurement_time: 15,
+    },
+];
+criterion_group!(benches, verify_block_cert);
+criterion_main!(benches);

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -43,6 +43,8 @@ use self::acceptor::{Acceptor, RevertTarget};
 use self::consensus::Task;
 use self::fsm::SimpleFSM;
 
+pub use acceptor::verify_block_cert;
+
 const TOPICS: &[u8] = &[
     Topics::Block as u8,
     Topics::NewBlock as u8,

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -558,7 +558,7 @@ pub(crate) async fn verify_block_header<DB: database::DB>(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn verify_block_cert(
+pub async fn verify_block_cert(
     curr_seed: Signature,
     curr_eligible_provisioners: &Provisioners,
     curr_public_key: &node_data::bls::PublicKey,

--- a/node/testbed.sh
+++ b/node/testbed.sh
@@ -1,89 +1,101 @@
-#!/bin/bash
-killall rusk-node
+	#!/bin/bash
+	killall rusk
 
-# Determines how many pre-loaded provisioners will be in use.
-PROV_NUM=$1
-MODE=$2
-BOOTSTRAP_ADDR="127.0.0.1:7000"
+	# Determines how many pre-loaded provisioners will be in use.
+	PROV_NUM=$1
+	MODE=$2
+	#GENESIS_PATH="/home/tech/repo/dusk-network/dusk-blockchain/harness/tests/rusk_localnet_state.toml"
+	GENESIS_PATH="./rusk-recovery/config/testnet.toml"
 
-# DUSK_WALLET_DIR is the path to the directory containing a set of consensus keys files.
-if [ -z "$DUSK_WALLET_DIR" ]; then
-    echo "Warning: DUSK_WALLET_DIR is not set"
-fi
+	#BOOTSTRAP_ADDR="127.0.0.1:10000"
+	BOOTSTRAP_ADDR="127.0.0.1:7000"
+	# DUSK_WALLET_DIR is the path to the directory containing a set of consensus keys files.
+	if [ -z "$DUSK_WALLET_DIR" ]; then
+	    echo "Warning: DUSK_WALLET_DIR is not set"
+	fi
 
-# Create a temporary directory.
-TEMPD=/tmp/rust-harness/
-rm -fr $TEMPD
-mkdir $TEMPD
+	# Create a temporary directory.`
+	TEMPD=/tmp/rust-harness/
+	rm -fr $TEMPD
+	mkdir $TEMPD
 
-# Exit if the temp directory wasn't created successfully.
-if [ ! -e "$TEMPD" ]; then
-    >&2 echo "Failed to create temp directory"
-    exit 1
-fi
+	# Exit if the temp directory wasn't created successfully.
+	if [ ! -e "$TEMPD" ]; then
+	    >&2 echo "Failed to create temp directory"
+	    exit 1
+	fi
 
-echo "test harness folder:$TEMPD"
+	echo "test harness folder:$TEMPD"
 
-run_node() {
-  if [ "$MODE" = "--with_telemetry" ]; then
-    run_node_with_telemetry "$@"
-  else
-    run_node_debug_mode "$@"
-  fi
-}
+	run_node() {
+	  if [ "$MODE" = "--with_telemetry" ]; then
+	    run_node_with_telemetry "$@"
+	  else
+	    run_node_debug_mode "$@"
+	  fi
+	}
 
-run_node_debug_mode() {
-  local BOOTSTRAP_ADDR="$1"
-  local PUBLIC_ADDR="$2"
-  local LOG_LEVEL="$3"
-  local KEYS_PATH="$4"
-  local ID="$5"
-  local TEMPD="$6"
+	run_node_debug_mode() {
+	  local BOOTSTRAP_ADDR="$1"
+	  local PUBLIC_ADDR="$2"
+	  local LOG_LEVEL="$3"
+	  local KEYS_PATH="$4"
+	  local ID="$5"
+	  local TEMPD="$6"
+	  local WS_LISTEN_ADDR="$7"
 
-  echo "starting node $ID ..."
-  cargo run --release --bin rusk-node -- --kadcast_bootstrap "$BOOTSTRAP_ADDR" --kadcast_public_address "$PUBLIC_ADDR" --log-level="$LOG_LEVEL" --consensus-keys-path="${KEYS_PATH}/node_$ID.keys" --db-path="${TEMPD}/db/${ID}" --delay_on_resp_msg=10 --config="default.config.toml" > "${TEMPD}/node_${ID}.log" &
-}
+    local NODE_FOLDER=${TEMPD}/node_${ID}
 
-## Use ~/.cargo/bin/tokio-console --retain-for 0s http://127.0.0.1:10000 to connect console to first node
-run_node_with_telemetry() {
-  local BOOTSTRAP_ADDR="$1"
-  local PUBLIC_ADDR="$2"
-  local LOG_LEVEL="$3"
-  local KEYS_PATH="$4"
-  local ID="$5"
-  local TEMPD="$6"
-  
-  T_BIND_PORT=$((10000+$ID))
+	  local RUSK_STATE_PATH=${NODE_FOLDER}/state
 
-  echo "starting node $ID ..."
+	  RUSK_STATE_PATH=${RUSK_STATE_PATH} cargo r --release -p rusk -- recovery-state --init $GENESIS_PATH
+	  echo "starting node $ID ..."
+    echo "${KEYS_PATH}/node_$ID.keys"
+	  RUSK_STATE_PATH=${RUSK_STATE_PATH} ./target/release/rusk --kadcast-bootstrap "$BOOTSTRAP_ADDR" --kadcast-public-address "$PUBLIC_ADDR" --log-level="$LOG_LEVEL" --consensus-keys-path="${KEYS_PATH}/node_$ID.keys" --db-path="$NODE_FOLDER" --http-listen-addr "$WS_LISTEN_ADDR" --delay-on-resp-msg=10 > "${TEMPD}/node_${ID}.log" &
+	}
 
-  RUST_LOG="info" TOKIO_CONSOLE_BIND="127.0.0.1:$T_BIND_PORT" \
-  cargo --config 'build.rustflags = ["--cfg", "tokio_unstable"]' run --features with_telemetry --bin rusk-node --\
-  --kadcast_bootstrap "$BOOTSTRAP_ADDR" --kadcast_public_address "$PUBLIC_ADDR" --log-level="$LOG_LEVEL" \
+	## Use ~/.cargo/bin/tokio-console --retain-for 0s http://127.0.0.1:10000 to connect console to first node
+	run_node_with_telemetry() {
+	  local BOOTSTRAP_ADDR="$1"
+	  local PUBLIC_ADDR="$2"
+	  local LOG_LEVEL="$3"
+	  local KEYS_PATH="$4"
+	  local ID="$5"
+	  local TEMPD="$6"
+	  
+	  T_BIND_PORT=$((10000+$ID))
+
+	  echo "starting node $ID ..."
+
+	  RUST_LOG="info" TOKIO_CONSOLE_BIND="127.0.0.1:$T_BIND_PORT" \
+	  cargo --config 'build.rustflags = ["--cfg", "tokio_unstable"]' run --features with_telemetry --bin rusk-node --\
+	  --kadcast_bootstrap "$BOOTSTRAP_ADDR" --kadcast_public_address "$PUBLIC_ADDR" --log-level="$LOG_LEVEL" \
   --consensus-keys-path="${KEYS_PATH}/node_$ID.keys" --db-path="${TEMPD}/db/${ID}" --config="default.config.toml" > "${TEMPD}/node_${ID}.log" &
 }
-
 
 # Spawn N (up to 9) nodes
 for (( i=0; i<$PROV_NUM; i++ ))
 do
   PORT=$((7000+$i))
-  run_node "$BOOTSTRAP_ADDR" "127.0.0.1:$PORT" "info" "$DUSK_WALLET_DIR" "$i" "$TEMPD"
+  WS_PORT=$((8000+$i))
 
-  # Assuming first node is the bootstrap node, we need to wait for it to start
-  if [ $i -eq 0 ]; then
-    sleep 3
-  fi
- 
+  #delay=$(($i))
+  #sleep 20
+
+  run_node "$BOOTSTRAP_ADDR" "127.0.0.1:$PORT" "info" "$DUSK_WALLET_DIR" "$i" "$TEMPD" "127.0.0.1:$WS_PORT" &
+
+  # wait for bootstrappers 
+  # TODO
 done
 
 
 # monitor
-sleep 2
-tail -F ${TEMPD}node_*.log | grep -e "accepted\|ERROR"
+sleep 10
+tail -F ${TEMPD}node_*.log | grep -e "accepted\|ERROR\|gen_candidate"
+# tail -F ${TEMPD}node_*.log
 
 # Stop all running rusk-node processes when script is interrupted or terminated
-trap 'killall rusk-node || true; rm -rf "$TEMPD"' INT TERM EXIT
+trap 'killall rusk || true; rm -rf "$TEMPD"' INT TERM EXIT
 
 # Wait for all child processes to complete
 wait


### PR DESCRIPTION
node: Add `verify_block_cert` bench.

Create a `Certificate` with all voters signatures aggregated.
Even if this is probably not applicable in our context due to the fact that we short-circuit the certificate creation at 67% of quorum, it's still a valid starting point for benchmark

`cargo bench verify_block_cert -p node`

```
verify_block_cert/verify_block_cert/1 prov
                        time:   [6.8250 ms 6.8550 ms 6.8912 ms]

verify_block_cert/verify_block_cert/30 prov
                        time:   [52.643 ms 52.846 ms 53.063 ms]

verify_block_cert/verify_block_cert/64 prov
                        time:   [78.349 ms 78.666 ms 79.005 ms]

verify_block_cert/verify_block_cert/256 prov
                        time:   [111.34 ms 111.53 ms 111.75 ms]

verify_block_cert/verify_block_cert/1000 prov
                        time:   [118.67 ms 119.00 ms 119.39 ms]
```

See also #1149 