### PR TITLE
Compile transfer contract to `wasm64-unknown-unknown`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ keys: circuits ## Create the keys for the circuits
 state: keys wasm ## Create the network state
 	$(MAKE) -C ./rusk recovery-state
 
-wasm: ## Generate the WASM for all the contracts
+wasm: setup-compiler ## Generate the WASM for all the contracts
 	$(MAKE) -C ./contracts $@
 	$(MAKE) -C ./rusk-abi $@
 
@@ -57,4 +57,8 @@ run: keys state ## Run the server
 rusk: keys state ## Build rusk binary
 	$(MAKE) -C ./rusk build
 
-.PHONY: all abi circuits keys state wasm allcircuits contracts test run help rusk
+COMPILER_VERSION=v0.1.0
+setup-compiler: ## Setup the Dusk Contract Compiler
+	@./scripts/setup-compiler.sh $(COMPILER_VERSION)
+
+.PHONY: all abi circuits keys state wasm allcircuits contracts test run help rusk setup-compiler

--- a/contracts/alice/Makefile
+++ b/contracts/alice/Makefile
@@ -2,7 +2,7 @@ all: wasm
 
 wasm: ## Generate the optimized WASM for the contract given
 	@RUSTFLAGS="$(RUSTFLAGS) --remap-path-prefix $(HOME)= -C link-args=-zstack-size=65536" \
-    	cargo build \
+    	cargo +dusk build \
     		--release \
     		--color=always \
     		-Z build-std=core,alloc,panic_abort \

--- a/contracts/bob/Makefile
+++ b/contracts/bob/Makefile
@@ -2,7 +2,7 @@ all: wasm
 
 wasm: ## Generate the optimized WASM for the contract given
 	@RUSTFLAGS="$(RUSTFLAGS) --remap-path-prefix $(HOME)= -C link-args=-zstack-size=65536" \
-    	cargo build \
+    	cargo +dusk build \
     		--release \
     		--color=always \
     		-Z build-std=core,alloc,panic_abort \

--- a/contracts/governance/Makefile
+++ b/contracts/governance/Makefile
@@ -15,7 +15,7 @@ test: wasm ## Perform the contract tests defined in the host module
 
 wasm: ## Generate the optimized WASM for the contract given
 	@RUSTFLAGS="$(RUSTFLAGS) --remap-path-prefix $(HOME)= -C link-args=-zstack-size=65536" \
-    	cargo build \
+    	cargo +dusk build \
     		--release \
     		--color=always \
     		-Z build-std=core,alloc,panic_abort \

--- a/contracts/license/Makefile
+++ b/contracts/license/Makefile
@@ -15,7 +15,7 @@ test: wasm ## Perform the contract tests defined in the host module
 
 wasm: ## Generate the optimized WASM for the contract given
 	@RUSTFLAGS="$(RUSTFLAGS) --remap-path-prefix $(HOME)= -C link-args=-zstack-size=65536" \
-    	cargo build \
+    	cargo +dusk build \
     		--release \
     		--color=always \
 			-Z build-std=core,alloc \

--- a/contracts/stake/Makefile
+++ b/contracts/stake/Makefile
@@ -15,7 +15,7 @@ test: wasm ## Perform the contract tests defined in the host module
 
 wasm: ## Generate the optimized WASM for the contract given
 	@RUSTFLAGS="$(RUSTFLAGS) --remap-path-prefix $(HOME)= -C link-args=-zstack-size=65536" \
-    	cargo build \
+    	cargo +dusk build \
     		--release \
     		--color=always \
 			-Z build-std=core,alloc \

--- a/contracts/stake/tests/stake.rs
+++ b/contracts/stake/tests/stake.rs
@@ -46,7 +46,7 @@ fn instantiate<Rng: RngCore + CryptoRng>(
     pk: &PublicKey,
 ) -> Session {
     let transfer_bytecode = include_bytes!(
-        "../../../target/wasm32-unknown-unknown/release/transfer_contract.wasm"
+        "../../../target/wasm64-unknown-unknown/release/transfer_contract.wasm"
     );
     let stake_bytecode = include_bytes!(
         "../../../target/wasm32-unknown-unknown/release/stake_contract.wasm"

--- a/contracts/transfer/Makefile
+++ b/contracts/transfer/Makefile
@@ -19,7 +19,7 @@ wasm: ## Build the WASM files
 			--release \
 			--color=always \
 			-Z build-std=core,alloc \
-			--target wasm32-unknown-unknown
+			--target wasm64-unknown-unknown
 			
 clippy: ## Run clippy
 	@cargo clippy --all-features --release -- -D warnings

--- a/contracts/transfer/Makefile
+++ b/contracts/transfer/Makefile
@@ -15,7 +15,7 @@ test: wasm ## Perform the contract tests defined in the host module
 
 wasm: ## Build the WASM files
 	@RUSTFLAGS="$(RUSTFLAGS) --remap-path-prefix $(HOME)= -C link-args=-zstack-size=65536" \
-		cargo build \
+		cargo +dusk build \
 			--release \
 			--color=always \
 			-Z build-std=core,alloc \

--- a/contracts/transfer/tests/transfer.rs
+++ b/contracts/transfer/tests/transfer.rs
@@ -58,7 +58,7 @@ fn instantiate<Rng: RngCore + CryptoRng>(
     psk: &PublicSpendKey,
 ) -> Session {
     let transfer_bytecode = include_bytes!(
-        "../../../target/wasm32-unknown-unknown/release/transfer_contract.wasm"
+        "../../../target/wasm64-unknown-unknown/release/transfer_contract.wasm"
     );
     let alice_bytecode = include_bytes!(
         "../../../target/wasm32-unknown-unknown/release/alice.wasm"

--- a/rusk-abi/tests/contracts/host_fn/Makefile
+++ b/rusk-abi/tests/contracts/host_fn/Makefile
@@ -1,6 +1,6 @@
 wasm: ## Generate the optimized WASM for the contract given
 	@RUSTFLAGS="-C link-args=-zstack-size=65536" \
-    	cargo build \
+    	cargo +dusk build \
     	  --release \
     	  --color=always \
     	  -Z build-std=core,alloc,panic_abort \

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -198,7 +198,7 @@ fn generate_empty_state<P: AsRef<Path>>(
     let mut session = rusk_abi::new_genesis_session(&vm);
 
     let transfer_code = include_bytes!(
-        "../../target/wasm32-unknown-unknown/release/transfer_contract.wasm"
+        "../../target/wasm64-unknown-unknown/release/transfer_contract.wasm"
     );
 
     let stake_code = include_bytes!(

--- a/scripts/setup-compiler.sh
+++ b/scripts/setup-compiler.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+# The script should check whether the inputs are set, or print usage
+# information otherwise.
+if [ -z "$1" ]; then
+    echo "Usage: $0 <compiler-version>"
+    exit 1
+fi
+
+RELEASES_URL=https://github.com/dusk-network/rust/releases/download
+
+COMPILER_VERSION=$1
+COMPILER_ARCH=$(rustc -vV | sed -n 's|host: ||p')
+
+ARTIFACT_NAME=duskc-$COMPILER_ARCH.zip
+ARTIFACT_URL=$RELEASES_URL/$COMPILER_VERSION/$ARTIFACT_NAME
+
+ARTIFACT_DIR=$PWD/target/dusk/$COMPILER_VERSION
+ARTIFACT_PATH=$ARTIFACT_DIR/$ARTIFACT_NAME
+
+# If the artifact doesn't already exist in the target directory, download it,
+# otherwise skip.
+if [ ! -f "$ARTIFACT_PATH" ]; then
+    echo "Downloading compiler version $COMPILER_VERSION"
+    mkdir -p "$ARTIFACT_DIR"
+    curl -L "$ARTIFACT_URL" -o "$ARTIFACT_PATH"
+fi
+
+# Unzip the artifact, if it isn't already unzipped
+UNZIPPED_DIR=$ARTIFACT_DIR/unzipped
+
+if [ ! -d "$UNZIPPED_DIR" ]; then
+    echo "Extracting compiler..."
+    mkdir -p "$UNZIPPED_DIR"
+    unzip "$ARTIFACT_PATH" -d "$UNZIPPED_DIR" >> /dev/null
+    # We don't require the source of the compiler itself
+    rm "$UNZIPPED_DIR/rustc-nightly-src.tar.gz"
+fi
+
+# Extract the tarballs, if they aren't already extracted
+EXTRACTED_DIR=$ARTIFACT_DIR/extracted
+
+if [ ! -d "$EXTRACTED_DIR" ]; then
+    mkdir -p "$EXTRACTED_DIR"
+    tarballs=$(find "$UNZIPPED_DIR" -name '*.tar.gz')
+    for tarball in $tarballs; do
+        tar -xzf "$tarball" -C "$EXTRACTED_DIR" --strip-components=2 &
+    done
+    wait
+    # We don't require the, clearly clobbered at this point, file manifest
+    rm "$EXTRACTED_DIR/manifest.in"
+fi
+
+# Ensure that the extracted compiler is symlinked in the toolchain directory
+TOOLCHAIN_DIR=$HOME/.rustup/toolchains
+TOOLCHAIN_LINK=$TOOLCHAIN_DIR/dusk
+
+rm -f "$TOOLCHAIN_LINK"
+ln -s "$EXTRACTED_DIR" "$TOOLCHAIN_LINK"


### PR DESCRIPTION
We introduce `duskc` to compile the genesis contracts, and all other contracts present in the repository. Following this, we compile *only the transfer contract* to `wasm64-unknown-unknown`.

The transfer contract, so far as I can see, is the only genesis contract with an ever growing state that requires a such a large tree. One possible exception may be the license contract, since it uses such a tree as well. I'll leave it up to @xevisalle or @miloszm to decide whether this is necessary or not.
