### PR TITLE
node: change block timestamp validation

### DIFF
--- a/consensus/src/commons.rs
+++ b/consensus/src/commons.rs
@@ -34,7 +34,6 @@ pub struct RoundUpdate {
 
     seed: Seed,
     hash: [u8; 32],
-    timestamp: i64,
     cert: Certificate,
 }
 
@@ -53,7 +52,6 @@ impl RoundUpdate {
             cert: mrb_block.header().cert,
             hash: mrb_block.header().hash,
             seed: mrb_block.header().seed,
-            timestamp: mrb_block.header().timestamp,
             round_base_timeout,
         }
     }
@@ -64,10 +62,6 @@ impl RoundUpdate {
 
     pub fn hash(&self) -> [u8; 32] {
         self.hash
-    }
-
-    pub fn timestamp(&self) -> i64 {
-        self.timestamp
     }
 
     pub fn cert(&self) -> &Certificate {

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -32,3 +32,5 @@ pub const RELAX_ITERATION_THRESHOLD: u8 = 10;
 
 pub const ROUND_BASE_TIMEOUT: Duration = Duration::from_secs(5);
 pub const MAX_STEP_TIMEOUT: Duration = Duration::from_secs(60);
+
+pub const MAX_BLOCK_SECS_DRIFT: u64 = 120;

--- a/consensus/src/proposal/block_generator.rs
+++ b/consensus/src/proposal/block_generator.rs
@@ -107,7 +107,7 @@ impl<T: Operations> Generator<T> {
         let blk_header = ledger::Header {
             version: 0,
             height: ru.round,
-            timestamp: self.get_timestamp(ru.timestamp()) as i64,
+            timestamp: self.get_timestamp(),
             gas_limit: config::DEFAULT_BLOCK_GAS_LIMIT,
             prev_block_hash,
             seed,
@@ -134,11 +134,10 @@ impl<T: Operations> Generator<T> {
         Ok(Block::new(blk_header, txs).expect("block should be valid"))
     }
 
-    fn get_timestamp(&self, _prev_block_timestamp: i64) -> u64 {
-        // TODO: use config.MaxBlockTime
-        if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {
-            return n.as_secs();
-        }
-        0
+    fn get_timestamp(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|n| n.as_secs())
+            .expect("This is heavy.")
     }
 }

--- a/node-data/src/ledger.rs
+++ b/node-data/src/ledger.rs
@@ -27,7 +27,7 @@ pub struct Header {
     // Hashable fields
     pub version: u8,
     pub height: u64,
-    pub timestamp: i64,
+    pub timestamp: u64,
     pub prev_block_hash: Hash,
     pub seed: Seed,
     pub state_hash: Hash,
@@ -49,7 +49,7 @@ pub struct Header {
 impl std::fmt::Debug for Header {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let timestamp = chrono::NaiveDateTime::from_timestamp_opt(
-            self.timestamp,
+            self.timestamp as i64,
             0,
         )
         .map_or_else(
@@ -133,7 +133,7 @@ impl Header {
     ) -> io::Result<()> {
         w.write_all(&self.version.to_le_bytes())?;
         w.write_all(&self.height.to_le_bytes())?;
-        w.write_all(&(self.timestamp as u64).to_le_bytes())?;
+        w.write_all(&self.timestamp.to_le_bytes())?;
         w.write_all(&self.prev_block_hash[..])?;
 
         if fixed_size_seed {
@@ -165,7 +165,7 @@ impl Header {
 
         let mut buf = [0u8; 8];
         r.read_exact(&mut buf[..])?;
-        let timestamp = u64::from_le_bytes(buf) as i64;
+        let timestamp = u64::from_le_bytes(buf);
 
         let mut prev_block_hash = [0u8; 32];
         r.read_exact(&mut prev_block_hash[..])?;

--- a/rusk/src/lib/http/chain/graphql/data.rs
+++ b/rusk/src/lib/http/chain/graphql/data.rs
@@ -131,7 +131,7 @@ impl Header<'_> {
         hex::encode(self.0.prev_block_hash)
     }
 
-    pub async fn timestamp(&self) -> i64 {
+    pub async fn timestamp(&self) -> u64 {
         self.0.timestamp
     }
 
@@ -202,7 +202,7 @@ impl SpentTransaction {
     pub async fn block_timestamp(
         &self,
         ctx: &async_graphql::Context<'_>,
-    ) -> FieldResult<i64> {
+    ) -> FieldResult<u64> {
         let db = ctx.data::<super::DBContext>()?.read().await;
         let block_height = self.0.block_height;
 


### PR DESCRIPTION
This pull request aims to remove every timestamp control concerning the previous block.

I just considered that if I receive a block from the future that is obvious invalid (let's say with a date a year from now), it doesn't really make sense to accept it. 
So, I started thinking about what would be a reasonable drift to set, and for now, I've chosen 120 seconds. 


See also https://github.com/dusk-network/rusk/issues/1062#issuecomment-1880851992