### PR TITLE
Allow queries in parallel with state transitions

### DIFF
--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Allow state transitions to be executed in parallel with queries [#970]
 - Change dependencies declarations enforce bytecheck [#1371]
 - Fixed tests passing incorrect arguments [#1371]
 
@@ -199,6 +200,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1257]: https://github.com/dusk-network/rusk/pull/1257
 [#1219]: https://github.com/dusk-network/rusk/issues/1219
 [#1144]: https://github.com/dusk-network/rusk/issues/1144
+[#970]: https://github.com/dusk-network/rusk/issues/970
 [#401]: https://github.com/dusk-network/rusk/issues/401
 [#369]: https://github.com/dusk-network/rusk/issues/369
 [#327]: https://github.com/dusk-network/rusk/issues/327

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -17,9 +17,9 @@ tokio = { version = "1.15", features = ["rt-multi-thread", "fs", "macros"] }
 futures-util = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", features = [
-  "fmt",
-  "env-filter",
-  "json",
+    "fmt",
+    "env-filter",
+    "json",
 ] }
 clap = { version = "=4.4", features = ["env", "string", "derive"] }
 semver = "1.0"
@@ -80,7 +80,7 @@ async-graphql = "5.0"
 
 ## Ephemeral dependencies
 tempfile = { version = "3.2", optional = true }
-rusk-recovery = { version = "0.6", path = "../rusk-recovery", optional = true}
+rusk-recovery = { version = "0.6", path = "../rusk-recovery", optional = true }
 
 ## testwallet dependencies
 futures = { version = "0.3", optional = true }

--- a/rusk/src/lib/chain.rs
+++ b/rusk/src/lib/chain.rs
@@ -10,7 +10,7 @@ mod vm;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 
 use node::database::rocksdb::Backend;
 use node::network::Kadcast;
@@ -19,15 +19,16 @@ use rusk_abi::VM;
 
 pub const MINIMUM_STAKE: Dusk = dusk(1000.0);
 
-pub struct RuskInner {
-    pub current_commit: [u8; 32],
-    pub base_commit: [u8; 32],
-    pub vm: VM,
+#[derive(Debug, Clone, Copy)]
+pub struct RuskTip {
+    pub current: [u8; 32],
+    pub base: [u8; 32],
 }
 
 #[derive(Clone)]
 pub struct Rusk {
-    inner: Arc<Mutex<RuskInner>>,
+    tip: Arc<RwLock<RuskTip>>,
+    vm: Arc<VM>,
     dir: PathBuf,
 }
 

--- a/rusk/src/lib/chain.rs
+++ b/rusk/src/lib/chain.rs
@@ -27,8 +27,8 @@ pub struct RuskTip {
 
 #[derive(Clone)]
 pub struct Rusk {
-    tip: Arc<RwLock<RuskTip>>,
-    vm: Arc<VM>,
+    pub(crate) tip: Arc<RwLock<RuskTip>>,
+    pub(crate) vm: Arc<VM>,
     dir: PathBuf,
 }
 

--- a/rusk/src/lib/chain/rusk.rs
+++ b/rusk/src/lib/chain/rusk.rs
@@ -11,7 +11,7 @@ use std::{fs, io};
 use parking_lot::{RwLock, RwLockWriteGuard};
 use sha3::{Digest, Sha3_256};
 use tokio::task;
-use tracing::warn;
+use tracing::debug;
 
 use dusk_bls12_381::BlsScalar;
 use dusk_bls12_381_sign::PublicKey as BlsPublicKey;
@@ -371,7 +371,7 @@ impl Rusk {
 async fn delete_commits(vm: Arc<VM>, commits: Vec<[u8; 32]>) {
     for commit in commits {
         if let Err(err) = vm.delete_commit(commit) {
-            warn!("failed deleting commit {}: {err}", hex::encode(commit));
+            debug!("failed deleting commit {}: {err}", hex::encode(commit));
         }
     }
 }

--- a/rusk/src/lib/chain/rusk.rs
+++ b/rusk/src/lib/chain/rusk.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::sync::{mpsc, Arc, LazyLock};
 use std::{fs, io};
 
-use parking_lot::{RwLock, RwLockWriteGuard};
+use parking_lot::RwLock;
 use sha3::{Digest, Sha3_256};
 use tokio::task;
 use tracing::debug;
@@ -271,18 +271,6 @@ impl Rusk {
 
     pub fn revert_to_base_root(&self) -> Result<[u8; 32]> {
         self.revert(self.base_root())
-    }
-
-    /// Perform an action with the underlying data structure.
-    ///
-    /// This should **not be used** internally, to avoid locking the structure
-    /// for too long of a period of time.
-    pub fn with_tip<'a, F, T>(&'a self, closure: F) -> T
-    where
-        F: FnOnce(RwLockWriteGuard<'a, RuskTip>, &'a VM) -> T,
-    {
-        let tip = self.tip.write();
-        closure(tip, &self.vm)
     }
 
     /// Get the base root.

--- a/rusk/src/lib/chain/vm/query.rs
+++ b/rusk/src/lib/chain/vm/query.rs
@@ -25,12 +25,9 @@ impl Rusk {
         S: AsRef<str>,
         V: Into<Vec<u8>>,
     {
-        let inner = self.inner.lock();
-
         // For queries we set a point limit of effectively infinite and a block
         // height of zero since this doesn't affect the result.
-        let current_commit = inner.current_commit;
-        let mut session = rusk_abi::new_session(&inner.vm, current_commit, 0)?;
+        let mut session = self.session(0, None)?;
 
         session
             .call_raw(contract_id, fn_name.as_ref(), fn_arg, u64::MAX)
@@ -74,12 +71,9 @@ impl Rusk {
         R::Archived: Deserialize<R, Infallible>
             + for<'b> CheckBytes<DefaultValidator<'b>>,
     {
-        let inner = self.inner.lock();
-
         // For queries we set a point limit of effectively infinite and a block
         // height of zero since this doesn't affect the result.
-        let current_commit = inner.current_commit;
-        let mut session = rusk_abi::new_session(&inner.vm, current_commit, 0)?;
+        let mut session = self.session(0, None)?;
 
         let mut result = session
             .call(contract_id, call_name, call_arg, u64::MAX)?
@@ -108,12 +102,9 @@ impl Rusk {
         A: for<'b> Serialize<StandardBufSerializer<'b>>,
         A::Archived: for<'b> bytecheck::CheckBytes<DefaultValidator<'b>>,
     {
-        let inner = self.inner.lock();
-
         // For queries we set a point limit of effectively infinite and a block
         // height of zero since this doesn't affect the result.
-        let current_commit = base_commit.unwrap_or(inner.current_commit);
-        let mut session = rusk_abi::new_session(&inner.vm, current_commit, 0)?;
+        let mut session = self.session(0, base_commit)?;
 
         session.feeder_call::<_, ()>(
             contract_id,
@@ -136,12 +127,9 @@ impl Rusk {
         S: AsRef<str>,
         V: Into<Vec<u8>>,
     {
-        let inner = self.inner.lock();
-
         // For queries we set a point limit of effectively infinite and a block
         // height of zero since this doesn't affect the result.
-        let current_commit = inner.current_commit;
-        let mut session = rusk_abi::new_session(&inner.vm, current_commit, 0)?;
+        let mut session = self.session(0, None)?;
 
         session.feeder_call_raw(
             contract_id,


### PR DESCRIPTION
State transitions can now be performed in parallel with queries. This solves the issue of the consensus being blocked while the state is queried.

This is achieved by disentangling the `VM` from the current and base commits in the `Rusk` data structure, as well as using a `RWLock` instead of a `Mutex`, allowing for write-locking only at the end of a state transition. This, together with a read-lock and release for when the tip is used, effectively means that queries are never in contention with state transitions when they don't need to be.

We also ensure that, on a `finalize`, commits are deleted on a separate task, such that we don't block execution of the state transition itself, allowing the node to return from a `finalize` before the deletions are processed.

Resolves: #970
See-also: #1084