### PR TITLE
Implement adaptive consensus timeout

### DIFF
--- a/consensus/src/commons.rs
+++ b/consensus/src/commons.rs
@@ -10,6 +10,7 @@
 use node_data::ledger::*;
 use std::fmt;
 use std::fmt::Display;
+use std::time::Duration;
 
 use node_data::message::Payload;
 
@@ -26,6 +27,7 @@ use tracing::error;
 pub struct RoundUpdate {
     // Current round number of the ongoing consensus
     pub round: u64,
+    pub round_base_timeout: Duration,
 
     // This provisioner consensus keys
     pub pubkey_bls: PublicKey,
@@ -42,6 +44,7 @@ impl RoundUpdate {
         pubkey_bls: PublicKey,
         secret_key: SecretKey,
         mrb_block: &Block,
+        round_base_timeout: Duration,
     ) -> Self {
         let round = mrb_block.header().height + 1;
         RoundUpdate {
@@ -52,6 +55,7 @@ impl RoundUpdate {
             hash: mrb_block.header().hash,
             seed: mrb_block.header().seed,
             timestamp: mrb_block.header().timestamp,
+            round_base_timeout,
         }
     }
 

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -33,5 +33,4 @@ pub const DEFAULT_BLOCK_GAS_LIMIT: u64 = 5 * 1_000_000_000;
 pub const RELAX_ITERATION_THRESHOLD: u8 = 10;
 
 pub const ROUND_BASE_TIMEOUT: Duration = Duration::from_secs(5);
-pub const INCREASE_TIMEOUT: Duration = Duration::from_secs(5);
 pub const MAX_STEP_TIMEOUT: Duration = Duration::from_secs(60);

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use std::time::Duration;
+
 /// Maximum number of iterations Consensus runs per a single round.
 pub const CONSENSUS_MAX_ITER: u8 = 255;
 

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use std::time::Duration;
+
 /// Maximum number of steps Consensus runs per a single round.
 pub const CONSENSUS_MAX_STEP: u8 = 213;
 /// Maximum number of iterations Consensus runs per a single round.
@@ -18,9 +20,6 @@ pub const CONSENSUS_QUORUM_THRESHOLD: f64 = 0.67;
 /// Initial step timeout in milliseconds.
 pub const CONSENSUS_TIMEOUT_MS: u64 = 5 * 1000;
 
-/// Maximum step timeout.
-pub const CONSENSUS_MAX_TIMEOUT_MS: u64 = 60 * 1000;
-
 /// Steps committee sizes
 pub const PROPOSAL_COMMITTEE_SIZE: usize = 1;
 pub const VALIDATION_COMMITTEE_SIZE: usize = 64;
@@ -32,3 +31,7 @@ pub const CONSENSUS_DELAY_MS: u64 = 1000;
 pub const DEFAULT_BLOCK_GAS_LIMIT: u64 = 5 * 1_000_000_000;
 
 pub const RELAX_ITERATION_THRESHOLD: u8 = 10;
+
+pub const ROUND_BASE_TIMEOUT: Duration = Duration::from_secs(5);
+pub const INCREASE_TIMEOUT: Duration = Duration::from_secs(5);
+pub const MAX_STEP_TIMEOUT: Duration = Duration::from_secs(60);

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -14,7 +14,7 @@ use node_data::ledger::Block;
 
 use node_data::message::{AsyncQueue, Message, Topics};
 
-use crate::execution_ctx::{ExecutionCtx, IterationCtx};
+use crate::execution_ctx::ExecutionCtx;
 use crate::proposal;
 use crate::queue::Queue;
 use crate::quorum::task;
@@ -22,6 +22,7 @@ use crate::user::provisioners::Provisioners;
 use crate::{ratification, validation};
 use tracing::Instrument;
 
+use crate::iteration_ctx::IterationCtx;
 use crate::step_votes_reg::CertInfoRegistry;
 use std::sync::Arc;
 use tokio::sync::{oneshot, Mutex};

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -209,7 +209,6 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
                 validation_handler,
                 ratification_handler,
                 ru.round_base_timeout,
-
             );
 
             while iter < CONSENSUS_MAX_ITER {

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -264,7 +264,7 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
                     }
                 }
 
-                iter_ctx.on_end();
+                iter_ctx.on_close();
 
                 iteration_counter.next()?;
                 // Delegate (quorum) message result to quorum loop for

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -208,6 +208,7 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
                 proposal_handler.clone(),
                 validation_handler.clone(),
                 ratification_handler.clone(),
+                ru.round_base_timeout,
             );
 
             loop {

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -4,11 +4,12 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use crate::commons::Database;
 use crate::commons::QuorumMsgSender;
 use crate::commons::{ConsensusError, RoundUpdate};
-use crate::commons::{Database, IterCounter, StepName};
-use crate::config::{INCREASE_TIMEOUT, MAX_STEP_TIMEOUT};
+
 use crate::contract_state::Operations;
+use crate::iteration_ctx::IterationCtx;
 use crate::msg_handler::HandleMsgOutput::{Pending, Ready};
 use crate::msg_handler::MsgHandler;
 use crate::queue::Queue;
@@ -16,196 +17,17 @@ use crate::step_votes_reg::SafeCertificateInfoRegistry;
 use crate::user::committee::Committee;
 use crate::user::provisioners::Provisioners;
 use crate::user::sortition;
-use crate::{proposal, ratification, validation};
+
 use node_data::bls::PublicKeyBytes;
 use node_data::ledger::{to_str, Block};
 use node_data::message::Payload;
 use node_data::message::{AsyncQueue, Message, Topics};
-use std::cmp;
-use std::collections::HashMap;
+
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::Mutex;
-use tokio::task::JoinSet;
 use tokio::time;
 use tokio::time::Instant;
 use tracing::{debug, error, info, trace};
-
-/// A pool of all generated committees
-#[derive(Default)]
-pub struct RoundCommittees {
-    committees: HashMap<u8, Committee>,
-}
-
-impl RoundCommittees {
-    pub(crate) fn get_committee(&self, step: u8) -> Option<&Committee> {
-        self.committees.get(&step)
-    }
-
-    pub(crate) fn get_generator(&self, iter: u8) -> Option<PublicKeyBytes> {
-        let step = iter.step_from_name(StepName::Proposal);
-        self.get_committee(step)
-            .and_then(|c| c.iter().next().map(|p| *p.bytes()))
-    }
-
-    pub(crate) fn get_validation_committee(
-        &self,
-        iter: u8,
-    ) -> Option<&Committee> {
-        let step = iter.step_from_name(StepName::Validation);
-        self.get_committee(step)
-    }
-
-    pub(crate) fn insert(&mut self, step: u8, committee: Committee) {
-        self.committees.insert(step, committee);
-    }
-}
-
-/// Represents a shared state within a context of the execution of a single
-/// iteration.
-pub struct IterationCtx<DB: Database> {
-    validation_handler: Arc<Mutex<validation::handler::ValidationHandler>>,
-    ratification_handler:
-        Arc<Mutex<ratification::handler::RatificationHandler>>,
-    proposal_handler: Arc<Mutex<proposal::handler::ProposalHandler<DB>>>,
-
-    pub join_set: JoinSet<()>,
-
-    round: u64,
-    iter: u8,
-
-    /// Stores any committee already generated in the execution of any
-    /// iteration of current round
-    committees: RoundCommittees,
-
-    step_base_timeout: Duration,
-}
-
-impl<D: Database> IterationCtx<D> {
-    pub fn new(
-        round: u64,
-        iter: u8,
-        proposal_handler: Arc<Mutex<proposal::handler::ProposalHandler<D>>>,
-        validation_handler: Arc<Mutex<validation::handler::ValidationHandler>>,
-        ratification_handler: Arc<
-            Mutex<ratification::handler::RatificationHandler>,
-        >,
-        round_base_timeout: Duration,
-    ) -> Self {
-        Self {
-            round,
-            join_set: JoinSet::new(),
-            iter,
-            proposal_handler,
-            validation_handler,
-            ratification_handler,
-            committees: Default::default(),
-            step_base_timeout: round_base_timeout,
-        }
-    }
-
-    pub(crate) async fn collect_past_event(
-        &self,
-        ru: &RoundUpdate,
-        msg: &Message,
-    ) -> Option<Message> {
-        let committee = self.committees.get_committee(msg.header.step)?;
-        match msg.topic() {
-            node_data::message::Topics::Candidate => {
-                let mut handler = self.proposal_handler.lock().await;
-                _ = handler
-                    .collect_from_past(
-                        msg.clone(),
-                        ru,
-                        msg.header.step,
-                        committee,
-                    )
-                    .await;
-            }
-            node_data::message::Topics::Validation => {
-                let mut handler = self.validation_handler.lock().await;
-                if let Ok(Ready(m)) = handler
-                    .collect_from_past(
-                        msg.clone(),
-                        ru,
-                        msg.header.step,
-                        committee,
-                    )
-                    .await
-                {
-                    return Some(m);
-                }
-            }
-            node_data::message::Topics::Ratification => {
-                let mut handler = self.ratification_handler.lock().await;
-                if let Ok(Ready(m)) = handler
-                    .collect_from_past(
-                        msg.clone(),
-                        ru,
-                        msg.header.step,
-                        committee,
-                    )
-                    .await
-                {
-                    return Some(m);
-                }
-            }
-            _ => {}
-        };
-
-        None
-    }
-
-    pub(crate) fn on_begin(&mut self, iter: u8) {
-        self.iter = iter;
-        // TODO: Re-adjust step_base_timeout
-    }
-
-    pub(crate) fn get_generator(&self, iter: u8) -> Option<PublicKeyBytes> {
-        let step = iter.step_from_name(StepName::Proposal);
-        self.committees
-            .get_committee(step)
-            .and_then(|c| c.iter().next().map(|p| *p.bytes()))
-    }
-
-    pub(crate) fn on_end(&mut self) {
-        debug!(
-            event = "iter completed",
-            len = self.join_set.len(),
-            round = self.round,
-            iter = self.iter,
-        );
-        self.join_set.abort_all();
-    }
-
-    pub(crate) fn get_timeout(&self) -> Duration {
-        let step = self.iter.to_step_name();
-
-        match step {
-            StepName::Proposal => self.step_base_timeout,
-            StepName::Validation => self.step_base_timeout * 3,
-            StepName::Ratification => self.step_base_timeout * 3,
-        }
-    }
-
-    /// Handles an event of a Phase timeout
-    pub(crate) fn on_timeout_event(&mut self) {
-        self.increase_step_timeout();
-    }
-
-    pub(crate) fn increase_step_timeout(&mut self) {
-        self.step_base_timeout = cmp::min(
-            MAX_STEP_TIMEOUT,
-            self.step_base_timeout + INCREASE_TIMEOUT, // TODO:
-        );
-    }
-}
-
-impl<DB: Database> Drop for IterationCtx<DB> {
-    fn drop(&mut self) {
-        self.on_end();
-    }
-}
 
 /// ExecutionCtx encapsulates all data needed by a single step to be fully
 /// executed.
@@ -287,7 +109,7 @@ impl<'a, DB: Database, T: Operations + 'static> ExecutionCtx<'a, DB, T> {
     ) -> Result<Message, ConsensusError> {
         debug!(event = "run event_loop");
 
-        let timeout = self.iter_ctx.get_timeout();
+        let timeout = self.iter_ctx.get_timeout(self.step);
         let deadline = Instant::now().checked_add(timeout).unwrap();
 
         let inbound = self.inbound.clone();

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -5,7 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::commons::{ConsensusError, Database, QuorumMsgSender, RoundUpdate};
-use crate::config::CONSENSUS_MAX_TIMEOUT_MS;
 
 use crate::contract_state::Operations;
 use crate::iteration_ctx::IterationCtx;
@@ -22,10 +21,7 @@ use node_data::ledger::{to_str, Block};
 use node_data::message::Payload;
 use node_data::message::{AsyncQueue, Message, Topics};
 
-
 use node_data::StepName;
-use std::cmp;
-use std::collections::HashMap;
 
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -124,7 +120,7 @@ impl<'a, DB: Database, T: Operations + 'static> ExecutionCtx<'a, DB, T> {
     ) -> Result<Message, ConsensusError> {
         debug!(event = "run event_loop");
 
-        let timeout = self.iter_ctx.get_timeout(self.step);
+        let timeout = self.iter_ctx.get_timeout(self.step_name());
         let deadline = Instant::now().checked_add(timeout).unwrap();
 
         let inbound = self.inbound.clone();

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -9,7 +9,7 @@ use crate::commons::{ConsensusError, RoundUpdate};
 use crate::commons::{Database, IterCounter, StepName};
 use crate::config::{INCREASE_TIMEOUT, MAX_STEP_TIMEOUT};
 use crate::contract_state::Operations;
-use crate::msg_handler::HandleMsgOutput::{Ready, ReadyWithTimeoutIncrease};
+use crate::msg_handler::HandleMsgOutput::{Pending, Ready};
 use crate::msg_handler::MsgHandler;
 use crate::queue::Queue;
 use crate::step_votes_reg::SafeCertificateInfoRegistry;
@@ -468,11 +468,9 @@ impl<'a, DB: Database, T: Operations + 'static> ExecutionCtx<'a, DB, T> {
                         // an output to populate next step with it.
                         return Some(m);
                     }
-                    ReadyWithTimeoutIncrease(m) => {
-                        return Some(m);
-                    }
-                    _ => {} /* Message collected but phase does not reach
-                             * a final result */
+                    Pending(_) => {} /* Message collected but phase does not
+                                      * reach
+                                      * a final result */
                 }
             }
             Err(e) => {

--- a/consensus/src/iteration_ctx.rs
+++ b/consensus/src/iteration_ctx.rs
@@ -1,0 +1,212 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::commons::RoundUpdate;
+use crate::commons::{Database, IterCounter, StepName};
+use crate::config::MAX_STEP_TIMEOUT;
+use crate::msg_handler::HandleMsgOutput::Ready;
+use crate::msg_handler::MsgHandler;
+
+use crate::user::committee::Committee;
+
+use crate::{config, proposal, ratification, validation};
+use node_data::bls::PublicKeyBytes;
+
+use node_data::message::Message;
+use std::cmp;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::task::JoinSet;
+
+use tracing::debug;
+
+/// A pool of all generated committees
+#[derive(Default)]
+pub struct RoundCommittees {
+    committees: HashMap<u8, Committee>,
+}
+
+impl RoundCommittees {
+    pub(crate) fn get_committee(&self, step: u8) -> Option<&Committee> {
+        self.committees.get(&step)
+    }
+
+    pub(crate) fn get_generator(&self, iter: u8) -> Option<PublicKeyBytes> {
+        let step = iter.step_from_name(StepName::Proposal);
+        self.get_committee(step)
+            .and_then(|c| c.iter().next().map(|p| *p.bytes()))
+    }
+
+    pub(crate) fn get_validation_committee(
+        &self,
+        iter: u8,
+    ) -> Option<&Committee> {
+        let step = iter.step_from_name(StepName::Validation);
+        self.get_committee(step)
+    }
+
+    pub(crate) fn insert(&mut self, step: u8, committee: Committee) {
+        self.committees.insert(step, committee);
+    }
+}
+
+/// Represents a shared state within a context of the execution of a single
+/// iteration.
+pub struct IterationCtx<DB: Database> {
+    validation_handler: Arc<Mutex<validation::handler::ValidationHandler>>,
+    ratification_handler:
+        Arc<Mutex<ratification::handler::RatificationHandler>>,
+    proposal_handler: Arc<Mutex<proposal::handler::ProposalHandler<DB>>>,
+
+    pub join_set: JoinSet<()>,
+
+    round: u64,
+    iter: u8,
+
+    /// Stores any committee already generated in the execution of any
+    /// iteration of current round
+    pub(crate) committees: RoundCommittees,
+
+    /// Implements the adaptive timeout algorithm
+    step_base_timeout: Duration,
+}
+
+impl<D: Database> IterationCtx<D> {
+    pub fn new(
+        round: u64,
+        iter: u8,
+        proposal_handler: Arc<Mutex<proposal::handler::ProposalHandler<D>>>,
+        validation_handler: Arc<Mutex<validation::handler::ValidationHandler>>,
+        ratification_handler: Arc<
+            Mutex<ratification::handler::RatificationHandler>,
+        >,
+        round_base_timeout: Duration,
+    ) -> Self {
+        Self {
+            round,
+            join_set: JoinSet::new(),
+            iter,
+            proposal_handler,
+            validation_handler,
+            ratification_handler,
+            committees: Default::default(),
+            step_base_timeout: round_base_timeout,
+        }
+    }
+
+    /// Executed on starting a new iteration, before Proposal step execution
+    pub(crate) fn on_begin(&mut self, iter: u8) {
+        self.iter = iter;
+    }
+
+    /// Executed on closing an iteration, after Ratification step execution
+    pub(crate) fn on_end(&mut self) {
+        debug!(
+            event = "iter completed",
+            len = self.join_set.len(),
+            round = self.round,
+            iter = self.iter,
+        );
+        self.join_set.abort_all();
+    }
+
+    /// Handles an event of a Phase timeout
+    pub(crate) fn on_timeout_event(&mut self) {
+        self.increase_step_timeout();
+    }
+
+    pub(crate) fn get_generator(&self, iter: u8) -> Option<PublicKeyBytes> {
+        let step = iter.step_from_name(StepName::Proposal);
+        self.committees
+            .get_committee(step)
+            .and_then(|c| c.iter().next().map(|p| *p.bytes()))
+    }
+
+    /// Calculates and returns the adjusted timeout for current step
+    pub(crate) fn get_timeout(&self, step: u8) -> Duration {
+        let step = step.to_step_name();
+
+        match step {
+            StepName::Proposal => self.step_base_timeout,
+            StepName::Validation => self.step_base_timeout * 3,
+            StepName::Ratification => self.step_base_timeout * 3,
+        }
+    }
+
+    pub(crate) fn increase_step_timeout(&mut self) {
+        let increase_millis =
+            (f64::log2((config::CONSENSUS_MAX_ITER - self.iter) as f64)
+                * 1000.0)
+                .ceil();
+
+        self.step_base_timeout = cmp::min(
+            MAX_STEP_TIMEOUT,
+            self.step_base_timeout
+                + Duration::from_millis(increase_millis as u64),
+        );
+    }
+
+    /// Collects a message from a past iteration or step
+    pub(crate) async fn collect_past_event(
+        &self,
+        ru: &RoundUpdate,
+        msg: &Message,
+    ) -> Option<Message> {
+        let committee = self.committees.get_committee(msg.header.step)?;
+        match msg.topic() {
+            node_data::message::Topics::Candidate => {
+                let mut handler = self.proposal_handler.lock().await;
+                _ = handler
+                    .collect_from_past(
+                        msg.clone(),
+                        ru,
+                        msg.header.step,
+                        committee,
+                    )
+                    .await;
+            }
+            node_data::message::Topics::Validation => {
+                let mut handler = self.validation_handler.lock().await;
+                if let Ok(Ready(m)) = handler
+                    .collect_from_past(
+                        msg.clone(),
+                        ru,
+                        msg.header.step,
+                        committee,
+                    )
+                    .await
+                {
+                    return Some(m);
+                }
+            }
+            node_data::message::Topics::Ratification => {
+                let mut handler = self.ratification_handler.lock().await;
+                if let Ok(Ready(m)) = handler
+                    .collect_from_past(
+                        msg.clone(),
+                        ru,
+                        msg.header.step,
+                        committee,
+                    )
+                    .await
+                {
+                    return Some(m);
+                }
+            }
+            _ => {}
+        };
+
+        None
+    }
+}
+
+impl<DB: Database> Drop for IterationCtx<DB> {
+    fn drop(&mut self) {
+        self.on_end();
+    }
+}

--- a/consensus/src/iteration_ctx.rs
+++ b/consensus/src/iteration_ctx.rs
@@ -105,7 +105,7 @@ impl<D: Database> IterationCtx<D> {
     }
 
     /// Executed on closing an iteration, after Ratification step execution
-    pub(crate) fn on_end(&mut self) {
+    pub(crate) fn on_close(&mut self) {
         debug!(
             event = "iter completed",
             len = self.join_set.len(),
@@ -127,7 +127,7 @@ impl<D: Database> IterationCtx<D> {
             .and_then(|c| c.iter().next().map(|p| *p.bytes()))
     }
 
-    /// Calculates and returns the adjusted timeout for current step
+    /// Calculates and returns the adjusted timeout for the specified step
     pub(crate) fn get_timeout(&self, step: u8) -> Duration {
         let step = step.to_step_name();
 
@@ -207,6 +207,6 @@ impl<D: Database> IterationCtx<D> {
 
 impl<DB: Database> Drop for IterationCtx<DB> {
     fn drop(&mut self) {
-        self.on_end();
+        self.on_close();
     }
 }

--- a/consensus/src/iteration_ctx.rs
+++ b/consensus/src/iteration_ctx.rs
@@ -12,7 +12,7 @@ use crate::msg_handler::MsgHandler;
 
 use crate::user::committee::Committee;
 
-use crate::{config, proposal, ratification, validation};
+use crate::{proposal, ratification, validation};
 use node_data::bls::PublicKeyBytes;
 
 use node_data::message::Message;
@@ -138,16 +138,8 @@ impl<D: Database> IterationCtx<D> {
     }
 
     pub(crate) fn increase_step_timeout(&mut self) {
-        let increase_millis =
-            (f64::log2((config::CONSENSUS_MAX_ITER - self.iter) as f64)
-                * 1000.0)
-                .ceil();
-
-        self.step_base_timeout = cmp::min(
-            MAX_STEP_TIMEOUT,
-            self.step_base_timeout
-                + Duration::from_millis(increase_millis as u64),
-        );
+        self.step_base_timeout =
+            cmp::min(MAX_STEP_TIMEOUT, self.step_base_timeout * 2);
     }
 
     /// Collects a message from a past iteration

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -23,6 +23,7 @@ mod ratification;
 mod step_votes_reg;
 mod validation;
 
+mod iteration_ctx;
 pub mod merkle;
 
 #[cfg(test)]

--- a/consensus/src/msg_handler.rs
+++ b/consensus/src/msg_handler.rs
@@ -18,7 +18,6 @@ use tracing::{debug, trace};
 pub enum HandleMsgOutput {
     Pending(Message),
     Ready(Message),
-    ReadyWithTimeoutIncrease(Message),
 }
 
 /// MsgHandler must be implemented by any step that needs to handle an external

--- a/consensus/src/msg_handler.rs
+++ b/consensus/src/msg_handler.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::commons::{ConsensusError, RoundUpdate};
-use crate::execution_ctx::RoundCommittees;
+use crate::iteration_ctx::RoundCommittees;
 use crate::user::committee::Committee;
 use async_trait::async_trait;
 use node_data::ledger::to_str;

--- a/consensus/src/phase.rs
+++ b/consensus/src/phase.rs
@@ -57,7 +57,7 @@ impl<T: Operations + 'static, D: Database + 'static> Phase<T, D> {
         &mut self,
         mut ctx: ExecutionCtx<'_, D, T>,
     ) -> Result<Message, ConsensusError> {
-        let timeout = ctx.iter_ctx.get_timeout();
+        let timeout = ctx.iter_ctx.get_timeout(ctx.step);
         debug!(event = "execute_step", ?timeout);
 
         let size = call_phase!(self, get_committee_size());

--- a/consensus/src/phase.rs
+++ b/consensus/src/phase.rs
@@ -57,7 +57,8 @@ impl<T: Operations + 'static, D: Database + 'static> Phase<T, D> {
         &mut self,
         mut ctx: ExecutionCtx<'_, D, T>,
     ) -> Result<Message, ConsensusError> {
-        debug!(event = "execute_step", timeout = self.get_timeout());
+        let timeout = ctx.iter_ctx.get_timeout();
+        debug!(event = "execute_step", ?timeout);
 
         let size = call_phase!(self, get_committee_size());
 
@@ -95,9 +96,5 @@ impl<T: Operations + 'static, D: Database + 'static> Phase<T, D> {
 
     pub fn name(&self) -> &'static str {
         call_phase!(self, name())
-    }
-
-    fn get_timeout(&self) -> u64 {
-        call_phase!(self, get_timeout())
     }
 }

--- a/consensus/src/phase.rs
+++ b/consensus/src/phase.rs
@@ -71,7 +71,7 @@ impl<T: Operations + 'static, D: Database + 'static> Phase<T, D> {
         &mut self,
         mut ctx: ExecutionCtx<'_, D, T>,
     ) -> Result<Message, ConsensusError> {
-        let timeout = ctx.iter_ctx.get_timeout(ctx.step);
+        let timeout = ctx.iter_ctx.get_timeout(ctx.step_name());
         debug!(event = "execute_step", ?timeout);
 
         let size = call_phase!(self, get_committee_size());

--- a/consensus/src/proposal/handler.rs
+++ b/consensus/src/proposal/handler.rs
@@ -11,7 +11,7 @@ use crate::step_votes_reg::SafeCertificateInfoRegistry;
 use crate::user::committee::Committee;
 use async_trait::async_trait;
 
-use crate::execution_ctx::RoundCommittees;
+use crate::iteration_ctx::RoundCommittees;
 use node_data::message::{Message, Payload};
 use std::sync::Arc;
 use tokio::sync::Mutex;

--- a/consensus/src/proposal/step.rs
+++ b/consensus/src/proposal/step.rs
@@ -24,7 +24,6 @@ where
 {
     handler: Arc<Mutex<handler::ProposalHandler<D>>>,
     bg: Generator<T>,
-    timeout_millis: u64,
 }
 
 impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
@@ -34,7 +33,6 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
         handler: Arc<Mutex<handler::ProposalHandler<D>>>,
     ) -> Self {
         Self {
-            timeout_millis: config::CONSENSUS_TIMEOUT_MS,
             handler,
             bg: Generator::new(executor),
         }
@@ -46,7 +44,6 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
             name = self.name(),
             round = round,
             step = step,
-            timeout = self.timeout_millis,
         )
     }
 
@@ -111,15 +108,11 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
             return Ok(m);
         }
 
-        ctx.event_loop(self.handler.clone(), &mut self.timeout_millis)
-            .await
+        ctx.event_loop(self.handler.clone()).await
     }
 
     pub fn name(&self) -> &'static str {
         "sel"
-    }
-    pub fn get_timeout(&self) -> u64 {
-        self.timeout_millis
     }
     pub fn get_committee_size(&self) -> usize {
         config::PROPOSAL_COMMITTEE_SIZE

--- a/consensus/src/proposal/step.rs
+++ b/consensus/src/proposal/step.rs
@@ -44,12 +44,7 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
         round: u64,
         iteration: u8,
     ) {
-        debug!(
-            event = "init",
-            name = self.name(),
-            round,
-            iteration,
-        )
+        debug!(event = "init", name = self.name(), round, iteration,)
     }
 
     pub async fn run(

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -15,7 +15,7 @@ use tracing::{error, warn};
 use crate::aggregator::Aggregator;
 
 use crate::config;
-use crate::execution_ctx::RoundCommittees;
+use crate::iteration_ctx::RoundCommittees;
 use crate::quorum::verifiers::verify_votes;
 use node_data::message::payload::{QuorumType, Ratification, ValidationResult};
 use node_data::message::{payload, Message, Payload, Topics};

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -14,7 +14,7 @@ use tracing::warn;
 
 use crate::user::committee::Committee;
 
-use crate::execution_ctx::RoundCommittees;
+use crate::iteration_ctx::RoundCommittees;
 use node_data::message::payload::QuorumType;
 use node_data::message::{payload, Message, Payload};
 

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -34,20 +34,6 @@ fn final_result(
     HandleMsgOutput::Ready(msg)
 }
 
-fn final_result_with_timeout(
-    sv: StepVotes,
-    hash: [u8; 32],
-    quorum: QuorumType,
-) -> HandleMsgOutput {
-    let msg = Message::from_validation_result(payload::ValidationResult {
-        sv,
-        hash,
-        quorum,
-    });
-
-    HandleMsgOutput::ReadyWithTimeoutIncrease(msg)
-}
-
 pub struct ValidationHandler {
     pub(crate) aggr: Aggregator,
     pub(crate) candidate: Block,
@@ -138,11 +124,7 @@ impl MsgHandler<Message> for ValidationHandler {
                     tracing::warn!(
                         "votes converged for an empty hash (timeout)"
                     );
-                    return Ok(final_result_with_timeout(
-                        sv,
-                        hash,
-                        QuorumType::NilQuorum,
-                    ));
+                    return Ok(final_result(sv, hash, QuorumType::NilQuorum));
                 }
 
                 return Ok(final_result(sv, hash, QuorumType::ValidQuorum));

--- a/consensus/src/validation/step.rs
+++ b/consensus/src/validation/step.rs
@@ -21,7 +21,6 @@ use tokio::task::JoinSet;
 use tracing::{debug, error, Instrument};
 
 pub struct ValidationStep<T> {
-    timeout_millis: u64,
     handler: Arc<Mutex<handler::ValidationHandler>>,
     executor: Arc<Mutex<T>>,
 }
@@ -166,11 +165,7 @@ impl<T: Operations + 'static> ValidationStep<T> {
         executor: Arc<Mutex<T>>,
         handler: Arc<Mutex<handler::ValidationHandler>>,
     ) -> Self {
-        Self {
-            timeout_millis: config::CONSENSUS_TIMEOUT_MS,
-            handler,
-            executor,
-        }
+        Self { handler, executor }
     }
 
     pub async fn reinitialize(&mut self, msg: &Message, round: u64, step: u8) {
@@ -186,7 +181,6 @@ impl<T: Operations + 'static> ValidationStep<T> {
             name = self.name(),
             round = round,
             step = step,
-            timeout = self.timeout_millis,
             hash = to_str(&handler.candidate.header().hash),
         )
     }
@@ -217,15 +211,11 @@ impl<T: Operations + 'static> ValidationStep<T> {
             return Ok(m);
         }
 
-        ctx.event_loop(self.handler.clone(), &mut self.timeout_millis)
-            .await
+        ctx.event_loop(self.handler.clone()).await
     }
 
     pub fn name(&self) -> &'static str {
         "validation"
-    }
-    pub fn get_timeout(&self) -> u64 {
-        self.timeout_millis
     }
     pub fn get_committee_size(&self) -> usize {
         config::VALIDATION_COMMITTEE_SIZE

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -22,6 +22,7 @@ use tokio::task::JoinHandle;
 use tracing::{error, info, trace, warn};
 
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Consensus Service Task is responsible for running the consensus layer.
 ///
@@ -86,10 +87,13 @@ impl Task {
             Arc::new(Mutex::new(CandidateDB::new(db.clone(), network.clone()))),
         );
 
+        let round_base_timeout = self.adjust_round_base_timeout(db);
+
         let ru = RoundUpdate::new(
             self.keys.1.clone(),
             self.keys.0,
             most_recent_block,
+            round_base_timeout,
         );
 
         self.task_id += 1;
@@ -141,6 +145,14 @@ impl Task {
                 warn!("Unable to send cancel for abort")
             };
         }
+    }
+
+    /// TBD
+    fn adjust_round_base_timeout<D: database::DB>(
+        &mut self,
+        _db: &Arc<RwLock<D>>,
+    ) -> Duration {
+        dusk_consensus::config::ROUND_BASE_TIMEOUT
     }
 }
 

--- a/node/testbed.sh
+++ b/node/testbed.sh
@@ -82,7 +82,7 @@ do
   #delay=$(($i))
   #sleep 20
 
-  run_node "$BOOTSTRAP_ADDR" "127.0.0.1:$PORT" "info" "$DUSK_WALLET_DIR" "$i" "$TEMPD" "127.0.0.1:$WS_PORT" &
+  run_node "$BOOTSTRAP_ADDR" "127.0.0.1:$PORT" "debug" "$DUSK_WALLET_DIR" "$i" "$TEMPD" "127.0.0.1:$WS_PORT" &
 
   # wait for bootstrappers 
   # TODO


### PR DESCRIPTION
fixes #1170 

The provided logics for listed points below will be revised later on accordingly. Currently, the PR only includes a basic implementation.

-  adjust_round_base_timeout
- increasing step_base_timeout
- Default values for step_base_timeout, round_base_timeout and max_step_timeout