### PR TITLE
rusk: Add mempool transaction replacement

### DIFF
--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -30,6 +30,7 @@ async-trait = "0.1"
 anyhow = "1.0"
 node-data = { version = "0.1", path = "../node-data" }
 dusk-merkle = "0.5"
+thiserror = "1"
 
 [dev-dependencies]
 hex-literal = { version = "0.3.4" }

--- a/consensus/src/commons.rs
+++ b/consensus/src/commons.rs
@@ -9,9 +9,8 @@
 
 use node_data::ledger::*;
 use node_data::message::payload::{QuorumType, Vote};
-use std::fmt;
-use std::fmt::Display;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use thiserror::Error;
 
 use node_data::message::Payload;
 
@@ -70,31 +69,21 @@ impl RoundUpdate {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum Error {
+#[derive(Debug, Clone, Copy, Error)]
+pub enum StepSigError {
+    #[error("Failed to reach a quorum at step {0}")]
     VoteSetTooSmall(u16),
+    #[error("Verification error {0}")]
     VerificationFailed(dusk_bls12_381_sign::Error),
+    #[error("Empty Apk instance")]
     EmptyApk,
+    #[error("Invalid Type")]
     InvalidType,
-    InvalidStepNum,
 }
 
-impl From<dusk_bls12_381_sign::Error> for Error {
+impl From<dusk_bls12_381_sign::Error> for StepSigError {
     fn from(inner: dusk_bls12_381_sign::Error) -> Self {
         Self::VerificationFailed(inner)
-    }
-}
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::VoteSetTooSmall(step) => {
-                write!(f, "Failed to reach a quorum at step {step}")
-            }
-            Error::VerificationFailed(_) => write!(f, "Verification error"),
-            Error::EmptyApk => write!(f, "Empty Apk instance"),
-            Error::InvalidType => write!(f, "Invalid Type"),
-            Error::InvalidStepNum => write!(f, "Invalid step number"),
-        }
     }
 }
 
@@ -104,7 +93,7 @@ pub enum ConsensusError {
     InvalidBlockHash,
     InvalidSignature(dusk_bls12_381_sign::Error),
     InvalidMsgType,
-    InvalidValidationStepVotes(Error),
+    InvalidValidationStepVotes(StepSigError),
     InvalidValidation(QuorumType),
     InvalidQuorumType,
     FutureEvent,
@@ -117,8 +106,8 @@ pub enum ConsensusError {
     Canceled,
 }
 
-impl From<Error> for ConsensusError {
-    fn from(e: Error) -> Self {
+impl From<StepSigError> for ConsensusError {
+    fn from(e: StepSigError) -> Self {
         Self::InvalidValidationStepVotes(e)
     }
 }

--- a/node-data/src/ledger.rs
+++ b/node-data/src/ledger.rs
@@ -114,6 +114,13 @@ impl Transaction {
     pub fn gas_price(&self) -> u64 {
         self.inner.fee().gas_price
     }
+    pub fn to_nullifiers(&self) -> Vec<[u8; 32]> {
+        self.inner
+            .nullifiers()
+            .iter()
+            .map(|n| n.to_bytes())
+            .collect()
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -34,6 +34,7 @@ console-subscriber = { version = "0.1.8", optional = true }
 smallvec = "1.10.0"
 
 serde = "1.0"
+thiserror = "1"
 
 [dev-dependencies]
 fake = { version = "2.5", features = ['derive'] }

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -363,6 +363,10 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
         self.db.read().await.update(|update| {
             for tx in mrb.inner().txs().iter() {
                 database::Mempool::delete_tx(update, tx.hash())?;
+                let nullifiers = tx.to_nullifiers();
+                for orphan_tx in update.get_txs_by_nullifiers(&nullifiers) {
+                    database::Mempool::delete_tx(update, orphan_tx)?;
+                }
             }
             Ok(())
         })?;

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -138,7 +138,7 @@ impl Task {
     pub(crate) async fn abort_with_wait(&mut self) {
         if let Some((handle, cancel_chan)) = self.running_task.take() {
             if cancel_chan.send(0).is_err() {
-                warn!("Unable to send cancel for abort_with_wait")
+                trace!("Unable to send cancel for abort_with_wait")
             }
             if let Err(e) = handle.await {
                 warn!("Unable to wait for abort {e}")

--- a/node/src/database.rs
+++ b/node/src/database.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 pub mod rocksdb;
@@ -104,8 +105,8 @@ pub trait Mempool {
     /// Deletes a transaction from the mempool.
     fn delete_tx(&self, tx_hash: [u8; 32]) -> Result<bool>;
 
-    /// Checks if any of the passed nullifiers exists in the mempool.
-    fn get_any_nullifier_exists(&self, nullifiers: Vec<[u8; 32]>) -> bool;
+    /// Get transactions hash from the mempool, searching by nullifiers
+    fn get_txs_by_nullifiers(&self, n: &[[u8; 32]]) -> HashSet<[u8; 32]>;
 
     /// Get an iterator over the mempool transactions sorted by gas price
     fn get_txs_sorted_by_fee(

--- a/node/src/database/rocksdb.rs
+++ b/node/src/database/rocksdb.rs
@@ -19,6 +19,7 @@ use rocksdb_lib::{
     WriteOptions,
 };
 
+use std::collections::HashSet;
 use std::io;
 use std::io::Read;
 use std::io::Write;
@@ -462,17 +463,17 @@ impl<'db, DB: DBAccess> Persist for DBTransaction<'db, DB> {
 impl<'db, DB: DBAccess> Mempool for DBTransaction<'db, DB> {
     fn add_tx(&self, tx: &ledger::Transaction) -> Result<()> {
         // Map Hash to serialized transaction
-        let mut d = vec![];
-        tx.write(&mut d)?;
+        let mut tx_data = vec![];
+        tx.write(&mut tx_data)?;
 
         let hash = tx.hash();
-        self.inner.put_cf(self.mempool_cf, hash, d)?;
+        self.inner.put_cf(self.mempool_cf, hash, tx_data)?;
 
         // Add Secondary indexes //
         // Nullifiers
         for n in tx.inner.nullifiers().iter() {
             let key = n.to_bytes();
-            self.inner.put_cf(self.nullifiers_cf, key, vec![0])?;
+            self.inner.put_cf(self.nullifiers_cf, key, hash)?;
         }
 
         // Map Fee_Hash to Null to facilitate sort-by-fee
@@ -527,14 +528,13 @@ impl<'db, DB: DBAccess> Mempool for DBTransaction<'db, DB> {
         Ok(false)
     }
 
-    fn get_any_nullifier_exists(&self, nullifiers: Vec<[u8; 32]>) -> bool {
-        nullifiers.into_iter().any(|n| {
-            let r = self.snapshot.get_cf(self.nullifiers_cf, n);
-            match r {
-                Ok(r) => r.is_some(),
-                _ => false,
-            }
-        })
+    fn get_txs_by_nullifiers(&self, n: &[[u8; 32]]) -> HashSet<[u8; 32]> {
+        n.iter()
+            .filter_map(|n| match self.snapshot.get_cf(self.nullifiers_cf, n) {
+                Ok(Some(tx_hash)) => tx_hash.try_into().ok(),
+                _ => None,
+            })
+            .collect()
     }
 
     fn get_txs_sorted_by_fee(


### PR DESCRIPTION
When a transaction is submitted to the mempool, it is discarded if there is already a transaction in the mempool that uses at least one of the sent nullifiers. 
This means that if a user submits a transaction with a GasLimit that is too low (preventing its execution) or if their transaction is pending due to network congestion, the user cannot submit new transactions.

With this PR, however, if the gasPrice of the submitted transaction is higher than the gasPrice of the transaction in the mempool, the latter is removed in favor of the new one.

In essence, this PR implements a kind of "boost" for one's transactions.

Resolves #914 
Resolves #935