### PR TITLE
stake-contract: fix slash

### DIFF
--- a/rusk/tests/services/stake.rs
+++ b/rusk/tests/services/stake.rs
@@ -332,7 +332,7 @@ pub async fn slash() -> Result<()> {
 
     let after_slash = wallet.get_stake(0).unwrap();
     assert_eq!(after_slash.reward, 0);
-    assert_eq!(after_slash.amount, Some((dusk(20.0), 2160)));
+    assert_eq!(after_slash.amount, Some((dusk(20.0), 4320)));
     let new_balance = rusk.module_balance(STAKE_CONTRACT).unwrap();
     assert_eq!(new_balance, module_balance);
     let module_balance = new_balance;
@@ -354,11 +354,11 @@ pub async fn slash() -> Result<()> {
     let (_, prev) = last_changes.first().expect("Something changed").clone();
     let prev = prev.expect("to have something");
     assert_eq!(prev.reward, 0);
-    assert_eq!(prev.amount, Some((dusk(20.0), 2160)));
+    assert_eq!(prev.amount, Some((dusk(20.0), 4320)));
 
     let after_slash = wallet.get_stake(0).unwrap();
     assert_eq!(after_slash.reward, 0);
-    assert_eq!(after_slash.amount, Some((dusk(20.0), 2160)));
+    assert_eq!(after_slash.amount, Some((dusk(20.0), 4320)));
     let new_balance = rusk.module_balance(STAKE_CONTRACT).unwrap();
     assert_eq!(new_balance, module_balance);
     let module_balance = new_balance;
@@ -380,11 +380,11 @@ pub async fn slash() -> Result<()> {
     let (_, prev) = last_changes.first().expect("Something changed").clone();
     let prev = prev.expect("to have something");
     assert_eq!(prev.reward, 0);
-    assert_eq!(prev.amount, Some((dusk(20.0), 2160)));
+    assert_eq!(prev.amount, Some((dusk(20.0), 4320)));
 
     let after_slash = wallet.get_stake(0).unwrap();
     assert_eq!(after_slash.reward, 0);
-    assert_eq!(after_slash.amount, Some((dusk(20.0), 10800)));
+    assert_eq!(after_slash.amount, Some((dusk(20.0), 12960)));
     let new_balance = rusk.module_balance(STAKE_CONTRACT).unwrap();
     assert_eq!(new_balance, module_balance);
 
@@ -398,7 +398,7 @@ pub async fn slash() -> Result<()> {
     )
     .expect_err("Slashing a public key that never staked must fail");
 
-    //Ensure we still have changes, because generator procedure failed
+    //Ensure we still have previous changes, because generator procedure failed
     let last_changes = rusk
         .last_provisioners_change(None)
         .unwrap()
@@ -406,7 +406,7 @@ pub async fn slash() -> Result<()> {
     let (_, prev) = last_changes.first().expect("Something changed").clone();
     let prev = prev.expect("to have something");
     assert_eq!(prev.reward, 0);
-    assert_eq!(prev.amount, Some((dusk(20.0), 2160)));
+    assert_eq!(prev.amount, Some((dusk(20.0), 4320)));
 
     generator_procedure(&rusk, &[], 9001, BLOCK_GAS_LIMIT, vec![], None)
         .expect("To work properly");


### PR DESCRIPTION
- Remove tracking when no hard_slash is performed
- Fix hard_slash panic when unstake is performed in the same block
- Fix slash panic when unstake is performed in the same block
- Change shift eligibility to add a maturity epoch
- Change events order to reflect the doc