### PR TITLE
Set consensus RFT conditionally

### DIFF
--- a/consensus/CHANGELOG.md
+++ b/consensus/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change dependencies declarations enforce bytecheck [#1371]
 - Expose `verify_step_votes`. [#50]
+- Increase `CONSENSUS_ROLLING_FINALITY_THRESHOLD` from 5 to 20.
 
 ### Removed
 

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 pub const CONSENSUS_MAX_ITER: u8 = 255;
 
 /// Number of consecutive attested blocks needed to consider a final block.
-pub const CONSENSUS_ROLLING_FINALITY_THRESHOLD: u64 = 5;
+pub const CONSENSUS_ROLLING_FINALITY_THRESHOLD: u64 = 20;
 
 /// Percentage number that determines quorums.
 pub const SUPERMAJORITY_THRESHOLD: f64 = 0.67;

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -287,6 +287,15 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
         // Final from rolling
         let mut ffr = false;
 
+        // FIXME: Remove later, adjust CONSENSUS_ROLLING_FINALITY_THRESHOLD
+        // based on block height
+        let consensus_rolling_finality_threshold =
+            if blk.header().height <= 50645 {
+                5
+            } else {
+                CONSENSUS_ROLLING_FINALITY_THRESHOLD
+            };
+
         // Define new block label
         let label = match (attested, mrb.is_final()) {
             (true, true) => Label::Final,
@@ -294,7 +303,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
             (true, _) => {
                 let current = blk.header().height;
                 let target = current
-                    .checked_sub(CONSENSUS_ROLLING_FINALITY_THRESHOLD)
+                    .checked_sub(consensus_rolling_finality_threshold)
                     .unwrap_or_default();
                 self.db.read().await.view(|t| {
                     for h in (target..current).rev() {


### PR DESCRIPTION
- Increase `CONSENSUS_ROLLING_FINALITY_THRESHOLD` from 5 to 20.
- Introduce conditional RFT based on block height to remain backward compatible.