### PR TITLE
consensus: ignore candidate with wrong prev_block_hash

### DIFF
--- a/consensus/src/aggregator.rs
+++ b/consensus/src/aggregator.rs
@@ -8,7 +8,7 @@ use crate::user::cluster::Cluster;
 use crate::user::committee::Committee;
 use dusk_bytes::Serializable;
 use node_data::bls::PublicKey;
-use node_data::ledger::{to_str, Signature, StepVotes};
+use node_data::ledger::{to_str, StepVotes};
 use node_data::message::payload::Vote;
 use node_data::message::SignInfo;
 use std::collections::BTreeMap;
@@ -95,15 +95,12 @@ impl Aggregator {
             signature = to_str(signature),
         );
 
-        let s = aggr_sign
+        let aggregate_signature = aggr_sign
             .aggregated_bytes()
             .expect("Signature to exist after aggregating");
         let bitset = committee.bits(cluster);
 
-        let step_votes = StepVotes {
-            bitset,
-            aggregate_signature: Signature::from(s),
-        };
+        let step_votes = StepVotes::new(aggregate_signature, bitset);
 
         let quorum_reached = match &vote {
             Vote::Valid(_) => total >= committee.super_majority_quorum(),
@@ -118,7 +115,7 @@ impl Aggregator {
                 target = quorum_target,
                 bitset,
                 step = msg_step,
-                signature = to_str(&s),
+                signature = to_str(&aggregate_signature),
             );
         }
 

--- a/consensus/src/aggregator.rs
+++ b/consensus/src/aggregator.rs
@@ -74,7 +74,7 @@ impl Aggregator {
             debug_assert!(weight.is_some());
 
             let total = cluster.total_occurrences();
-            let quorum_target = committee.quorum();
+            let quorum_target = committee.super_majority_quorum();
 
             debug!(
                 event = "vote aggregated",
@@ -97,8 +97,8 @@ impl Aggregator {
             };
 
             let quorum_reached = match &vote {
-                Vote::NoCandidate => total >= committee.nil_quorum(),
-                _ => total >= committee.quorum(),
+                Vote::Valid(_) => total >= committee.super_majority_quorum(),
+                _ => total >= committee.majority_quorum(),
             };
 
             if quorum_reached {
@@ -261,7 +261,7 @@ mod tests {
 
         let target_quorum = 7;
 
-        assert_eq!(c.quorum(), target_quorum);
+        assert_eq!(c.super_majority_quorum(), target_quorum);
 
         let mut a = Aggregator::default();
 

--- a/consensus/src/commons.rs
+++ b/consensus/src/commons.rs
@@ -96,6 +96,7 @@ pub enum ConsensusError {
     InvalidMsgType,
     InvalidValidationStepVotes(StepSigError),
     InvalidValidation(QuorumType),
+    InvalidPrevBlockHash(Hash),
     InvalidQuorumType,
     InvalidVote(Vote),
     FutureEvent,

--- a/consensus/src/commons.rs
+++ b/consensus/src/commons.rs
@@ -88,7 +88,7 @@ impl From<dusk_bls12_381_sign::Error> for StepSigError {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum ConsensusError {
     InvalidBlock,
     InvalidBlockHash,
@@ -97,6 +97,7 @@ pub enum ConsensusError {
     InvalidValidationStepVotes(StepSigError),
     InvalidValidation(QuorumType),
     InvalidQuorumType,
+    InvalidVote(Vote),
     FutureEvent,
     PastEvent,
     NotCommitteeMember,

--- a/consensus/src/commons.rs
+++ b/consensus/src/commons.rs
@@ -140,35 +140,29 @@ impl QuorumMsgSender {
     }
 
     /// Sends an quorum (internally) to the quorum loop.
-    pub(crate) async fn send(&self, msg: Message) -> bool {
-        if let Payload::Quorum(q) = &msg.payload {
-            if q.validation.is_empty()
-                || q.ratification.is_empty()
-                || q.vote == Vote::NoCandidate
+    pub(crate) async fn send(&self, msg: Message) {
+        match &msg.payload {
             // TODO: Change me accordingly to https://github.com/dusk-network/rusk/issues/1268
+            Payload::Quorum(q)
+                if !q.validation.is_empty()
+                    && !q.ratification.is_empty()
+                    && q.vote != Vote::NoCandidate =>
             {
-                return false;
+                tracing::debug!(
+                    event = "send quorum_msg",
+                    vote = %q.vote,
+                    round = msg.header.round,
+                    iteration = msg.header.iteration,
+                    validation = ?q.validation,
+                    ratification = ?q.ratification,
+                );
             }
-
-            tracing::debug!(
-                event = "send quorum_msg",
-                vote = %q.vote,
-                round = msg.header.round,
-                iteration = msg.header.iteration,
-                validation = ?q.validation,
-                ratification = ?q.ratification,
-            );
-
-            let _ = self
-                .queue
-                .send(msg.clone())
-                .await
-                .map_err(|e| error!("send quorum_msg failed with {:?}", e));
-
-            return true;
+            _ => return,
         }
 
-        false
+        if let Err(e) = self.queue.send(msg).await {
+            error!("send quorum_msg failed with {e:?}")
+        }
     }
 }
 

--- a/consensus/src/commons.rs
+++ b/consensus/src/commons.rs
@@ -72,8 +72,8 @@ impl RoundUpdate {
 
 #[derive(Debug, Clone, Copy, Error)]
 pub enum StepSigError {
-    #[error("Failed to reach a quorum at step {0}")]
-    VoteSetTooSmall(u16),
+    #[error("Failed to reach a quorum")]
+    VoteSetTooSmall,
     #[error("Verification error {0}")]
     VerificationFailed(dusk_bls12_381_sign::Error),
     #[error("Empty Apk instance")]

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -12,8 +12,9 @@ pub const CONSENSUS_MAX_ITER: u8 = 255;
 /// Number of consecutive attested blocks needed to consider a final block.
 pub const CONSENSUS_ROLLING_FINALITY_THRESHOLD: u64 = 5;
 
-/// Percentage number that determines a quorum.
-pub const CONSENSUS_QUORUM_THRESHOLD: f64 = 0.67;
+/// Percentage number that determines quorums.
+pub const SUPERMAJORITY_THRESHOLD: f64 = 0.67;
+pub const MAJORITY_THRESHOLD: f64 = 0.5;
 
 /// Initial step timeout in milliseconds.
 pub const CONSENSUS_TIMEOUT_MS: u64 = 5 * 1000;

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -220,7 +220,7 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
                     let step_name = phase.to_step_name();
                     // Initialize new phase with message returned by previous
                     // phase.
-                    phase.reinitialize(&msg, ru.round, iter).await;
+                    phase.reinitialize(msg, ru.round, iter).await;
 
                     // Construct phase execution context
                     let ctx = ExecutionCtx::new(

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -164,11 +164,9 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
             let sv_registry =
                 Arc::new(Mutex::new(CertInfoRegistry::new(ru.clone())));
 
-            let proposal_handler =
-                Arc::new(Mutex::new(proposal::handler::ProposalHandler::new(
-                    db.clone(),
-                    sv_registry.clone(),
-                )));
+            let proposal_handler = Arc::new(Mutex::new(
+                proposal::handler::ProposalHandler::new(db.clone()),
+            ));
 
             let validation_handler = Arc::new(Mutex::new(
                 validation::handler::ValidationHandler::new(

--- a/consensus/src/msg_handler.rs
+++ b/consensus/src/msg_handler.rs
@@ -50,6 +50,11 @@ pub trait MsgHandler {
         match msg.compare(ru.round, iteration, step) {
             Status::Past => Err(ConsensusError::PastEvent),
             Status::Present => {
+                let msg_tip = msg.header.prev_block_hash;
+                if msg_tip != ru.hash() {
+                    return Err(ConsensusError::InvalidPrevBlockHash(msg_tip));
+                }
+
                 // Ensure the message originates from a committee member.
                 if !committee.is_member(signer) {
                     return Err(ConsensusError::NotCommitteeMember);

--- a/consensus/src/msg_handler.rs
+++ b/consensus/src/msg_handler.rs
@@ -58,7 +58,7 @@ pub trait MsgHandler {
                 // Delegate message final verification to the phase instance.
                 // It is the phase that knows what message type to expect and if
                 // it is valid or not.
-                self.verify(msg, ru, iteration, committee, round_committees)
+                self.verify(msg, iteration, round_committees)
             }
             Status::Future => Err(ConsensusError::FutureEvent),
         }
@@ -68,9 +68,7 @@ pub trait MsgHandler {
     fn verify(
         &self,
         msg: &Message,
-        ru: &RoundUpdate,
         iteration: u8,
-        committee: &Committee,
         round_committees: &RoundCommittees,
     ) -> Result<(), ConsensusError>;
 

--- a/consensus/src/phase.rs
+++ b/consensus/src/phase.rs
@@ -42,7 +42,7 @@ impl<T: Operations + 'static, D: Database + 'static> Phase<T, D> {
 
     pub async fn reinitialize(
         &mut self,
-        msg: &Message,
+        msg: Message,
         round: u64,
         iteration: u8,
     ) {

--- a/consensus/src/proposal/handler.rs
+++ b/consensus/src/proposal/handler.rs
@@ -7,7 +7,6 @@
 use crate::commons::{ConsensusError, Database, RoundUpdate};
 use crate::merkle::merkle_root;
 use crate::msg_handler::{HandleMsgOutput, MsgHandler};
-use crate::step_votes_reg::SafeCertificateInfoRegistry;
 use crate::user::committee::Committee;
 use async_trait::async_trait;
 use node_data::message::payload::Candidate;
@@ -19,7 +18,6 @@ use tokio::sync::Mutex;
 
 pub struct ProposalHandler<D: Database> {
     pub(crate) db: Arc<Mutex<D>>,
-    pub(crate) _sv_registry: SafeCertificateInfoRegistry,
 }
 
 #[async_trait]
@@ -71,14 +69,8 @@ impl<D: Database> MsgHandler for ProposalHandler<D> {
 }
 
 impl<D: Database> ProposalHandler<D> {
-    pub(crate) fn new(
-        db: Arc<Mutex<D>>,
-        sv_registry: SafeCertificateInfoRegistry,
-    ) -> Self {
-        Self {
-            db,
-            _sv_registry: sv_registry,
-        }
+    pub(crate) fn new(db: Arc<Mutex<D>>) -> Self {
+        Self { db }
     }
 
     fn verify_new_block(

--- a/consensus/src/proposal/step.rs
+++ b/consensus/src/proposal/step.rs
@@ -41,7 +41,7 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
 
     pub async fn reinitialize(
         &mut self,
-        _msg: &Message,
+        _msg: Message,
         round: u64,
         iteration: u8,
     ) {

--- a/consensus/src/quorum/verifiers.rs
+++ b/consensus/src/quorum/verifiers.rs
@@ -98,7 +98,7 @@ pub async fn verify_step_votes(
     let set = committees_set.read().await;
     let committee = set.get(&cfg).expect("committee to be created");
 
-    verify_votes(header, step_name, vote, sv, committee, &cfg)
+    verify_votes(header, step_name, vote, sv, committee)
 }
 
 #[derive(Default)]
@@ -119,7 +119,6 @@ pub fn verify_votes(
     vote: &Vote,
     step_votes: &StepVotes,
     committee: &Committee,
-    cfg: &sortition::Config,
 ) -> Result<QuorumResult, StepSigError> {
     let bitset = step_votes.bitset;
     let signature = step_votes.aggregate_signature().inner();
@@ -140,12 +139,11 @@ pub fn verify_votes(
         tracing::error!(
             desc = "vote_set_too_small",
             committee = format!("{:#?}", sub_committee),
-            cfg = format!("{:#?}", cfg),
             bitset,
             target_quorum,
             total,
         );
-        return Err(StepSigError::VoteSetTooSmall(cfg.step()));
+        return Err(StepSigError::VoteSetTooSmall);
     }
 
     // If bitset=0 this means that we are checking for failed iteration

--- a/consensus/src/quorum/verifiers.rs
+++ b/consensus/src/quorum/verifiers.rs
@@ -134,8 +134,8 @@ pub fn verify_votes(
 
     let total = committee.total_occurrences(&sub_committee);
     let target_quorum = match vote {
-        Vote::NoCandidate => committee.nil_quorum(),
-        _ => committee.quorum(),
+        Vote::Valid(_) => committee.super_majority_quorum(),
+        _ => committee.majority_quorum(),
     };
 
     let quorum_result = QuorumResult {

--- a/consensus/src/quorum/verifiers.rs
+++ b/consensus/src/quorum/verifiers.rs
@@ -98,15 +98,7 @@ pub async fn verify_step_votes(
     let set = committees_set.read().await;
     let committee = set.get(&cfg).expect("committee to be created");
 
-    verify_votes(
-        header,
-        step_name,
-        vote,
-        sv.bitset,
-        sv.aggregate_signature.inner(),
-        committee,
-        &cfg,
-    )
+    verify_votes(header, step_name, vote, sv, committee, &cfg)
 }
 
 #[derive(Default)]
@@ -125,11 +117,12 @@ pub fn verify_votes(
     header: &ConsensusHeader,
     msg_type: StepName,
     vote: &Vote,
-    bitset: u64,
-    signature: &[u8; 48],
+    step_votes: &StepVotes,
     committee: &Committee,
     cfg: &sortition::Config,
 ) -> Result<QuorumResult, StepSigError> {
+    let bitset = step_votes.bitset;
+    let signature = step_votes.aggregate_signature().inner();
     let sub_committee = committee.intersect(bitset);
 
     let total = committee.total_occurrences(&sub_committee);

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -213,9 +213,9 @@ impl RatificationHandler {
         Message::new_quorum(quorum)
     }
 
-    pub(crate) fn reset(&mut self, iteration: u8) {
-        self.validation_result = Default::default();
-        self.curr_iteration = iteration;
+    pub(crate) fn reset(&mut self, iter: u8, validation: ValidationResult) {
+        self.validation_result = validation;
+        self.curr_iteration = iter;
     }
 
     pub(crate) fn validation_result(&self) -> &ValidationResult {

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -112,7 +112,7 @@ impl MsgHandler for RatificationHandler {
         Ok(HandleMsgOutput::Pending)
     }
 
-    /// Collects the reduction message from former iteration.
+    /// Collects the ratification message from former iteration.
     async fn collect_from_past(
         &mut self,
         msg: Message,
@@ -121,7 +121,7 @@ impl MsgHandler for RatificationHandler {
     ) -> Result<HandleMsgOutput, ConsensusError> {
         let p = Self::unwrap_msg(msg)?;
 
-        // Collect vote, if msg payload is reduction type
+        // Collect vote, if msg payload is ratification type
         if let Some((sv, quorum_reached)) = self.aggregator.collect_vote(
             committee,
             p.header(),

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -212,7 +212,7 @@ impl RatificationHandler {
         result: &ValidationResult,
     ) -> Result<(), ConsensusError> {
         match result.quorum {
-            QuorumType::ValidQuorum | QuorumType::NilQuorum => {
+            QuorumType::Valid | QuorumType::NoCandidate => {
                 if let Some(generator) = round_committees.get_generator(iter) {
                     if let Some(validation_committee) =
                         round_committees.get_validation_committee(iter)

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -29,7 +29,7 @@ pub struct RatificationHandler {
     pub(crate) sv_registry: SafeCertificateInfoRegistry,
 
     pub(crate) aggregator: Aggregator,
-    pub(crate) validation_result: ValidationResult,
+    validation_result: ValidationResult,
     pub(crate) curr_iteration: u8,
 }
 
@@ -105,7 +105,7 @@ impl MsgHandler for RatificationHandler {
                         ru,
                         iteration,
                         p.vote,
-                        p.validation_result.sv,
+                        *p.validation_result.sv(),
                         sv,
                     )));
                 }
@@ -237,7 +237,8 @@ impl RatificationHandler {
         round_committees: &RoundCommittees,
         result: &ValidationResult,
     ) -> Result<(), ConsensusError> {
-        match result.quorum {
+        // TODO: Check all quorums
+        match result.quorum() {
             QuorumType::Valid | QuorumType::NoCandidate => {
                 if let Some(generator) = round_committees.get_generator(iter) {
                     if let Some(validation_committee) =
@@ -254,9 +255,8 @@ impl RatificationHandler {
                         verify_votes(
                             header,
                             StepName::Validation,
-                            &result.vote,
-                            result.sv.bitset,
-                            result.sv.aggregate_signature.inner(),
+                            result.vote(),
+                            result.sv(),
                             validation_committee,
                             &cfg,
                         )?;
@@ -271,6 +271,6 @@ impl RatificationHandler {
             }
             _ => {}
         }
-        Err(ConsensusError::InvalidValidation(result.quorum))
+        Err(ConsensusError::InvalidValidation(result.quorum()))
     }
 }

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -6,7 +6,7 @@
 
 use crate::commons::{ConsensusError, RoundUpdate};
 use crate::msg_handler::{HandleMsgOutput, MsgHandler};
-use crate::step_votes_reg::{SafeCertificateInfoRegistry, SvType};
+use crate::step_votes_reg::SafeCertificateInfoRegistry;
 use async_trait::async_trait;
 use node_data::{ledger, StepName};
 use tracing::{error, warn};
@@ -93,7 +93,7 @@ impl MsgHandler for RatificationHandler {
                 iteration,
                 &p.vote,
                 sv,
-                SvType::Ratification,
+                StepName::Ratification,
                 quorum_reached,
                 committee.excluded().expect("Generator to be excluded"),
             );
@@ -135,7 +135,7 @@ impl MsgHandler for RatificationHandler {
                     p.header().iteration,
                     &p.vote,
                     sv,
-                    SvType::Ratification,
+                    StepName::Ratification,
                     quorum_reached,
                     committee.excluded().expect("Generator to be excluded"),
                 )

--- a/consensus/src/ratification/step.rs
+++ b/consensus/src/ratification/step.rs
@@ -43,7 +43,7 @@ impl<T: Operations + 'static, DB: Database> RatificationStep<T, DB> {
         let msg = Message::new_ratification(ratification);
 
         // Publish ratification vote
-        info!(event = "send_vote", validation_bitset = result.sv.bitset);
+        info!(event = "send_vote", validation_bitset = result.sv().bitset);
 
         // Publish
         outbound.send(msg.clone()).await.unwrap_or_else(|err| {
@@ -68,7 +68,7 @@ pub fn build_ratification_payload(
     let sign_info = message::SignInfo::default();
     let mut ratification = message::payload::Ratification {
         header,
-        vote: result.vote.clone(),
+        vote: result.vote().clone(),
         sign_info,
         validation_result: result.clone(),
         timestamp: get_current_timestamp(),
@@ -113,9 +113,9 @@ impl<T: Operations + 'static, DB: Database> RatificationStep<T, DB> {
             name = self.name(),
             round = round,
             iter = iteration,
-            vote = ?handler.validation_result().vote,
-            fsv_bitset = handler.validation_result().sv.bitset,
-            quorum_type = format!("{:?}", handler.validation_result().quorum)
+            vote = ?handler.validation_result().vote(),
+            fsv_bitset = handler.validation_result().sv().bitset,
+            quorum_type = ?handler.validation_result().quorum()
         )
     }
 
@@ -129,7 +129,7 @@ impl<T: Operations + 'static, DB: Database> RatificationStep<T, DB> {
 
         if ctx.am_member(committee) {
             let mut handler = self.handler.lock().await;
-            let vote = &handler.validation_result().vote;
+            let vote = handler.validation_result().vote();
 
             let vote_msg = Self::try_vote(
                 &ctx.round_update,

--- a/consensus/src/ratification/step.rs
+++ b/consensus/src/ratification/step.rs
@@ -91,7 +91,7 @@ impl<T: Operations + 'static, DB: Database> RatificationStep<T, DB> {
 
     pub async fn reinitialize(
         &mut self,
-        msg: &Message,
+        msg: Message,
         round: u64,
         iteration: u8,
     ) {

--- a/consensus/src/ratification/step.rs
+++ b/consensus/src/ratification/step.rs
@@ -96,7 +96,6 @@ impl<T: Operations + 'static, DB: Database> RatificationStep<T, DB> {
         iteration: u8,
     ) {
         let mut handler = self.handler.lock().await;
-        handler.reset(iteration);
 
         // The Validation output must be the vote to cast on the Ratification.
         // There are these possible outputs:
@@ -104,9 +103,9 @@ impl<T: Operations + 'static, DB: Database> RatificationStep<T, DB> {
         //  - (unsupported) Quorum on Invalid Candidate
         //  - Quorum on Timeout (NilQuorum)
         //  - No Quorum (Validation step time-ed out)
-
-        if let Payload::ValidationResult(p) = &msg.payload {
-            handler.validation_result = p.as_ref().clone();
+        match msg.payload {
+            Payload::ValidationResult(p) => handler.reset(iteration, *p),
+            _ => handler.reset(iteration, Default::default()),
         }
 
         tracing::debug!(

--- a/consensus/src/step_votes_reg.rs
+++ b/consensus/src/step_votes_reg.rs
@@ -49,7 +49,9 @@ impl CertificateInfo {
         }
     }
 
-    pub(crate) fn add_sv(
+    /// Set certificate stepvotes according to [step]. Store [quorum_reached] to
+    /// calculate [CertificateInfo::is_ready]
+    pub(crate) fn set_sv(
         &mut self,
         iter: u8,
         sv: StepVotes,
@@ -164,7 +166,7 @@ impl CertInfoRegistry {
 
         let cert_info = cert.get_or_insert(vote);
 
-        cert_info.add_sv(iteration, sv, step, quorum_reached);
+        cert_info.set_sv(iteration, sv, step, quorum_reached);
         cert_info
             .is_ready()
             .then(|| Self::build_quorum_msg(&self.ru, iteration, cert_info))

--- a/consensus/src/step_votes_reg.rs
+++ b/consensus/src/step_votes_reg.rs
@@ -9,16 +9,12 @@ use node_data::bls::PublicKeyBytes;
 use node_data::ledger::{Certificate, IterationInfo, StepVotes};
 use node_data::message::payload::Vote;
 use node_data::message::{payload, Message};
+use node_data::StepName;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::debug;
-
-pub(crate) enum SvType {
-    Validation,
-    Ratification,
-}
+use tracing::{debug, warn};
 
 #[derive(Clone)]
 struct CertificateInfo {
@@ -57,23 +53,33 @@ impl CertificateInfo {
         &mut self,
         iter: u8,
         sv: StepVotes,
-        svt: SvType,
+        step: StepName,
         quorum_reached: bool,
     ) {
-        match svt {
-            SvType::Validation => {
+        match step {
+            StepName::Validation => {
                 self.cert.validation = sv;
 
                 if quorum_reached {
                     self.quorum_reached_validation = quorum_reached;
                 }
             }
-            SvType::Ratification => {
+            StepName::Ratification => {
                 self.cert.ratification = sv;
 
                 if quorum_reached {
                     self.quorum_reached_ratification = quorum_reached;
                 }
+            }
+            _ => {
+                warn!(
+                    event = "invalid add_sv",
+                    iter,
+                    data = format!("{}", self),
+                    quorum_reached,
+                    ?step
+                );
+                return;
             }
         }
 
@@ -147,7 +153,7 @@ impl CertInfoRegistry {
         iteration: u8,
         vote: &Vote,
         sv: StepVotes,
-        svt: SvType,
+        step: StepName,
         quorum_reached: bool,
         generator: &PublicKeyBytes,
     ) -> Option<Message> {
@@ -158,7 +164,7 @@ impl CertInfoRegistry {
 
         let cert_info = cert.get_or_insert(vote);
 
-        cert_info.add_sv(iteration, sv, svt, quorum_reached);
+        cert_info.add_sv(iteration, sv, step, quorum_reached);
         cert_info
             .is_ready()
             .then(|| Self::build_quorum_msg(&self.ru, iteration, cert_info))

--- a/consensus/src/user/committee.rs
+++ b/consensus/src/user/committee.rs
@@ -126,14 +126,10 @@ impl Committee {
     }
 
     pub fn total_occurrences(&self, voters: &Cluster<PublicKey>) -> usize {
-        let mut total = 0;
-        for (item_pk, _) in voters.iter() {
-            if let Some(weight) = self.votes_for(item_pk) {
-                total += weight;
-            };
-        }
-
-        total
+        voters
+            .iter()
+            .flat_map(|(voter, _)| self.votes_for(voter))
+            .sum()
     }
 }
 

--- a/consensus/src/user/sortition.rs
+++ b/consensus/src/user/sortition.rs
@@ -249,7 +249,7 @@ mod tests {
         let cfg = Config::raw(Seed::default(), 7777, 8, 64, None);
 
         let c = Committee::new(&p, &cfg);
-        assert_eq!(c.quorum(), 43);
+        assert_eq!(c.super_majority_quorum(), 43);
     }
 
     #[test]

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -128,6 +128,7 @@ impl MsgHandler for ValidationHandler {
                     Vote::NoCandidate => QuorumType::NilQuorum,
                     Vote::Invalid(_) => QuorumType::InvalidQuorum,
                     Vote::Valid(_) => QuorumType::ValidQuorum,
+                    Vote::NoQuorum => QuorumType::NoQuorum,
                 };
                 info!(event = "quorum reached", %vote);
                 return Ok(final_result(sv, vote, quorum_type));

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -65,7 +65,7 @@ impl ValidationHandler {
 
 #[async_trait]
 impl MsgHandler for ValidationHandler {
-    /// Verifies if a msg is a valid reduction message.
+    /// Verifies if a msg is a valid validation message.
     fn verify(
         &self,
         msg: &Message,
@@ -83,7 +83,7 @@ impl MsgHandler for ValidationHandler {
         Ok(())
     }
 
-    /// Collects the reduction message.
+    /// Collects the validation message.
     async fn collect(
         &mut self,
         msg: Message,
@@ -103,7 +103,7 @@ impl MsgHandler for ValidationHandler {
             return Ok(HandleMsgOutput::Pending);
         }
 
-        // Collect vote, if msg payload is reduction type
+        // Collect vote, if msg payload is validation type
         if let Some((sv, quorum_reached)) = self.aggr.collect_vote(
             committee,
             p.header(),
@@ -138,7 +138,7 @@ impl MsgHandler for ValidationHandler {
         Ok(HandleMsgOutput::Pending)
     }
 
-    /// Collects the reduction message from former iteration.
+    /// Collects the validation message from former iteration.
     async fn collect_from_past(
         &mut self,
         msg: Message,
@@ -147,7 +147,7 @@ impl MsgHandler for ValidationHandler {
     ) -> Result<HandleMsgOutput, ConsensusError> {
         let p = Self::unwrap_msg(msg)?;
 
-        // Collect vote, if msg payload is reduction type
+        // Collect vote, if msg payload is validation type
         if let Some((sv, quorum_reached)) = self.aggr.collect_vote(
             committee,
             p.header(),

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -7,9 +7,10 @@
 use crate::aggregator::Aggregator;
 use crate::commons::{ConsensusError, RoundUpdate};
 use crate::msg_handler::{HandleMsgOutput, MsgHandler};
-use crate::step_votes_reg::{SafeCertificateInfoRegistry, SvType};
+use crate::step_votes_reg::SafeCertificateInfoRegistry;
 use async_trait::async_trait;
 use node_data::ledger::{Block, StepVotes};
+use node_data::StepName;
 use tracing::{info, warn};
 
 use crate::user::committee::Committee;
@@ -115,7 +116,7 @@ impl MsgHandler for ValidationHandler {
                 iteration,
                 &p.vote,
                 sv,
-                SvType::Validation,
+                StepName::Validation,
                 quorum_reached,
                 committee.excluded().expect("Generator to be excluded"),
             );
@@ -159,7 +160,7 @@ impl MsgHandler for ValidationHandler {
                     p.header().iteration,
                     &p.vote,
                     sv,
-                    SvType::Validation,
+                    StepName::Validation,
                     quorum_reached,
                     committee.excluded().expect("Generator to be excluded"),
                 )

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -24,11 +24,8 @@ fn final_result(
     vote: Vote,
     quorum: QuorumType,
 ) -> HandleMsgOutput {
-    let msg = Message::from_validation_result(payload::ValidationResult {
-        sv,
-        vote,
-        quorum,
-    });
+    let p = payload::ValidationResult::new(sv, vote, quorum);
+    let msg = Message::from_validation_result(p);
 
     HandleMsgOutput::Ready(msg)
 }

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -181,8 +181,6 @@ impl MsgHandler for ValidationHandler {
             {
                 return Ok(HandleMsgOutput::Ready(quorum_msg));
             }
-
-            return Ok(final_result(sv, p.vote, QuorumType::Valid));
         }
 
         Ok(HandleMsgOutput::Pending)

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -66,9 +66,7 @@ impl MsgHandler for ValidationHandler {
     fn verify(
         &self,
         msg: &Message,
-        _ru: &RoundUpdate,
         _iteration: u8,
-        _committee: &Committee,
         _round_committees: &RoundCommittees,
     ) -> Result<(), ConsensusError> {
         match &msg.payload {

--- a/consensus/src/validation/step.rs
+++ b/consensus/src/validation/step.rs
@@ -209,7 +209,7 @@ impl<T: Operations + 'static> ValidationStep<T> {
 
     pub async fn reinitialize(
         &mut self,
-        msg: &Message,
+        msg: Message,
         round: u64,
         iteration: u8,
     ) {

--- a/node-data/src/encoding.rs
+++ b/node-data/src/encoding.rs
@@ -322,7 +322,7 @@ impl Serializable for ValidationResult {
         let vote = Vote::read(r)?;
         let quorum = QuorumType::read(r)?;
 
-        Ok(ValidationResult { sv, vote, quorum })
+        Ok(ValidationResult::new(sv, vote, quorum))
     }
 }
 

--- a/node-data/src/ledger.rs
+++ b/node-data/src/ledger.rs
@@ -258,7 +258,7 @@ impl BlockWithLabel {
 #[cfg_attr(any(feature = "faker", test), derive(Dummy))]
 pub struct StepVotes {
     pub bitset: u64,
-    pub aggregate_signature: Signature,
+    pub(crate) aggregate_signature: Signature,
 }
 
 impl StepVotes {
@@ -271,6 +271,10 @@ impl StepVotes {
 
     pub fn is_empty(&self) -> bool {
         self.bitset == 0 || self.aggregate_signature.is_zeroed()
+    }
+
+    pub fn aggregate_signature(&self) -> &Signature {
+        &self.aggregate_signature
     }
 }
 

--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -554,19 +554,19 @@ pub mod payload {
             })
         }
     }
-    #[derive(Clone, Copy, Default)]
+    #[derive(Clone, Copy, Debug, Default)]
     #[cfg_attr(
         any(feature = "faker", test),
         derive(fake::Dummy, Eq, PartialEq)
     )]
     pub enum QuorumType {
-        /// Quorum on Valid Candidate
-        ValidQuorum = 0,
-        // Quorum on Invalid Candidate
-        InvalidQuorum = 1,
-        //Quorum on Timeout (NilQuorum)
-        NilQuorum = 2,
-        // NoQuorum
+        /// Supermajority of Valid votes
+        Valid = 0,
+        /// Majority of Invalid votes
+        Invalid = 1,
+        /// Majority of NoCandidate votes
+        NoCandidate = 2,
+        /// No quorum reached (timeout expired)
         #[default]
         NoQuorum = 255,
     }
@@ -574,23 +574,11 @@ pub mod payload {
     impl From<u8> for QuorumType {
         fn from(v: u8) -> QuorumType {
             match v {
-                0 => QuorumType::ValidQuorum,
-                1 => QuorumType::InvalidQuorum,
-                2 => QuorumType::NilQuorum,
+                0 => QuorumType::Valid,
+                1 => QuorumType::Invalid,
+                2 => QuorumType::NoCandidate,
                 _ => QuorumType::NoQuorum,
             }
-        }
-    }
-
-    impl fmt::Debug for QuorumType {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let label = match self {
-                QuorumType::ValidQuorum => "valid_quorum",
-                QuorumType::InvalidQuorum => "invalid_quorum",
-                QuorumType::NilQuorum => "nil_quorum",
-                QuorumType::NoQuorum => "no_quorum",
-            };
-            f.write_str(label)
         }
     }
 
@@ -1174,7 +1162,7 @@ mod tests {
                     bitset: 12345,
                     aggregate_signature: [1; 48].into(),
                 },
-                quorum: payload::QuorumType::ValidQuorum,
+                quorum: payload::QuorumType::Valid,
                 vote: payload::Vote::Valid([5; 32]),
             },
             timestamp: 1_000_000,

--- a/node/benches/accept.rs
+++ b/node/benches/accept.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use dusk_consensus::commons::RoundUpdate;
@@ -24,7 +25,7 @@ use dusk_consensus::user::{
     cluster::Cluster, committee::Committee, provisioners::Provisioners,
     sortition::Config as SortitionConfig,
 };
-use node_data::message::payload::{ValidationResult, Vote};
+use node_data::message::payload::{QuorumType, ValidationResult, Vote};
 use node_data::{
     bls::PublicKey,
     ledger::{Certificate, StepVotes},
@@ -60,7 +61,7 @@ fn create_step_votes(
                 pk.clone(),
                 *sk,
                 mrb_header,
-                Duration::from_millis(1),
+                HashMap::default(),
             );
             let sig = match step {
                 StepName::Validation => {
@@ -74,10 +75,11 @@ fn create_step_votes(
                     dusk_consensus::build_ratification_payload(
                         &ru,
                         iteration,
-                        &ValidationResult {
+                        &ValidationResult::new(
+                            StepVotes::default(),
                             vote,
-                            ..Default::default()
-                        },
+                            QuorumType::Valid,
+                        ),
                     )
                     .sign_info
                     .signature

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -639,6 +639,8 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
             .unwrap_or_default()
             .average()
             .unwrap_or(MIN_STEP_TIMEOUT)
+            .max(MIN_STEP_TIMEOUT)
+            .min(MAX_STEP_TIMEOUT)
     }
 }
 

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -360,9 +360,9 @@ impl<DB: database::DB, VM: vm::VMExecution> Operations for Executor<DB, VM> {
         elapsed: Duration,
     ) -> Result<(), Error> {
         let db_key = match step_name {
-            StepName::Proposal => &MD_AVG_PROPOSAL[..],
-            StepName::Validation => &MD_AVG_VALIDATION[..],
-            StepName::Ratification => &MD_AVG_RATIFICATION[..],
+            StepName::Proposal => MD_AVG_PROPOSAL,
+            StepName::Validation => MD_AVG_VALIDATION,
+            StepName::Ratification => MD_AVG_RATIFICATION,
         };
 
         let db = self.db.read().await;

--- a/node/src/database/rocksdb.rs
+++ b/node/src/database/rocksdb.rs
@@ -42,11 +42,11 @@ const MAX_MEMPOOL_SIZE: usize = 64 * 1024 * 1024; // 64 MiB
 const DB_FOLDER_NAME: &str = "chain.db";
 
 // List of supported metadata keys
-pub const MD_HASH_KEY: &[u8; 8] = b"hash_key";
-pub const MD_STATE_ROOT_KEY: &[u8; 14] = b"state_hash_key";
-pub const MD_AVG_VALIDATION: &[u8; 19] = b"avg_validation_time";
-pub const MD_AVG_RATIFICATION: &[u8; 21] = b"avg_ratification_time";
-pub const MD_AVG_PROPOSAL: &[u8; 17] = b"avg_proposal_time";
+pub const MD_HASH_KEY: &[u8] = b"hash_key";
+pub const MD_STATE_ROOT_KEY: &[u8] = b"state_hash_key";
+pub const MD_AVG_VALIDATION: &[u8] = b"avg_validation_time";
+pub const MD_AVG_RATIFICATION: &[u8] = b"avg_ratification_time";
+pub const MD_AVG_PROPOSAL: &[u8] = b"avg_proposal_time";
 
 #[derive(Clone)]
 pub struct Backend {

--- a/node/testbed.sh
+++ b/node/testbed.sh
@@ -51,7 +51,7 @@
 	  RUSK_STATE_PATH=${RUSK_STATE_PATH} cargo r --release -p rusk -- recovery-state --init $GENESIS_PATH
 	  echo "starting node $ID ..."
     echo "${KEYS_PATH}/node_$ID.keys"
-	  RUSK_STATE_PATH=${RUSK_STATE_PATH} ./target/release/rusk --kadcast-bootstrap "$BOOTSTRAP_ADDR" --kadcast-public-address "$PUBLIC_ADDR" --log-type="json" --log-level="debug" --log-filter="dusk_consensus=debug"  --consensus-keys-path="${KEYS_PATH}/node_$ID.keys" --db-path="$NODE_FOLDER" --http-listen-addr "$WS_LISTEN_ADDR" --delay-on-resp-msg=10 > "${TEMPD}/node_${ID}.log" &
+	  RUSK_STATE_PATH=${RUSK_STATE_PATH} ./target/release/rusk --kadcast-bootstrap "$BOOTSTRAP_ADDR" --kadcast-public-address "$PUBLIC_ADDR" --log-type="json" --log-level="info" --log-filter="dusk_consensus=debug"  --consensus-keys-path="${KEYS_PATH}/node_$ID.keys" --db-path="$NODE_FOLDER" --http-listen-addr "$WS_LISTEN_ADDR" --delay-on-resp-msg=10 > "${TEMPD}/node_${ID}.log" &
 	}
 
 	## Use ~/.cargo/bin/tokio-console --retain-for 0s http://127.0.0.1:10000 to connect console to first node


### PR DESCRIPTION
Additionally:
- Change quorum terminology to reflect new names defined in #1268
- Refactor codebase to get rid of unused function arguments
- Refactor codebase to be more idiomatic 
- Fix validation::collect_from_past from returning a final_result even if the quorum is not reached
- Adapt node benches to previous PRs changes

Resolves #1183 