### PR TITLE
Selective provisioners update

### DIFF
--- a/consensus/src/user/provisioners.rs
+++ b/consensus/src/user/provisioners.rs
@@ -86,6 +86,18 @@ impl Provisioners {
         self.members.entry(pubkey_bls).or_insert_with(|| stake);
     }
 
+    pub fn replace_stake(
+        &mut self,
+        pubkey_bls: PublicKey,
+        stake: Stake,
+    ) -> Option<Stake> {
+        self.members.insert(pubkey_bls, stake)
+    }
+
+    pub fn remove_stake(&mut self, pubkey_bls: &PublicKey) -> Option<Stake> {
+        self.members.remove(pubkey_bls)
+    }
+
     /// Adds a new member with reward=0 and elibile_since=0.
     ///
     /// Useful for implementing unit tests.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -25,7 +25,7 @@ tracing-subscriber = { version = "0.3", features = [
 async-channel = "1.7"
 
 stake-contract-types = { version = "0.0.1-rc.2", path = "../contracts/stake-types" }
-rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
+rkyv = "0.7"
 
 rocksdb_lib = { package = "rocksdb", version = "0.21", default-features = false }
 dusk-bytes = "^0.1"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,6 +24,9 @@ tracing-subscriber = { version = "0.3", features = [
 ] }
 async-channel = "1.7"
 
+stake-contract-types = { version = "0.0.1-rc.2", path = "../contracts/stake-types" }
+rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
+
 rocksdb_lib = { package = "rocksdb", version = "0.21", default-features = false }
 dusk-bytes = "^0.1"
 node-data = { version = "0.1", path = "../node-data" }

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -35,7 +35,7 @@ use crate::database::rocksdb::{
 };
 
 const DUSK: u64 = 1_000_000_000;
-const MINIMUM_STAKE: u64 = 1_000_000 * DUSK;
+const MINIMUM_STAKE: u64 = 1_000 * DUSK;
 
 #[allow(dead_code)]
 pub(crate) enum RevertTarget {

--- a/node/src/vm.rs
+++ b/node/src/vm.rs
@@ -4,9 +4,10 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use dusk_bls12_381_sign::PublicKey;
 use dusk_consensus::{
-    operations::CallParams, operations::VerificationOutput,
-    user::provisioners::Provisioners,
+    operations::{CallParams, VerificationOutput},
+    user::{provisioners::Provisioners, stake::Stake},
 };
 use node_data::ledger::{Block, SpentTransaction, Transaction};
 
@@ -45,6 +46,8 @@ pub trait VMExecution: Send + Sync + 'static {
         &self,
         base_commit: [u8; 32],
     ) -> anyhow::Result<Provisioners>;
+
+    fn get_provisioner(&self, pk: &PublicKey) -> anyhow::Result<Option<Stake>>;
 
     fn get_state_root(&self) -> anyhow::Result<[u8; 32]>;
 

--- a/rusk/src/lib/chain/rusk.rs
+++ b/rusk/src/lib/chain/rusk.rs
@@ -348,6 +348,10 @@ impl Rusk {
             )
         }))
     }
+
+    pub fn provisioner(&self, pk: &BlsPublicKey) -> Result<Option<StakeData>> {
+        self.query(STAKE_CONTRACT, "get_stake", pk)
+    }
 }
 
 fn accept(

--- a/rusk/src/lib/chain/vm.rs
+++ b/rusk/src/lib/chain/vm.rs
@@ -148,6 +148,21 @@ impl VMExecution for Rusk {
         self.query_provisioners(Some(base_commit))
     }
 
+    fn get_provisioner(
+        &self,
+        pk: &dusk_bls12_381_sign::PublicKey,
+    ) -> anyhow::Result<Option<Stake>> {
+        let stake = self
+            .provisioner(pk)
+            .map_err(|e| anyhow::anyhow!("Cannot get provisioner {e}"))?
+            .and_then(|stake| {
+                stake.amount.map(|(value, eligibility)| {
+                    Stake::new(value, stake.reward, eligibility)
+                })
+            });
+        Ok(stake)
+    }
+
     fn get_state_root(&self) -> anyhow::Result<[u8; 32]> {
         Ok(self.state_root())
     }


### PR DESCRIPTION
Change the node to call get_provisioners in 3 cases:
1. Startup
2. Rollback
3. Something wrong while inspecting transactions

For any other case described in the issue, a precise `get_provisioner` is performed

See also #1442 