### PR TITLE
stake-contract: track provisioners change

### DIFF
--- a/contracts/stake/src/lib.rs
+++ b/contracts/stake/src/lib.rs
@@ -76,7 +76,20 @@ unsafe fn stakes(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |_: ()| STATE.stakes())
 }
 
+#[no_mangle]
+unsafe fn prev_state_changes(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |_: ()| STATE.prev_state_changes())
+}
+
 // "Management" transactions
+
+#[no_mangle]
+unsafe fn before_state_transition(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |_: ()| {
+        assert_external_caller();
+        STATE.before_state_transition()
+    })
+}
 
 #[no_mangle]
 unsafe fn insert_stake(arg_len: u32) -> u32 {


### PR DESCRIPTION
Save previous state of provisioners that changed in last block.

See also https://github.com/dusk-network/rusk/pull/1513#discussion_r1516380001
See also #1516 