### PR TITLE
web-wallet: Update Tabs to use native scroll

### DIFF
--- a/web-wallet/CHANGELOG.md
+++ b/web-wallet/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `OperationResult` to infer error messages from arbitrary values [#1524]
+- Update Tabs to use native scroll behavior [#1320]
 
 ## [0.4.0] - 2024-03-13
 
@@ -137,6 +138,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1309]: https://github.com/dusk-network/rusk/issues/1309
 [#1311]: https://github.com/dusk-network/rusk/issues/1311
 [#1317]: https://github.com/dusk-network/rusk/issues/1317
+[#1320]: https://github.com/dusk-network/rusk/issues/1320
 [#1322]: https://github.com/dusk-network/rusk/issues/1322
 [#1323]: https://github.com/dusk-network/rusk/issues/1323
 [#1334]: https://github.com/dusk-network/rusk/issues/1334

--- a/web-wallet/src/lib/dusk/components/Tabs/Tabs.css
+++ b/web-wallet/src/lib/dusk/components/Tabs/Tabs.css
@@ -18,8 +18,15 @@
   user-select: none;
   cursor: default;
   white-space: nowrap;
-  overflow: hidden;
+  overflow-x: scroll;
   width: 100%;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  overscroll-behavior: contain;
+}
+
+.dusk-tabs-list::-webkit-scrollbar {
+  display: none;
 }
 
 .dusk-tab-item {

--- a/web-wallet/src/lib/dusk/components/Tabs/Tabs.svelte
+++ b/web-wallet/src/lib/dusk/components/Tabs/Tabs.svelte
@@ -7,7 +7,6 @@
   import { isGTE, isLTE } from "lamb";
 
   import { Button, Icon } from "$lib/dusk/components";
-  import { lerp } from "$lib/dusk/math";
   import { makeClassName } from "$lib/dusk/string";
 
   import "./Tabs.css";
@@ -26,9 +25,6 @@
 
   /** @type {Number} */
   let rafID = 0;
-
-  let scrollLeftStart = 0;
-  let touchStartX = 0;
 
   const dispatch = createEventDispatcher();
 
@@ -56,26 +52,6 @@
 
     /** @param {HTMLLIElement} tab */
     return (tab) => checkSide(tab.getBoundingClientRect()[side]);
-  }
-
-  /** @type {import("svelte/elements").TouchEventHandler<HTMLUListElement>} */
-  function handleTouchMove(event) {
-    const scrollX = tabsList.scrollLeft;
-    const deltaX = event.targetTouches[0].clientX - touchStartX;
-    const amount = lerp(deltaX, scrollX - scrollLeftStart, 0.4);
-
-    tabsList.scrollBy(-amount, 0);
-  }
-
-  /** @type {import("svelte/elements").TouchEventHandler<HTMLUListElement>} */
-  function handleTouchStart(event) {
-    scrollLeftStart = tabsList.scrollLeft;
-    touchStartX = event.targetTouches[0].clientX;
-  }
-
-  /** @type {import("svelte/elements").WheelEventHandler<HTMLUListElement>} */
-  function handleWheel(event) {
-    tabsList.scrollBy(event.deltaX, 0);
   }
 
   // @ts-ignore
@@ -204,9 +180,6 @@
     bind:this={tabsList}
     class="dusk-tabs-list"
     on:scroll={updateScrollStatus}
-    on:touchmove|preventDefault={handleTouchMove}
-    on:touchstart={handleTouchStart}
-    on:wheel|preventDefault={handleWheel}
     role="tablist"
   >
     {#each items as item (item.id)}

--- a/web-wallet/src/lib/dusk/components/__tests__/Tabs.spec.js
+++ b/web-wallet/src/lib/dusk/components/__tests__/Tabs.spec.js
@@ -353,34 +353,4 @@ describe("Tabs", () => {
     firstTabGetRectSpy.mockRestore();
     lastTabGetRectSpy.mockRestore();
   });
-
-  it("should scroll the tabs on a wheel event if there is a deltaX", async () => {
-    const { container } = render(Tabs, baseOptions);
-    const tabsList = getAsHTMLElement(container, ".dusk-tabs-list");
-    const eventInfo1 = { deltaX: 0 };
-    const eventInfo2 = { deltaX: 100 };
-
-    await fireEvent.wheel(tabsList, eventInfo1);
-    await fireEvent.wheel(tabsList, eventInfo2);
-
-    expect(scrollBySpy).toHaveBeenCalledTimes(2);
-    expect(scrollBySpy).toHaveBeenNthCalledWith(1, eventInfo1.deltaX, 0);
-    expect(scrollBySpy).toHaveBeenNthCalledWith(2, eventInfo2.deltaX, 0);
-  });
-
-  it("should scroll the tabs on a touch move", async () => {
-    const { container } = render(Tabs, baseOptions);
-    const tabsList = getAsHTMLElement(container, ".dusk-tabs-list");
-    const touchStartInfo = { targetTouches: [{ clientX: 10 }] };
-    const touchMoveInfo = { targetTouches: [{ clientX: 100 }] };
-
-    // "magic number" calculated with the current algorithm
-    const expectedScrollX = -54;
-
-    await fireEvent.touchStart(tabsList, touchStartInfo);
-    await fireEvent.touchMove(tabsList, touchMoveInfo);
-
-    expect(scrollBySpy).toHaveBeenCalledTimes(1);
-    expect(scrollBySpy).toHaveBeenCalledWith(expectedScrollX, 0);
-  });
 });


### PR DESCRIPTION
Resolves dusk-network/web-wallet#880

Brings back the native scroll behavior for mobile:

https://github.com/dusk-network/rusk/assets/34094428/b66ec1ad-eced-4088-a703-403d21fc6a20

Restores the default behavior on desktop, when scrolling on a touchpad – in-browser navigation gestures work as expected, addressing accessibility concerns with the previous implementation:

https://github.com/dusk-network/rusk/assets/34094428/04aab014-727b-4df8-8dd8-79726d97dae1