### PR TITLE
Memoize `verify_proof` host function

### DIFF
--- a/rusk-abi/CHANGELOG.md
+++ b/rusk-abi/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Memoize the `verify_proof` function [#1228]
+
 ### Changed
 
 - Change dependencies declarations enforce bytecheck [#1371]
@@ -194,6 +198,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add README.md
 
 [#1371]: https://github.com/dusk-network/rusk/issues/1371
+[#1228]: https://github.com/dusk-network/rusk/issues/1228
 [#945]: https://github.com/dusk-network/rusk/issues/945
 [#937]: https://github.com/dusk-network/rusk/issues/937
 [#874]: https://github.com/dusk-network/rusk/issues/874

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -28,6 +28,8 @@ piecrust = { version = "0.17.0", optional = true }
 # These are patches since these crates don't seem to like semver.
 rkyv = { version = "=0.7.39", default-features = false, features = ["size_32"] }
 
+lru = "0.12"
+
 [dev-dependencies]
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 once_cell = "1.15"

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -22,12 +22,11 @@ dusk-bytes = "0.1"
 bytecheck = { version = "0.6", default-features = false }
 dusk-plonk = { version = "0.16", default-features = false, features = ["rkyv-impl", "alloc"] }
 
-piecrust-uplink = { version= "0.11.0" }
+piecrust-uplink = { version = "0.11.0" }
 piecrust = { version = "0.17.0", optional = true }
 
 # These are patches since these crates don't seem to like semver.
 rkyv = { version = "=0.7.39", default-features = false, features = ["size_32"] }
-wasmer = { version = "=3.1", optional = true }
 
 [dev-dependencies]
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }

--- a/rusk-abi/src/host.rs
+++ b/rusk-abi/src/host.rs
@@ -199,7 +199,7 @@ pub fn verify_proof(
 
     let hash = *hasher.finalize().as_array();
 
-    // If the proof verification has been memoized with the se arguments,
+    // If the proof verification has been memoized with the same arguments,
     // return the result
     if let Some(v) = get_cache(hash) {
         return v;
@@ -229,7 +229,9 @@ pub fn verify_proof(
     });
 
     let verified = verifier.verify(&proof, &pis).is_ok();
-    put_cache(hash, verified);
+    if verified {
+        put_cache(hash, verified);
+    }
     verified
 }
 

--- a/rusk/benches/block_ingestion.rs
+++ b/rusk/benches/block_ingestion.rs
@@ -44,6 +44,15 @@ fn load_txs() -> Vec<Transaction> {
         });
     }
 
+    for tx in txs.iter() {
+        match rusk::verifier::verify_proof(&tx.inner) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(anyhow::anyhow!("Invalid proof")),
+            Err(e) => Err(anyhow::anyhow!("Cannot verify the proof: {e}")),
+        }
+        .unwrap()
+    }
+
     txs
 }
 


### PR DESCRIPTION
We memoize the `verify_proof` host function, allowing proof verification to happen only once per equivalent proof being verified in the context of transaction execution.

This is achieved by using a static LruCache, with a configurable maximum limit of entries. These entries are key-value pairs, from the hash of the parameters used to call the proof verification to the outcome of said verification, which allows us to skip verification if we've already performed it once.

Resolves #1228