### PR TITLE
ITN migration: track rewards

### DIFF
--- a/consensus/src/user/provisioners.rs
+++ b/consensus/src/user/provisioners.rs
@@ -17,6 +17,7 @@ use std::mem;
 use super::committee::Committee;
 
 pub const DUSK: u64 = 1_000_000_000;
+const MINIMUM_STAKE: u64 = 1_000 * DUSK;
 
 #[derive(Clone, Debug)]
 pub struct Provisioners {
@@ -117,9 +118,9 @@ impl Provisioners {
         &self,
         round: u64,
     ) -> impl Iterator<Item = (&PublicKey, &Stake)> {
-        self.members
-            .iter()
-            .filter(move |(_, m)| m.is_eligible(round))
+        self.members.iter().filter(move |(_, m)| {
+            m.is_eligible(round) && m.value() >= MINIMUM_STAKE
+        })
     }
 
     /// Runs the deterministic sortition algorithm which determines the

--- a/node-data/src/ledger.rs
+++ b/node-data/src/ledger.rs
@@ -52,20 +52,9 @@ pub struct Header {
 
 impl std::fmt::Debug for Header {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let timestamp = chrono::NaiveDateTime::from_timestamp_opt(
-            self.timestamp as i64,
-            0,
-        )
-        .map_or_else(
-            || "unknown".to_owned(),
-            |v| {
-                chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
-                    v,
-                    chrono::Utc,
-                )
-                .to_rfc2822()
-            },
-        );
+        let timestamp =
+            chrono::DateTime::from_timestamp(self.timestamp as i64, 0)
+                .map_or_else(|| "unknown".to_owned(), |v| v.to_rfc2822());
 
         f.debug_struct("Header")
             .field("version", &self.version)

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -34,9 +34,6 @@ use crate::database::rocksdb::{
     MD_STATE_ROOT_KEY,
 };
 
-const DUSK: u64 = 1_000_000_000;
-const MINIMUM_STAKE: u64 = 1_000 * DUSK;
-
 #[allow(dead_code)]
 pub(crate) enum RevertTarget {
     Commit([u8; 32]),
@@ -239,7 +236,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
                 let pk = change.into_public_key();
                 let prov = pk.to_bs58();
                 match vm.get_provisioner(pk.inner())? {
-                    Some(stake) if stake.value() >= MINIMUM_STAKE => {
+                    Some(stake) => {
                         debug!(event = "new_stake", src, prov, ?stake);
                         let replaced = new_prov.replace_stake(pk, stake);
                         if replaced.is_none() && !is_stake {

--- a/rusk/src/lib/chain/vm.rs
+++ b/rusk/src/lib/chain/vm.rs
@@ -15,7 +15,7 @@ use dusk_consensus::user::stake::Stake;
 use node::vm::VMExecution;
 use node_data::ledger::{Block, SpentTransaction, Transaction};
 
-use super::{Rusk, MINIMUM_STAKE};
+use super::Rusk;
 
 impl VMExecution for Rusk {
     fn execute_state_transition<I: Iterator<Item = Transaction>>(
@@ -197,12 +197,6 @@ impl Rusk {
         let provisioners = self
             .provisioners(base_commit)
             .map_err(|e| anyhow::anyhow!("Cannot get provisioners {e}"))?
-            .filter(|(_, stake)| {
-                stake
-                    .amount
-                    .map(|(amount, _)| amount >= MINIMUM_STAKE)
-                    .unwrap_or_default()
-            })
             .filter_map(|(key, stake)| {
                 stake.amount.map(|(value, eligibility)| {
                     let stake = Stake::new(value, stake.reward, eligibility);


### PR DESCRIPTION
Right now changes in reward are not tracked, since they are not impacting the sortition.
However the rewards needs to be tracked in order to properly migrate rewards during stake contract migration.