### PR TITLE
CI: disable tests for draft PRs

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -1,4 +1,10 @@
-on: [pull_request]
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 name: Continuous integration
 
@@ -13,6 +19,7 @@ jobs:
       - run: cargo dusk-analyzer
 
   test_nightly:
+    if: github.event.pull_request.draft == false
     name: Nightly tests
     runs-on: core
     steps:

--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - opened
@@ -19,7 +20,7 @@ jobs:
       - run: cargo dusk-analyzer
 
   test_nightly:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
     name: Nightly tests
     runs-on: core
     steps:


### PR DESCRIPTION
Change CI to:
- Run on `ready_for_review`[^1] too 
- Run on manual `workflow_dispatch`
- Run `tests` step only if `manual` or `ready_for_review`

[^1]: By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened _[(src)](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)_