### PR TITLE
Support lazy-initialization for all services

### DIFF
--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -97,7 +97,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
         )
         .await?;
 
-        let acc = self.acceptor.as_mut().unwrap();
+        let acc = self.acceptor.as_mut().expect("initialize is called");
         acc.write().await.spawn_task().await;
 
         // Start-up FSM instance

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -161,11 +161,10 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
             acc.try_revert(RevertTarget::LastFinalizedState).await?;
         }
 
-        acc.spawn_task().await;
         Ok(acc)
     }
 
-    async fn spawn_task(&self) {
+    pub async fn spawn_task(&self) {
         let provisioners_list = self.provisioners_list.read().await.clone();
         let base_timeouts = self.adjust_round_base_timeouts().await;
 

--- a/node/src/databroker.rs
+++ b/node/src/databroker.rs
@@ -93,6 +93,15 @@ impl DataBrokerSrv {
 impl<N: Network, DB: database::DB, VM: vm::VMExecution>
     LongLivedService<N, DB, VM> for DataBrokerSrv
 {
+    async fn initialize(
+        &mut self,
+        _network: Arc<RwLock<N>>,
+        _db: Arc<RwLock<DB>>,
+        _vm: Arc<RwLock<VM>>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn execute(
         &mut self,
         network: Arc<RwLock<N>>,

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -166,10 +166,10 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> Node<N, DB, VM> {
 
     pub async fn initialize(
         &self,
-        service_list: &mut Vec<Box<dyn LongLivedService<N, DB, VM>>>,
+        services: &mut [Box<dyn LongLivedService<N, DB, VM>>],
     ) -> anyhow::Result<()> {
         // Run lazy-initialization of all registered services
-        for mut service in service_list.into_iter() {
+        for service in services.iter_mut() {
             info!("initialize service {}", service.name());
             service
                 .initialize(

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -87,6 +87,13 @@ pub trait Network: Send + Sync + 'static {
 pub trait LongLivedService<N: Network, DB: database::DB, VM: vm::VMExecution>:
     Send + Sync
 {
+    async fn initialize(
+        &mut self,
+        network: Arc<RwLock<N>>,
+        database: Arc<RwLock<DB>>,
+        vm: Arc<RwLock<VM>>,
+    ) -> anyhow::Result<()>;
+
     async fn execute(
         &mut self,
         network: Arc<RwLock<N>>,
@@ -155,6 +162,25 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> Node<N, DB, VM> {
 
     pub fn network(&self) -> Arc<RwLock<N>> {
         self.network.clone()
+    }
+
+    pub async fn initialize(
+        &self,
+        service_list: &mut Vec<Box<dyn LongLivedService<N, DB, VM>>>,
+    ) -> anyhow::Result<()> {
+        // Run lazy-initialization of all registered services
+        for mut service in service_list.into_iter() {
+            info!("initialize service {}", service.name());
+            service
+                .initialize(
+                    self.network.clone(),
+                    self.database.clone(),
+                    self.vm_handler.clone(),
+                )
+                .await?;
+        }
+
+        Ok(())
     }
 
     /// Sets up and runs a list of services.

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -55,6 +55,15 @@ impl crate::Filter for TxFilter {
 impl<N: Network, DB: database::DB, VM: vm::VMExecution>
     LongLivedService<N, DB, VM> for MempoolSrv
 {
+    async fn initialize(
+        &mut self,
+        _network: Arc<RwLock<N>>,
+        _db: Arc<RwLock<DB>>,
+        _vm: Arc<RwLock<VM>>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn execute(
         &mut self,
         network: Arc<RwLock<N>>,

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     #[cfg(feature = "node")]
-    let (rusk, node, service_list) = {
+    let (rusk, node, mut service_list) = {
         let state_dir = rusk_profile::get_rusk_state_dir()?;
         info!("Using state from {state_dir:?}");
         let rusk = Rusk::new(state_dir)?;
@@ -152,6 +152,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         _ws_server =
             Some(HttpServer::bind(handler, listen_addr, cert_and_key).await?);
+    }
+
+    #[cfg(feature = "node")]
+    // initialize all registered services
+    if let Err(err) = node.0.initialize(&mut service_list).await {
+        tracing::error!("node initialization  failed: {}", err);
+        return Err(err.into());
     }
 
     #[cfg(feature = "node")]


### PR DESCRIPTION
Any services registered may introduce an implementation of `Initialize` in which method any major components/structs/resources can be fully instantiated. On implementing `Initialize`, ChainSrv instantiates `Acceptor` struct by which it can revert to last final state before spawning `DataBroker` service.