### PR TITLE
node: Allow fallback to lower-round blocks

### DIFF
--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -494,7 +494,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
     }
 
     /// Returns chain tip header
-    pub(crate) async fn header(&self) -> ledger::Header {
+    pub(crate) async fn tip_header(&self) -> ledger::Header {
         self.mrb.read().await.inner().header().clone()
     }
 
@@ -547,15 +547,14 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
     }
 }
 
-/// Performs full verification of block header (blk_header) against
-/// local/current state.
+/// Performs full verification of block header against prev_block header where
+/// prev_block is usually the blockchain tip
 pub(crate) async fn verify_block_header<DB: database::DB>(
     db: Arc<RwLock<DB>>,
-    mrb: &ledger::Header,
+    prev_block: &ledger::Header,
     provisioners: &ContextProvisioners,
-    candidate_header: &ledger::Header,
+    header: &ledger::Header,
 ) -> anyhow::Result<bool> {
-    let validator = Validator::new(db, mrb, provisioners);
-
-    validator.execute_checks(candidate_header, false).await
+    let validator = Validator::new(db, prev_block, provisioners);
+    validator.execute_checks(header, false).await
 }

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -493,6 +493,11 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
         self.mrb.read().await.inner().header().height
     }
 
+    /// Returns chain tip header
+    pub(crate) async fn header(&self) -> ledger::Header {
+        self.mrb.read().await.inner().header().clone()
+    }
+
     pub(crate) async fn get_curr_hash(&self) -> [u8; 32] {
         self.mrb.read().await.inner().header().hash
     }

--- a/node/src/chain/fallback.rs
+++ b/node/src/chain/fallback.rs
@@ -36,14 +36,16 @@ impl<'a, N: Network, DB: database::DB, VM: vm::VMExecution>
         Self { acc }
     }
 
-    ///
-    pub(crate) async fn try_execute_fallback(
+    /// Makes an attempt to revert to the specified Target, if remote header is
+    /// fully valid
+    pub(crate) async fn try_revert(
         &self,
         local: &Header,
         remote: &Header,
+        revert_target: RevertTarget,
     ) -> Result<()> {
         self.verify_header(local, remote).await?;
-        self.acc.try_revert(RevertTarget::LastFinalizedState).await
+        self.acc.try_revert(revert_target).await
     }
 
     /// Verifies if a block of header `local` can be replaced with a block with

--- a/node/src/chain/fallback.rs
+++ b/node/src/chain/fallback.rs
@@ -48,8 +48,8 @@ impl<'a, N: Network, DB: database::DB, VM: vm::VMExecution>
         self.acc.try_revert(revert_target).await
     }
 
-    /// Verifies if a block of header `local` can be replaced with a block with
-    /// header `remote`
+    /// Verifies if a block with header `local` can be replaced with a block
+    /// with header `remote`
     async fn verify_header(
         &self,
         local: &Header,
@@ -65,7 +65,7 @@ impl<'a, N: Network, DB: database::DB, VM: vm::VMExecution>
             (_, Ordering::Equal) => Err(anyhow!(
                 "iteration is equal to the current {:?}",
                 local.iteration
-            )),
+            )), // TODO: This may be a slashing condition
             _ => Ok(()),
         }?;
 

--- a/node/src/chain/fsm.rs
+++ b/node/src/chain/fsm.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use super::acceptor::Acceptor;
+use super::acceptor::{Acceptor, RevertTarget};
 use crate::chain::fallback;
 use crate::database;
 use crate::{vm, Network};
@@ -318,7 +318,11 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> InSyncImpl<DB, VM, N> {
 
             if let Some(header) = header {
                 match fallback::WithContext::new(acc.deref())
-                    .try_execute_fallback(&header, remote_blk.header())
+                    .try_revert(
+                        &header,
+                        remote_blk.header(),
+                        RevertTarget::LastFinalizedState,
+                    )
                     .await
                 {
                     Ok(_) => {
@@ -357,7 +361,11 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> InSyncImpl<DB, VM, N> {
             );
 
             match fallback::WithContext::new(acc.deref())
-                .try_execute_fallback(&local_header, remote_blk.header())
+                .try_revert(
+                    &local_header,
+                    remote_blk.header(),
+                    RevertTarget::LastFinalizedState,
+                )
                 .await
             {
                 Err(e) => {


### PR DESCRIPTION
fixes #1168 

As already mentioned, this PR implements issue 1168 by reverting to LastFinalized state. 

In order to, implement the part "then we fallback to $B_H.PrevBlock$ and accept $B'_H$ to our chain ", another DIP issue should be filed where we can refine the concept.

See also:  #1260 