### PR TITLE
Introduce recovery checkpoints per epoch

### DIFF
--- a/node/src/vm.rs
+++ b/node/src/vm.rs
@@ -35,7 +35,11 @@ pub trait VMExecution: Send + Sync + 'static {
         blk: &Block,
     ) -> anyhow::Result<(Vec<SpentTransaction>, VerificationOutput)>;
 
-    fn finalize_state(&self, commit: [u8; 32]) -> anyhow::Result<()>;
+    fn finalize_state(
+        &self,
+        commit: [u8; 32],
+        block_height: u64,
+    ) -> anyhow::Result<()>;
 
     fn preverify(&self, tx: &Transaction) -> anyhow::Result<()>;
 
@@ -58,4 +62,5 @@ pub trait VMExecution: Send + Sync + 'static {
 
     fn revert(&self, state_hash: [u8; 32]) -> anyhow::Result<[u8; 32]>;
     fn revert_to_finalized(&self) -> anyhow::Result<[u8; 32]>;
+    fn revert_to_epoch(&self) -> anyhow::Result<[u8; 32]>;
 }

--- a/rusk-profile/src/lib.rs
+++ b/rusk-profile/src/lib.rs
@@ -147,6 +147,11 @@ pub fn to_rusk_state_id_path<P: AsRef<Path>>(dir: P) -> PathBuf {
     dir.join("state.id")
 }
 
+pub fn to_rusk_epoch_id_path<P: AsRef<Path>>(dir: P) -> PathBuf {
+    let dir = dir.as_ref();
+    dir.join("epoch.id")
+}
+
 pub fn get_common_reference_string() -> io::Result<Vec<u8>> {
     let crs = get_rusk_profile_dir()?.join(CRS_FNAME);
     read(crs)

--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Keep last epoch state commit as a reversion target [#1094]
 - Allow state transitions to be executed in parallel with queries [#970]
 - Change dependencies declarations enforce bytecheck [#1371]
 - Fixed tests passing incorrect arguments [#1371]
@@ -213,6 +214,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1257]: https://github.com/dusk-network/rusk/pull/1257
 [#1219]: https://github.com/dusk-network/rusk/issues/1219
 [#1144]: https://github.com/dusk-network/rusk/issues/1144
+[#1094]: https://github.com/dusk-network/rusk/issues/1094
 [#970]: https://github.com/dusk-network/rusk/issues/970
 [#931]: https://github.com/dusk-network/rusk/issues/931
 [#401]: https://github.com/dusk-network/rusk/issues/401

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -50,6 +50,7 @@ dusk-jubjub = "0.13"
 dusk-pki = "0.13"
 dusk-bytes = "0.1"
 kadcast = "0.6.0-rc"
+stake-contract-types = { version = "0.0.1-rc.2", path = "../contracts/stake-types" }
 dusk-wallet-core = "0.24.0-plonk.0.16-rc.2"
 phoenix-core = { version = "0.21", default-features = false, features = ["rkyv-impl", "alloc"] }
 tungstenite = "0.20"
@@ -61,7 +62,6 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tokio-rustls = "0.25"
 rustls-pemfile = "2"
 async-trait = "0.1"
-
 
 transfer-circuits = { version = "0.5", path = "../circuits/transfer" }
 rusk-profile = { version = "0.6", path = "../rusk-profile" }

--- a/rusk/src/lib/chain.rs
+++ b/rusk/src/lib/chain.rs
@@ -27,6 +27,7 @@ pub const MINIMUM_STAKE: Dusk = dusk(1000.0);
 pub struct RuskTip {
     pub current: [u8; 32],
     pub base: [u8; 32],
+    pub epoch: Option<[u8; 32]>,
 }
 
 #[derive(Clone)]

--- a/rusk/src/lib/chain/rusk.rs
+++ b/rusk/src/lib/chain/rusk.rs
@@ -431,13 +431,7 @@ impl Rusk {
             tip.epoch = Some(commit);
         }
 
-        let current_commit = tip.current;
-        let base_commit = tip.base;
-
-        let f = commit_retain_closure(
-            [current_commit, base_commit, commit],
-            tip.epoch,
-        );
+        let f = commit_retain_closure([tip.current, commit], tip.epoch);
 
         // We will delete all commits except the new commit, and the previous
         // epoch.

--- a/rusk/src/lib/chain/vm.rs
+++ b/rusk/src/lib/chain/vm.rs
@@ -89,9 +89,13 @@ impl VMExecution for Rusk {
         Ok((txs, verification_output))
     }
 
-    fn finalize_state(&self, commit: [u8; 32]) -> anyhow::Result<()> {
+    fn finalize_state(
+        &self,
+        commit: [u8; 32],
+        block_height: u64,
+    ) -> anyhow::Result<()> {
         info!("Received finalize request");
-        self.finalize_state(commit)
+        self.finalize_state(commit, block_height)
             .map_err(|e| anyhow::anyhow!("Cannot finalize state: {e}"))
     }
 
@@ -159,6 +163,14 @@ impl VMExecution for Rusk {
 
     fn revert_to_finalized(&self) -> anyhow::Result<[u8; 32]> {
         let state_hash = self.revert_to_base_root().map_err(|inner| {
+            anyhow::anyhow!("Cannot revert to finalized: {inner}")
+        })?;
+
+        Ok(state_hash)
+    }
+
+    fn revert_to_epoch(&self) -> anyhow::Result<[u8; 32]> {
+        let state_hash = self.revert_to_epoch_root().map_err(|inner| {
             anyhow::anyhow!("Cannot revert to finalized: {inner}")
         })?;
 

--- a/rusk/src/lib/error.rs
+++ b/rusk/src/lib/error.rs
@@ -51,6 +51,8 @@ pub enum Error {
     Other(Box<dyn std::error::Error>),
     /// Commit not found amongst existing commits
     CommitNotFound([u8; 32]),
+    /// Last epoch not found when expected
+    LastEpochNotFound,
 }
 
 impl std::error::Error for Error {}
@@ -145,6 +147,9 @@ impl fmt::Display for Error {
             }
             Error::CommitNotFound(commit_id) => {
                 write!(f, "Commit not found, id = {}", hex::encode(commit_id),)
+            }
+            Error::LastEpochNotFound => {
+                write!(f, "Last epoch not found when expected")
             }
         }
     }


### PR DESCRIPTION
These commits makes `rusk` keep the last epoch in the state as a reversion target should it be required.

As a bonus, since we now keep the state commits - namely the epoch - for a longer, less ephemeral, time, it becomes possible to think of downloading the state directly from other nodes on the network. 

Resolves: #1094
See-also: #1068
