### PR TITLE
Consensus: Increase RFT & MST

### DIFF
--- a/consensus/CHANGELOG.md
+++ b/consensus/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change dependencies declarations enforce bytecheck [#1371]
 - Expose `verify_step_votes`. [#50]
+- Increase `CONSENSUS_ROLLING_FINALITY_THRESHOLD` from 5 to 20.
 
 ### Removed
 

--- a/consensus/CHANGELOG.md
+++ b/consensus/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change dependencies declarations enforce bytecheck [#1371]
 - Expose `verify_step_votes`. [#50]
 - Increase `CONSENSUS_ROLLING_FINALITY_THRESHOLD` from 5 to 20.
+- Increase `MIN_STEP_TIMEOUT` from 2s to 5s.
 
 ### Removed
 

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -34,6 +34,6 @@ pub const RELAX_ITERATION_THRESHOLD: u8 = 10;
 /// Emergency mode is enabled only for the last N iterations
 pub const EMERGENCY_MODE_ITERATION_THRESHOLD: u8 = CONSENSUS_MAX_ITER - 9;
 
-pub const MIN_STEP_TIMEOUT: Duration = Duration::from_secs(2);
+pub const MIN_STEP_TIMEOUT: Duration = Duration::from_secs(5);
 pub const MAX_STEP_TIMEOUT: Duration = Duration::from_secs(30);
 pub const TIMEOUT_INCREASE: Duration = Duration::from_secs(2);

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 pub const CONSENSUS_MAX_ITER: u8 = 255;
 
 /// Number of consecutive attested blocks needed to consider a final block.
-pub const CONSENSUS_ROLLING_FINALITY_THRESHOLD: u64 = 5;
+pub const CONSENSUS_ROLLING_FINALITY_THRESHOLD: u64 = 20;
 
 /// Percentage number that determines quorums.
 pub const SUPERMAJORITY_THRESHOLD: f64 = 0.67;


### PR DESCRIPTION
- Increase `CONSENSUS_ROLLING_FINALITY_THRESHOLD` from 5 to 20.
- Increase `MIN_STEP_TIMEOUT` from 2s to 5s.