### PR TITLE
Update workflows to be skipped properly

### DIFF
--- a/.github/workflows/rusk_ci.yml
+++ b/.github/workflows/rusk_ci.yml
@@ -6,16 +6,33 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-    paths:
-      - "**"
-      - "!web-wallet/**"
-      - "!.github/workflows/webwallet_ci.yml"
-      - "!**/*.md'"
 
 name: Rusk CI
 
 jobs:
+  # JOB to run change detection
+  changes:
+    runs-on: core
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      run-ci: ${{ steps.filter.outputs.run-ci }}
+    steps:
+      # For pull requests it's not necessary to checkout the code
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run-ci:
+              - '!web-wallet/**'
+              - '!.github/workflows/webwallet_ci.yml'
+              - '!**/*.md'
   analyze:
+    needs: changes
+    if: needs.changes.outputs.run-ci == 'true'
+
     name: Dusk Analyzer
     runs-on: core
     steps:
@@ -25,7 +42,8 @@ jobs:
       - run: cargo dusk-analyzer
 
   test_nightly:
-    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
+    needs: changes
+    if: needs.changes.outputs.run-ci == 'true' && (github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch')
     name: Nightly tests
     runs-on: core
     steps:
@@ -48,6 +66,9 @@ jobs:
           path: ./target/release/rusk
           retention-days: 5
   fmt:
+    needs: changes
+    if: needs.changes.outputs.run-ci == 'true'
+
     name: Rustfmt
     runs-on: core
     steps:

--- a/.github/workflows/webwallet_ci.yml
+++ b/.github/workflows/webwallet_ci.yml
@@ -7,13 +7,29 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-    paths:
-      - "web-wallet/**"
-      - ".github/workflows/webwallet_ci.yml"
-      - "!**/*.md"
 jobs:
+  # JOB to run change detection
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      run-ci: ${{ steps.filter.outputs.run-ci }}
+    steps:
+      # For pull requests it's not necessary to checkout the code
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run-ci:
+              - 'web-wallet/**'
+              - '.github/workflows/webwallet_ci.yml'
+              - '!**/*.md'
   lint-test:
-    if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
+    needs: changes
+    if: needs.changes.outputs.run-ci == 'true' && (github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
 
     name: Node 20.x
@@ -26,7 +42,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20.x
-          registry-url: "https://npm.pkg.github.com/"
           scope: "@dusk-network"
 
       - name: Installing dev dependencies


### PR DESCRIPTION
As stated by the github docs, if a workflow is skipped due to path filtering, branch filtering or a commit message, then checks associated with that workflow will remain in a "Pending" state.

A pull request that requires those checks to be successful will be blocked from merging.
The solution is skipping those workflow without using the `paths` mechanism, but instead having a job that verifies if something changed in the interested paths and set a variable, to use on other jobs.