### PR TITLE
rusk-recovery: add snapshot of ITN2 to testnet.toml

### DIFF
--- a/rusk-recovery/config/testnet.toml
+++ b/rusk-recovery/config/testnet.toml
@@ -8,6 +8,55 @@ address = '4LULsDGr3CkeZcVDSfM9UtNr1Xa9DF7HqCEnfnbsDH2HXkkoCfdQWKpEwKwPF6enrSVoT
 seed = 0xdead_beef
 notes = [500_000_000_000_000_000]
 
+[[balance]]
+address = '9Qary8ZQHYRZos3jmk4FBqo35mjJVqzsLwFthRB2vDY3wNnFTNaKcVrw66aeF8X2nYf5YqSq6BDs4TfsbBEnGjd'
+seed = 0xdead_beef
+notes = [10_000_000_000_000_000]
+
+[[balance]]
+address = 'qDfYNMkC3m2GdBLsPy4PFCiVfniuSTzWPwgZ9TvpcgRE8ztEJvsCcfTJGtokrxGF8cFyCc9k1gZQpjrdjSooeDE'
+seed = 0xdead_beef
+notes = [10_000_000_000_000_000]
+
+[[balance]]
+address = '5KtKooBDhJFU3caSPC4AjeHcigRFrZ5YswMFXu74mavmu7sWPExDn9DLsYqTiLdstz8r7JJsDvAnCBhRPyEHQWMF'
+seed = 0xdead_beef
+notes = [10_000_000_000_000_000]
+
+[[balance]]
+address = '2N9o1ghLKx1e93weUJtymqfRoemjHu43xXLZWKEmbn6WtMrd3WzXDvtEw4LkBd4DskempKKq9UthdKGVoeXvhZVs'
+seed = 0xdead_beef
+notes = [10_000_000_000_000_000]
+
+[[balance]]
+address = '2neU6jSkQ2QnPxYfc4DaGQvkRtGeaBtU3vdfZHYh3iEWbZ3fosstgx2cKY3JVZTBiQHX3t5NetCK5v7fvoMPZaGe'
+seed = 0xdead_beef
+notes = [10_000_000_000_000_000]
+
+[[balance]]
+address = '3VHxhiWkA11vT8c5sTC4oDAk7QZ7hRqpMbrPP4z2A94mwWox1WhBWJjBMjVjQuvtJ7Mxqkm53JmH6oWBnXZqPSmi'
+seed = 0xdead_beef
+notes = [10_000_000_000_000_000]
+
+[[balance]]
+address = '3DXXr1k8NEerGwKCKsCbAaS6Da4TjkX1fYjoJeh61fPjJkyVnfiRG4A7eETTDoqWNUnmMVmvBniSMgcdWXHc7Q5J'
+seed = 0xdead_beef
+notes = [10_000_000_000_000_000]
+
+[[balance]]
+address = '2YiHv7ageZBUQif2ZRo4NUFGcZBNyWWAm3tyhchczBmPk336MX6ATkaPSLayHrhz1J6A5yfbU1zfoB8aRZBLHUK'
+seed = 0xdead_beef
+notes = [10_000_000_000_000_000]
+
+[[balance]]
+address = '3Bzh3YrwU1eiNoabHtSrwrU9AtTbAFDUt4w1rcEtCe9jztCrLzEZjJ14HBSECACf1g1jJjn5Ud1jM7oKWWjYSUTJ'
+seed = 0xdead_beef
+notes = [10_000_000_000_000_000]
+
+[[balance]]
+address = '33GGzrthCdzCT98ZvHSoXGbQVKkYPXkRfTuxxcTVDW44fJpzTdgoaZYj8tDADmfQX44Cdz9je9dvLrfa6a76Qkq9'
+seed = 0xdead_beef
+notes = [10_000_000_000_000_000]
 
 [[stake]]
 address = 'pFPEcfxidLvwmFKRQoifrSyWmmVY9UDEThoRFvGXddXRLZ8hB7xfWDYQYwHhTvZvXeL1p5Ygcnsuuxm1X8nHFJH6tEgK3cS76squcFVFSejaKJGMorYZdTup5uscNq6eDU2'

--- a/rusk-recovery/config/testnet.toml
+++ b/rusk-recovery/config/testnet.toml
@@ -128,3 +128,1669 @@ amount = 500_000_000_000_000
 [[stake]]
 address = '21SQ3HyThUvJUAtn3cfYUAisdw9h25DCp5hT2vzeiiQrvjGpmjsZKmbMMQTFSfU3EsEYtLqncXhVRkxnapwYrjYmR1tVdx3xE3nz2UkxSD1L34E1aTCoGqqZek9TfmSTQ5Sn'
 amount = 500_000_000_000_000
+
+# ITN2 Rewards
+[[stake]]
+address = 'mAkcDzY2uVvqbEv6Vkxbbro6V11z98ExmjCiNCD79Jrx3dLYrfPzrofpA5JZTDB8DWTBUUY2X895qmBkyEPTH8qs2nMStoXxv7XjxMkeCigGWjp877yzbZg2h1tsdeh99V8'
+amount = 0
+reward = 39200810000000
+
+[[stake]]
+address = 'mLx5HUo5PhsobwgMJhzL9j8TY7TjC13EsxHL7cKLTmMJ9BqvnG2RttD2uMg1FEDprnSvmN7BwCkpr6wW9XSco2ASrUjou2neUXj4uq16NreXVk4jmfr3CEHqvBrRgEzoka8'
+amount = 0
+reward = 45302459315405
+
+[[stake]]
+address = 'mNhNu5Zn21iBuPXYKfdrzQvX4Lr45MAWoxcYRS7dQz9v17ecGUJ5aXPTn8jwh4shui4N744VHN5CmDhjwVcARQ74TRtksQsxpUjYgWnypHSmxyHCD3QafCGrTFEwfApX5Ze'
+amount = 0
+reward = 10688011305745
+
+[[stake]]
+address = 'mSejRRFwVH4qSGajDVDsJoEySYr42UetyVoKJnq9F3RZ8egfyMrDNs2wB4iaJ9ZWrTkXcPGHCsW4arhfow54DnuT5gQ4oB1E4RbFmPoNW9AHFDSv8pr5gAZtiPtNuGDuta7'
+amount = 0
+reward = 5479200000000
+
+[[stake]]
+address = 'mW82qfkVP8tn3go9AUVJjvfgWTt6ERG6ZVC3zf9G31UtDvTZnKuj4akUDDzrua7tE4GSCAHn7jn26XQnhGjfB3e2EAixJY6TgJjAfrXdzuRFdwdaLTwnLWQmUddgggpXGHM'
+amount = 0
+reward = 13199848921534
+
+[[stake]]
+address = 'mZzBqZhW5hzF9f4QD15f6DQhiHCTUUuTcJp9sbgYzMmUSr2dXWdw9feeAp8Qvcq1HxYhLPY41Zot6Sc59gw76hTPPLPWajDbQBFMK2stvy7ftQT8Z8cx8PbPk4cYdq7tjKz'
+amount = 0
+reward = 7749200000000
+
+[[stake]]
+address = 'maR3HHEZi46zj7QkmUXHMrochpVGYhpKq6G2iwVMuG7qknLomQ6phVgnKx2mq7wvHxLefPM5H5Xn7wWZK8wKm7RRykovsczD97zZ1M4BXQohqza5ujVzw65fKhGFupJ9vT1'
+amount = 0
+reward = 9353601884217
+
+[[stake]]
+address = 'maV5d1FQYH4MSszXDQAYy9DaL1kcBa9MynPzNCypRAhvmc9RXbDJgGcfaHZqzhJddTfc9et4GdibXEYEP22y8UKCZ8dW3V6HJFaoQ8GvtbG2P4oGx5Gih9cWyPDUz85KXg7'
+amount = 0
+reward = 495109442243226
+
+[[stake]]
+address = 'mby7GWjqMPKj7ULWpGvpp4DC9tmg223nWzEffLirY4qKXZ3ziLpDs4MntQXwmn3JHrh5q4mdjSg6qLyi7eDQyDT2eSQ72yhB2mkDkrGbFw7TwXfB4ZeEa9eLgQ8gtq6UGWk'
+amount = 0
+reward = 5683000000000
+
+[[stake]]
+address = 'miqXjVi2xxy49Vp7wiK2YWpt2t7xj4HzTqAW1JyrSqjF7y4i4rGCgD6AijmZnZihuLd3aEq3BcM4nAeUKWvTLvmTEa78axDtH3Z8zLooQaQDNtfM7KfJ9Uvekv19YGNPTCd'
+amount = 0
+reward = 249517000000000
+
+[[stake]]
+address = 'mntoByrCpbZTBDyfsMvTMmDT9pDPhng3HA9ZKSBEerexYWAGuiEYQVdDiJAY7PAAH3AwNK3m2aspQNnFJKEEVAD9rBLAwJJwrzQQPMeTJSEMoDezNCezzSGbFGiF7fxx79r'
+amount = 0
+reward = 2621013761332640
+
+[[stake]]
+address = 'msnVj3UUqD9DMVm94JkQVxx4Xt9fvkQSTMF7GhmKZqhjveLnAqnSANpksiSq6sqegdhgkkGBppBeMPf9eRcS5f1Pewqkp9kYcefV3hn63162wNDv13hybXtjjgJeupovbCG'
+amount = 0
+reward = 5587200712853
+
+[[stake]]
+address = 'mvft6AXjR1mDtg1Qo3GzGBKZAvvxY1S6h41DSEPh9Ewj9GFR61rPQnjVaM1W9nqkHijRC2d5Yo4FSBwU8wf9eHeEJYXuMSrB7eJxvsY6HjCeDJ9pKfJLdjayAfrxEyudvx2'
+amount = 0
+reward = 26345376764288
+
+[[stake]]
+address = 'mzwpsJtkMT3qLnfPinDcN3HdfLk2VEdoogBh5B26G1U9BtfTZjCSQpHCXX2fhLg1XfkXuCVVvTDG55y6dm9szxUmEWZS1PB26UJTq6zooo74C8W9gmwbk6zSKMMHKaLFhSX'
+amount = 0
+reward = 51409601347772
+
+[[stake]]
+address = 'n6qpRa3TTmDzaiMmnqNjviJhFpj26A9RznWx8YbpQbiqs4kArZGtqyGka6FQovWWqsU3SYMDFpuRKxtoe7xGcvbh9T7GFZfM1mfFXGp1kpbT7mvooMWWGpm3rBztodgRTZ4'
+amount = 0
+reward = 140392911355009
+
+[[stake]]
+address = 'nGeRcG3E5je63fSAqXQSbAtj3U4DfqrScQUSbFWEK8c1367EfTQsNr2MbTHRq1eAAgvTtnmcNjFoC5Tj136vYAM6MeRSu1v7ZpGYLSU3QKbeGe1bm9YdRYCtMRcBLViZjRm'
+amount = 0
+reward = 162400000000000
+
+[[stake]]
+address = 'nKfphGtCdB6YDbRu1dVSDHqqKa7LwJpcYg9NhXxHpdpPaQqePqYzQXkVKJFXCqp8QD37Sv9s9gR8gkJtrAB14CnfTr386JpP4BtwqUbUnyNt73EJhzssH7GxrfL9N8Nn9Cv'
+amount = 0
+reward = 5599200262277
+
+[[stake]]
+address = 'nMTvZn6GYd7q9R6RVNv2mfBjVCDpS2eQkKncrpJB3tbUNwtbyb5fv13NsmKz5NaA5t2VuKF7qK7oCFUdNoJunvAjBHMJGdGrxoZhpgsgK512gqGeeaFjkYGQpwzYMVGuHfQ'
+amount = 0
+reward = 19999000000000
+
+[[stake]]
+address = 'nMhCGLmaEc24n3Z3sBnXAkna3de2RerwkfW12cmPyPvBtaavprAYtmi93JZgRaEa9hnQ4nPKVcCaQEmVNMvJiuTjPMWfHfxPDFwqtyExbUr67r2LooXottsEMQCqW3mRknu'
+amount = 0
+reward = 10325453961913
+
+[[stake]]
+address = 'nRDZTNgsRsaCc7aT8q9VVdy56UNRuMffEZhhRMsETEicgQunqHqKagrDsfivA4ZsEXfdmEaT1iWYmCacCuJKUFGGxpdoySzs9znfSbJscAjp2nT3jQRhtcpvujVAEYwM8eh'
+amount = 0
+reward = 24490000000000
+
+[[stake]]
+address = 'nURCBF2EPB1dDTkTPAYE4HcL65pUJm8NzohttGMHmZ712Ggt9JNGHXFs6RhQcYNzq8zsb68Tifzv52ZN7f9rwENeDhXirKjEzKzBk3fV6LyiS4xYAqGgjibPm9hVeWXpG4J'
+amount = 0
+reward = 10975202735911
+
+[[stake]]
+address = 'nWDih3TSkrMG1X4BG8A12BRQcrqdV5rd1YnCyieromYEcJZ8F8Ep3tA1DQyGFoAudgNVRwMBT5ZcmkMnG4aFgTh6DAonSun8WdnQtvCZUDAUWjSx7JoH4oD4N8qkWoiuy9X'
+amount = 0
+reward = 81238424886556
+
+[[stake]]
+address = 'nZrqbqw8mnHJf7S7waTEoVjWss5JnaHHuKex75KfRafoYJYmCErefhZikd7yMiJbUPoPcnVuH6hGPvkBha3MdedXDgdSG9PrkP78CS8GQ7Bp8tivcSoYHd8meb56SFTYrNZ'
+amount = 0
+reward = 10162229123068
+
+[[stake]]
+address = 'nb4fYpm7TANxd9u32Nkgny6KV53MkGVdLn1zLFsPt739WujLMd2MMoM1wd5F411totxVhpDMJvWAjEs5UXArgiWaozsdkr7QSwWnFYmG6DChoj6nVp1CadXJpYW18Mr5H5U'
+amount = 0
+reward = 33285403641795
+
+[[stake]]
+address = 'nb8hbL5ynH2yuG5t9PZGVbvLkwfXD4cGCEFkwdnYYSwEkqjN6qZcWoFsESWUGLE3138QTH9FHVpuH7xCvjDspqmkzNn8VCp75LgC9cMgBqUFtkX97fdXMeFnt3HNMscRB9c'
+amount = 0
+reward = 8672800000000
+
+[[stake]]
+address = 'ncrjNJfkoiPEVA5BSvfLsQmvJRyFn7GsjTKZQtmxP18pGKvMfFdkfVUmqs5TGUfAF6xFeFFBnWc2JuJTLg6uEscS1M9uGiRcPFg9Y8yyrsQTS85ETWHySYoKdUgKDf7FrhP'
+amount = 0
+reward = 7770000000000
+
+[[stake]]
+address = 'ndLdw8byg1bpsf7gyw7JmsbAXiSRfJSo8cgmVDn1JG3tqTkQdbQVypqDBqKiqxG44KXCcFbBnFtVnu8dzzBrBuJxFGpDj6D5V2RtySnVF7s4uHytNMULrxxgq3P93Nq1FzH'
+amount = 0
+reward = 24000000000000
+
+[[stake]]
+address = 'nem5qAR1LQqTxfhdMN7zq6Kn4ZrSjyY44uNcjev5rVjcsior9YtytswXpG1MJBk7Y3FRgEHc4Js6T546r4XF7Ugc33aKMGgq8ogjGxEmLo2nd28NgmJz3XNtV4BRJS2N7Qi'
+amount = 0
+reward = 6572000000000
+
+[[stake]]
+address = 'nfLSEvQFS6v4BwrgJ59TQBHJikeDyvrapcJGmtkRD45ryhH8daJRqcRUGFpW2kKtxWHx9P2P4H1YisyEC2ynYQDKTcqusfVo6EdRQnetRNRbBifxz16PNU2JV46S7QHyRjH'
+amount = 0
+reward = 9254403223912
+
+[[stake]]
+address = 'nhBn2phxNgSd9AmuzGzNvzk5ysQ2x28MwpYhNTk1qijTy73XXnB6oXk3hWgH1AJEApdzBRRa4UGDxqbhDWAGmSjdikR7EzPaXhCBUgyZ2gESgEEu9MCK1VT1FFRGwEwKrgS'
+amount = 0
+reward = 6624800000000
+
+[[stake]]
+address = 'nhurdFSUBzYNZXSwdtAkMvhxqytRvuxTkCBpcpiDeLBk1kWNzxFRQrxE3M9WDfUNAj2HaLFcFTKNvL3iFxt62ZweD8J216cf1yXLbiFgHmTLDDoQo7cAjVR5MXy19pQsxAv'
+amount = 0
+reward = 7398400262743
+
+[[stake]]
+address = 'nkCSuijXuecL4B6LQHAS7eyB5G1CFBSn6Vp92noCJjbgNEzuLbNGHdcUmz5BkhmkQGCmff49XdMEKtFPkQjydjh9LGGao39wnC3CvsefMUETUt8MJSLZxSyqJtgttqYcKRU'
+amount = 0
+reward = 35246404919171
+
+[[stake]]
+address = 'nkmW2iW76pbZg25DkTSu8UwkpjPCST884Wx9pPGjixuNmLRZo83tRtFqPePy7vENxsngEZfPdASCsp524chVGoQiUa75ieHZhJ7bB87D8vh4iwQFyzEaateNWDPms9Ssyee'
+amount = 0
+reward = 5300000000000
+
+[[stake]]
+address = 'nmbqJjGwnov6ya5CSStPWctWdaZiJa7W1aWsYWK7N4J45yS1HRDZkVpSTxGABcuugXjPdzpWHAZMk4Pb5yXUwBZVm4Nzq7nFQN6ueV1K4Rfp25VL19u3xzzosEaHDzC161C'
+amount = 0
+reward = 38501610128182
+
+[[stake]]
+address = 'noK13uKANRgCS99YmRTKGkvyjuWbCi7nNe2kTyEAyeGi9mwyP3G9jpLeU2YThgnf769uhECABiCdSuRLdHDtZjnny1KWcj6RA4hGBpUw6Mm8j83i4dhvY9gXzBgwnZkJbCF'
+amount = 0
+reward = 10187000713342
+
+[[stake]]
+address = 'nqXnf25MwWnij462yBAYBgUxFwKqss3P76H7w2JisE1czyzE4B66pQpcc9MPoi53abYhhNovWN7X9LtTip2mRJyMAH2g8UAzr3BiXzFpjTjAGaM6FN9eVbi8qk2HdvA9fF2'
+amount = 0
+reward = 6020810582643
+
+[[stake]]
+address = 'nrQnZmwCsFNfe9yBNzfieSjahmVRerYQPdXanCdiUjym7H5ML22RNYZMvWx65mJzfERUt3agRDKagz3b9fwRjGh4pjmdVhMZANAdn5djbJ9DYwGjZNq6G85QMtZ8BWopLCE'
+amount = 0
+reward = 8954800462778
+
+[[stake]]
+address = 'nva7jM9VG7TfQVHiGHUkrn6jpGq8QFgCMtAWLnJJj8X5PjR29PXqUPK9At37vSqszVpPmshPBKpzGHjjPLtjZzGRP8waF4fbLsP1Bxs2SqvWQGsR94E8X5mq21y2eJNxV6F'
+amount = 0
+reward = 108928268094203
+
+[[stake]]
+address = 'nxjyrUsJcWh4HwfKBk1NTNstfDvFGR2aU8YnERdrngWWrUjKLwjvnw6KDNa4Hs3Mbv2Q2rcWwx9L6uuiAyX5PvkZNfE7mkwf2PPrikwvCpDyj9NxpgXSgfXvgmtcwyozeuc'
+amount = 0
+reward = 1000000000000000
+
+[[stake]]
+address = 'nyDfR3XeNq9qnA2C2SuYW1CwBW4kJ6qRjs8YLDht6vWaESukBFRzdWtBs6ZtsQexKzAExASTk5pGtHZhRSEAPU51W4xx1irvCgHagvRsXuyKk1NqMi5tmXiWMrAY1uopgrx'
+amount = 0
+reward = 5499000000000
+
+[[stake]]
+address = 'nyGaY1MXjMexh5Q81dP1Dugw2MSh2e6bgzGBqdn6o2LeseKpLn9HuT7id2NExgnR9d1VQ42PfrLybhvvNvpnxLTCvgFLnNnxTVCkZTyqJv5enLFK3DT9P4qbxrahQA2gsTm'
+amount = 0
+reward = 37779037544779
+
+[[stake]]
+address = 'o2pBnhTUsiqEvoFoFkHSk5ozhvRygk2FaQYaUM6PfjaT9MWvcCZbYZcMQgxqYJPvrfkPXbCL2dobZpsxuXoaKC7YExbsckY6LCtni5iRxPu1Sz7bXdQpJb2fkQTg9wHCx4o'
+amount = 0
+reward = 10169600000000
+
+[[stake]]
+address = 'o71GNGA3SPb8UpArQjHv1VsLSpzgigYtCFhgReDXiypGW8rGBChrHgodTbGgx5qwmXQ6k2rziNmUC7ts8q8hGPT19DeTrYFQna9D7e9jtNzaotfy2imaEV3LBnu8KMMwuMW'
+amount = 0
+reward = 11042886069611
+
+[[stake]]
+address = 'o8ZifNuDmwYwZPWS6AgwJaUTcMNuGomUcNu3a9nxSsEzXo4XV8B1vCP8rz6Q3EfQmQimT9eYxy5dX3WwMz2T6FDFgZgWZDu5dsbKVb6tSkeyv3uCK9MxWdJXY52ZCYSYXKU'
+amount = 0
+reward = 18217227365897
+
+[[stake]]
+address = 'oA2RhVM1Z4FfhZNoth64MzVzuFik4TU8RPUWrmEtnq4Ua5PT6xhfEhQ5Swgz562NB91aqURtpwcuXH6VoJVTnVeKnhAm1dfWz2Lkmjt67v51qjfJb1us65YHgL25tjdYPyc'
+amount = 0
+reward = 22003200971588
+
+[[stake]]
+address = 'oAr3WkVyZxb6X6ZxLSzaU3FfA3FwA6YhdXQU41NYpE3FW6LMWo7dLcYqrCepJDGWMfynZKnoNahndT2rLQx47w48aMs7TMSUYnqpVMbYkG2RxyqZMxey3znVXQWZANbQsxG'
+amount = 0
+reward = 12310001050396
+
+[[stake]]
+address = 'oExoRHYtZVuhmTbuXcJhmoYWcKBU7A9DEKYE7j7P2AWRsA3kriqx89pWUR1XRgK4xmUSbvwQjPfabBYydvUoNExmFNEEwTkghhQTpbdrFD3JUJYKf9GW9f9rMUpicsaeGCu'
+amount = 0
+reward = 99146156296088
+
+[[stake]]
+address = 'oHUEt3hvyrMsTJyv79KfK7QzB7pnvLNgHNtzr79N6Dte24F6bL3Ja5pW75Yamrfpp3tEaaLmbAWNYnFHkLoFAmw8B7pApC4gSkPCTKeSakZmzE44SrJwukXZMWR4PXjXZcH'
+amount = 0
+reward = 21190400000000
+
+[[stake]]
+address = 'oKMXBgysxs8i4qi98KMjq2Ed3eEJDbyc5phzZBdMVUr3MJFgqmrcimCchR2n1G7PyVveaVp3UJcQGL4BqQ3M1aAsQvYgSDehv6rSMP54d9tphQLDBqV7zA7gB8QZ1torQGi'
+amount = 0
+reward = 9694502137300
+
+[[stake]]
+address = 'oMGbH2JZD2YPGPWYb2pj1Mf6ZJjwMKGpqU93p8GpDMHakJNXv8fQ9ku15k5LwwZkyHZnyg4kqeEkAkcu4TDFbVTd1ucfk2GCSx3CRHEj8sr1dGomx3i5PRG8PRMS2yRRBgw'
+amount = 0
+reward = 19374000792664
+
+[[stake]]
+address = 'oR3HnvP9EmnGi3ayx1skEaKrqijcy76Tg5z3S4mB7yqWifVBEqerccGpvkCHoiVxfL7orFZMeo2fmuxV9Hjg5TovqKXvnsixjpxVxKmmFM99Jw7gF6aBmSMjF8k6QgAa1nT'
+amount = 0
+reward = 8900000000000
+
+[[stake]]
+address = 'oTV9s4iUjmBSh839fvav4vjatfvzQpLZi7zBAhsQ5ryRTwaCGde9AvV3qPAPtr6DQ3WUgjPwKGXcxHA7ZxguDHHexhiu8HnFTGnKdT6q1aksi5sn296iZ9FWxLLDs1LLThX'
+amount = 0
+reward = 6707600000000
+
+[[stake]]
+address = 'oVRzGkBwFYa5VWsM6ZQYLhHeZtCiX96HvXU4CWeWQgkVg1gfk5LL5Aq2XVrth7g1J71oPq98w3ey83yRvNVggxiiKHMpPEnZFgfxVrJCWiqpHUG1pxJANaBFrWnoRDXu7VF'
+amount = 0
+reward = 5914000000000
+
+[[stake]]
+address = 'oVkYoZ68JmRTp8AtYwrEwbjafdQrGJQ6H56rekdPgCfnJKVFo6GSJhAeRxB8A4QHn6XAFkEczSA2xJkbybsSTxHWJQwuF7RrJg3ucdCfxiQSaEXEbnjbbBNT4Q3MzEtxzZG'
+amount = 0
+reward = 39407200262521
+
+[[stake]]
+address = 'oZmwy4BokY7GPcuTcokw7JiCJwXmPT4Ya9cx2L5iZC49chCbozBT1Xb5YMK2x2HrN9RSp91FMLNNSWPZwUkCM1kaEyHZyksqJeXExJJJBRqaZ3frLCVsDkiHJEmhxii8BJU'
+amount = 0
+reward = 137127021316298
+
+[[stake]]
+address = 'obQddzZvEE7mNJQfedj1yD8xvZzoUmw6RTL6xwbgu8MipU5trTuuPSegKHtPdvBuYHiQWRMDRP9ie3cteaTMCPBBo4WF8tmm1EtTpUdgTLNX8tkiqSSMsfLvekspivUzc5H'
+amount = 0
+reward = 22216000264213
+
+[[stake]]
+address = 'oceM43dkarVTxXx84CvSWGf96CdpKf4VGRLmwksHLaSnxuCWUtatx5g9vXpw2VXb3pHnjPgUUD8TAmUqC299Rgr6QATL7zzyaveKZ9nMam2XRGebCL4u8KMdixskDbuYamB'
+amount = 0
+reward = 5549610472784
+
+[[stake]]
+address = 'odVTKr1e3qGtnhqYbFhAwYAAaCod4bdz9kKL46Z1C9GFnofMG3pUexxd3usG7BFwM3t5fMyQsSkVziQZmtrBjHC13ZCEA78JEtKsvMuYrhfy7mYBj3AnvBqGdsVHTeeqpHA'
+amount = 0
+reward = 5399902962599
+
+[[stake]]
+address = 'oeL1eYoKSbfcDNHaRYf4NqUau6zUtJeaPaYZoAjqLuuG3PpLrG3ETdqDWh774sQprAakTD59KBdmQd7JscrgzwHCpPMmsbSzCBWwzUFRaqRTHoU79z7R5koATZqhoAxfABU'
+amount = 0
+reward = 137800000000000
+
+[[stake]]
+address = 'ohdBJHiXBMqGfB5pDDtCqRNzsraGepxUH36Evj5VowP4wyVBmGgq1Y3rPZ35nuT3emodxceT4wpio1JqQVS79LHxGbdL3oNxJLQRakTFcWsNVyPeA9uKrU2eSGR9C8JpmJp'
+amount = 0
+reward = 6599938302026
+
+[[stake]]
+address = 'oiGPqjfiKyZdxjJKPWAYdHMtaW6dVyiv5aUVFNCbsTMm5MpBywEpx7qmbUueototshKP2JkFNgGPT4iYd1nnSjgucHXQ4Rh5t4Tf4oWGLfRcdQTKBzphaVrDFaFKaR75uNQ'
+amount = 0
+reward = 326762645753103
+
+[[stake]]
+address = 'onqd5ZqKfbQVsjVzfXiDf4d1p6acut7haQjaSyihjCkvmBpBWEKZP33efMRerxSFRggk3hwpJ572bBeGwN23nu6mjTsNisSVRgDAV7LDxbYpSY6U3mJ5nLgtX1GNGrQXa5N'
+amount = 0
+reward = 66740708096447
+
+[[stake]]
+address = 'oqcCuFGu8zyT6wn9KNFY7vczeBFRx8ecrW4Raa3tAbKCVGz1p3QuoTsfaNB5dSMMziJLeo6t8MjYTuaasEhFU2XZsjGqkp5PXoTDuva4sgrgG9SeMeVHf3GkyMMxh8efxpg'
+amount = 0
+reward = 9000600262502
+
+[[stake]]
+address = 'ou1oqWcTmqnkDMRFb6yDZ5FYbbf3qXPeSdURanbWSZ4F4kXEsDVanxpTnLhRW7uAF2MPRjxii1eAmyQvHvhEWeCSkQQXz6eAz2foxGcCM5WGQzjxGGreAuQWBfsjv5y7PZF'
+amount = 0
+reward = 5749600711611
+
+[[stake]]
+address = 'ozZES9sJc2KfPDM4ovagzb6PrVkftgGmsM3wsamBKCgPWAtn2zV2Hvx55ToWcxektLCQw89na4U1DxvDUPioFSkJA3CtR2tbMtcU2PuYiKnCNcRrBuXFtmoiLcRzBqSZXJB'
+amount = 0
+reward = 104941048640966
+
+[[stake]]
+address = 'p6a2qicX5qJnDU5c7XTEpUwxyy8xG5Li91jtiZV5TzdDDiAGETraZaKTfyr9LAUDYjsYQjPjsi9GDhKfhpQAyy3XXPBtNFpYgdrX4C24pS9kMW9UWDuo56hLx6dypNt3ZTj'
+amount = 0
+reward = 8988400000000
+
+[[stake]]
+address = 'p7PBqdXXgguTJF7xQc4KMmwVAmttrNC6HVVEHXJaukPxLGUk4C5s1gMUdSkb1QH68wk46UyUhLoTbJGvpgG98n95i5u8EsNhLTEJPP3EFGAEw7jZDWadcPr4Yih2TVjDjZc'
+amount = 0
+reward = 5430400000000
+
+[[stake]]
+address = 'p7yuxdAct4dyvBwsGPzWMDChZaiaVzAxcPyBvBU5CGqzZL3dDZ2zvyC2hZh3GhQuc99kgo1fJ3SnbCvhKbj9uVCAwYUXU7L1FnWRUYD8tD6LiBAMVLwgGANPhWNdYJWeKdC'
+amount = 0
+reward = 494489074269455
+
+[[stake]]
+address = 'p9oEB9ADAntjt3DXHC4WsWFzEzwzSkV2emgVSVKtceXWjbKjam13Xx9X2fSzDBSTEi1PvjVEhACGNy5ApjE79Wnq3nhhvUWhfDfMH5ndg9bgBfkxTmBX9ez3fNhtVnihSRk'
+amount = 0
+reward = 19891000000000
+
+[[stake]]
+address = 'pAsCGjoiMA2vo1TRxzsxjUvtQcKVd65skAZSU5gr2Ux9u42t8zWgv66rWP2fe6vYDPmXEF9stEvcjw9NdJxmVLfGGueDqgmZcLXhyafoRC4rrgRkMfUPHmoXvzEqmVdZnHv'
+amount = 0
+reward = 14263200000000
+
+[[stake]]
+address = 'pCUybfSSyDJbvV2YMNrP1za2rhdbpsHSzkd1XnFwbHjeBUkmd8ZQqpBi1L9YgnSQ4zLmjPRshxQqASjiHdNuKybbCjX8e13xA3sniWyj79aaoNBYrTb2Ui3xVKsoiiG6Rwz'
+amount = 0
+reward = 6697709493387
+
+[[stake]]
+address = 'pDDBV64AFS8dg2gtCzaQs1Y1if1JnNKWaFtWDvKuvs81UNBvL4DMnfVp7B4ebPPkMoMPPYishHBQbr4jYuFrQDxb8e1QZbuhPC8NdARAgmYEK7fBN9cwL2EA2heKGEbEjbm'
+amount = 0
+reward = 9265400000000
+
+[[stake]]
+address = 'pFLMu1aTPAUTWqCw2aLxBJfZFruGKHkaasPXsGPnL6tfnecfxkgt2mWqrxoNPyexM3awpa8oyT2yjC8aERMrVwT4JNDMaXWaNyHRKb3kzaW3K24m3Z9QvDZ7FZhmczh9bs2'
+amount = 0
+reward = 21989200000000
+
+[[stake]]
+address = 'pGzWWgBxDyqTFNxhcr2DsYm4L9MoeXQNMVGpX8y4gogocQaRnywhxu1EorFDWHCASBb6BhVkbzGxtjDQAtggAUGb8o4cPbQxF7BvpNTFrtRfbxSPr4uc7E3i4jvqbh1HkYF'
+amount = 0
+reward = 7854321746103
+
+[[stake]]
+address = 'pLikTcXcNLCJtR9zTPphEQb3LAnRihcoi8kfUkq3G9CGSdHgVLbnrop48XSYb6u8RGsRctCTNiSwh7FWmRUwg8bEaJjXF2bDbBiTbQneFck2DD1YnMDNkDHE1EXAEDRn8eh'
+amount = 0
+reward = 1696992395934189
+
+[[stake]]
+address = 'pLvoQB7HbGymTsVZ3GPkwhZqR49yHM8PF89xDsxoqRWXLCHfiDLzyma5TmjeffpjiaLe7F68PxyUiCsnjorr2MJSDxN9jD8Uu44QW8EiEGds3hFm84ZtgE7qF5PzHeJ7zYA'
+amount = 0
+reward = 15127200000000
+
+[[stake]]
+address = 'pNnVt4BaNZT8Gq4Xyj5Ss9m7VpCXBSD4URAfF8iBKc17L2T2tM2mSczK6nVy7nT4kx8LLqhmz1zTbLWatcg8FYUvrFvmLa3WS7mqCgP9hoKeE5eejU56ANSwrUd4PrVh7hc'
+amount = 0
+reward = 9122800000000
+
+[[stake]]
+address = 'pRo3ETFJ68V4k5nUbv3rM6pvw8qsyrkRVTcj6xdW5nFNcqez3B1HCJNtYzgws2a3mVG4zppR3VC3rRfdd4ysfv2fFWjyXAEmSijxnDCsr469Ah2H8VZYVi6b5mdS5pNHiCT'
+amount = 0
+reward = 18195218836647
+
+[[stake]]
+address = 'pVLcJqm7111D3erTS6aKzJF75mHWjYZJvtEsXDATBccNMeywptiPQ6VDaE57PvBjpEx3Pf7BjgPfqSkk7PQvPcK7p88mtv6ssLYjXKpsMdWNxmNf6GgVHWzqJ5Hs4HNy9LA'
+amount = 0
+reward = 30161635235715
+
+[[stake]]
+address = 'pY9T2Wo96HoY2tFRAtLmY8o8Gkna5aoyphgedWuLAXsSaYUCnYPgYMJDRvMbvCUbFzRUfKw2kvjfqjWZf5rw7PWsbbuq7CiQj7GsUcJB5qhcZxMuPvKxjuxDVfAxzPP1qJh'
+amount = 0
+reward = 9371200529547
+
+[[stake]]
+address = 'pf9xrHjYmZpm9LcoTMDmDHBQqizPv1Rbwb3H5QJ4yFSv1TXiqJ1whXeNygTEjfKcaCJamBEePzoaaYZ3Cq61Zu6Kr72Ny3ofPh37TPWQGcMv43rZ1wQK85EbTrxKn7gSWLd'
+amount = 0
+reward = 5400800000000
+
+[[stake]]
+address = 'pjePGzrrEvBrjZd82VeAZgfr7J9jsidbw8or1YXkoiCtbkAaupmwg5ghAaAY8YNCgayNKiUUt7qtPG4utZq4GEzYCwq5JfFQsDHqooDuzRZUjqFmzHhjZtAJq9QyPUE3nnj'
+amount = 0
+reward = 1772762993758444
+
+[[stake]]
+address = 'ppMLM6t6GLmZb7xzx617TTHQPdHHRNSfB8PjtGe8YNbWAo4BRYfnNYZxCj62pLY8gXZqsrx7TaBS17dRsHoE81wLHgMHaYoq2z6GHX7KAD5TiRcX1w5ctiSqV3idx3SJdAe'
+amount = 0
+reward = 10202400000000
+
+[[stake]]
+address = 'puGcF44mE8Rbs957Ej7j2gaaqVZ27b5M9rgecRczcMEKSuvStpaRumM9C5qmmxKfjasdpgQo2YPfwGGHFeGb8qitEGQjE3tx4BGupxDPQBkyKpPumz7Pn2SQVtitng8CB6x'
+amount = 0
+reward = 454022495484893
+
+[[stake]]
+address = 'q2FsZVLeregzwyTowJRENLpUbTRv63xxvq6yrLVnofVt5m3UKnmStKQHmkEmeBTTLYRrAMADTz87Ga2eP72rjETLvKkxujXDyS7u7DbW59VzNiUmUVMEjh8nTs66FaxBHbD'
+amount = 0
+reward = 5349600000000
+
+[[stake]]
+address = 'qBEsVmMVqcefAtZbwAtK4JWtmtqezVJNPWY25XNoaqnEt2rBJ3iJNufmtt66Qut6rkcCiHZt5DeKEZ58psWDBAUxFnbYte2KyUg69j8NsV4M8ow6gDs47EJbpTXQrbSJH1K'
+amount = 0
+reward = 27980000000000
+
+[[stake]]
+address = 'qQBaPNADKYuK74UdXtBdq9CGrXxcaA1CAYeU5WjDdbBDwwB62fKJuNV1JGDfVgk2uog78uTmWsaCYANdQd4EqLDnYMVwC98Zn6KfX9CLUgYnQFYNS3JHgpCiq62Pi6QYGcn'
+amount = 0
+reward = 8948400000000
+
+[[stake]]
+address = 'qQFwqieL1RWKAsFqowJ2wVSE7YrGzH5yeBgePnvG4cP6hMFfmoLM5qhPqhmGSWqMifkwvvbnTvV3KzUjhwaXNf282yFQG2ZJ7mzz33faCfFk39NeeM1DPktXkod1v3qCnSi'
+amount = 0
+reward = 5632600000000
+
+[[stake]]
+address = 'qRRitpCxAnHQN2Wp6SkXktNiFLaJWdFftkznkkbYGpt9FntwEUiPy1shbfSgSLLBuXK9ZZcGWSm41VGG1Cm1ugnkCLzjnDQAFc8GQcFwVsRkddoUA5ByVPh59hiFRuixraR'
+amount = 0
+reward = 9015200897679
+
+[[stake]]
+address = 'qTnyKiDC7ou7aELMngJCzWNBP3qSo9DRwDE2cjPr34ck4UKbqxTSL5bkDSHyKRJ22o4Wgqwu8ZnZ7ijfQcQGtsFtmajYqToc3FbQ6VxpFpT52snvhXb6BtotruZtC2pzTMN'
+amount = 0
+reward = 184479076251338
+
+[[stake]]
+address = 'qVQusJyZMLYVXfB1DSh6iFXSG6XC41rF5C31grp7b3uBBMchPVc8wQxxpJpkkkcmBNxExuU32vE2oKMwY7qxAHyBoEjUUu5bYcvPAzRcwyvXULs8NHBDqAt4cY2YXbbERX3'
+amount = 0
+reward = 6730800000000
+
+[[stake]]
+address = 'qVmKFAqDACSK5Qb5PV3U79TYw5HdpWERTTUryoULCGSBnfcWCHpPU6w1DnMiLhN7v5rLhGfsrWRNatovrNhWHhdVsPhqTe2bNrU75cdLG8oWdNwNQG7Tkq1kcaFRwkiwzi3'
+amount = 0
+reward = 13773600000000
+
+[[stake]]
+address = 'qXPydJBqGQySjkFNnh2NkuU2RtE6hwwxS95pC2Zqpcn9ZpGaJj57QbgiB2GzEWCdDtG2WzbiF9hG9cNAkQjN1unePJ2jv244sHsDyYCZWbRM9x78qkEsLDQL1BgqpLdUqV4'
+amount = 0
+reward = 7650000000000
+
+[[stake]]
+address = 'qeitmKWiCXPkujPFVCYv9GzPSYzBU6djxCJqahUVZkymDurowd3tfhYXa28177UZ79RsuokuRmizFRJv9268Zc5PjojC2ZEEwscPTeF3HHCvbz2vTmycTUddWsxedU8ZwFJ'
+amount = 0
+reward = 5115200000000
+
+[[stake]]
+address = 'qi4CRDd5rTkdwVNG2ou4QaS67nDWcMkedaiHWhuMZVCU5r3jbtZRb3VGra6ggj6VnyTaQ4nyfKQmb5LV4qPpGSCgbvYtyAiTgnXDNzDLG8ZYhVQtHCqMgQoRMNpqUM2mbKG'
+amount = 0
+reward = 5115200897408
+
+[[stake]]
+address = 'qkciKKjrVoqGQJSfYmk5zhV991Uwzc6G9FH9p15wYLTFUxJkbGqySHHzUudSRHqQLNjUy8J9f3r8qKhipijfeXwMDx2VSA8HGpxicKGQDx1WybgS8EeqNKX2doadzVxS7Jg'
+amount = 0
+reward = 5614200000000
+
+[[stake]]
+address = 'qvNKWk62uzxZPxroiSnj1sxKRLi75zMppBbBoYNoBynnJcCgGJxo6Ak9RLU4herbjdbye4Vp6P7R2uQrvGC6jRbbwg8sy8hEyJGWwcpwYYhWxvhDQgvQZZ8ntjd5PiRFa5E'
+amount = 0
+reward = 116019200262435
+
+[[stake]]
+address = 'qwokK2bPQcV3Cgzesxid2T11Tr7j4rpNW4RoF3ZzsSfCYnh2gajPp87Zd8N8SaN63Aw473CJyus1LGFJHMzc4ZugmBFE6VrHESRs6ic6178WpkyRS5PpSni3f3tszkpW9zp'
+amount = 0
+reward = 21990000000000
+
+[[stake]]
+address = 'qz4WMjXDjEXV2UxooEEYsB1TbeoSXuDgBY8A3TqBr6SddEB14v5Gxy7HNH7Yxec1VLVZducU66Q7rkLfBQLZQ3PmMLQQAT8HwjjpFAd1rehVz1FoXZxXddTPrpQc9WpYyAv'
+amount = 0
+reward = 5504400000000
+
+[[stake]]
+address = 'r31n4t8CfsQ3iPsFZQipRMMwBsLZY1QPWApA12UmZQL4ovcWcSQJzSqGKu3khwmKnpr7Gy3Asd8yMhVa5iQbrJqdAacfRWkFRheaPPxzfBRfYCH3Mj1wGW9SrjRGYs21xZH'
+amount = 0
+reward = 7784000000000
+
+[[stake]]
+address = 'r9SdR2HASMr6ZqfpAZsmYquajKTDeYFgcQTJ4YRctrmmeTqFUEx6oeiGvgCjzm5zsDLHW5ynJz58m3rbiKXHv1fbBHng8VUm5YmCtFKU2raAYKVJdhf6kvQ1a5K5NwWPc9h'
+amount = 0
+reward = 22221000000000
+
+[[stake]]
+address = 'rBD2awoqYzYni1MwhqLqDLLy4DQXSPkhHUbidV2L4nGpYmhQEt6a79Ur9Z1mwZtAePPzUArTr2nR4w6wMnHPJmZNaYjNR1UewhK4pvwtfZQt9ji83iapMtnMaGmeshCkf6k'
+amount = 0
+reward = 73308082293129
+
+[[stake]]
+address = 'rBQ5m4uwswQQ5mvSSMKXADpcZ9qAsHMWdTm4QgVhFKtxaA55FipuEBeCzTLqEcDJ79WDXQysHzMccGs4hCwtFMcnHEg7WT1YP11Ng1EU4KauvHvf5P2wmF82qs7zfJFRVKK'
+amount = 0
+reward = 10272811380575
+
+[[stake]]
+address = 'rC7VrR2X35N4nq8c9o5xsT8buA3xwPu5WUavfDmQEyW59KbANGuHYA6LLwiWmDpfWhxuzmdV5PfpW6GGhrE78eBNjA2wP27pZWASEsbJfEVboF5ZUuvVKCiESwfVXypG279'
+amount = 0
+reward = 25172800000000
+
+[[stake]]
+address = 'rE6MWaDh79JSVRKdtQDrNfc4KfnR5VWX7FZAFY5QcsZFFKibQ1Wy3vjSDanEVN3nJhLYnv3B4HSWgwyQ1v1399MYiSgxdfw9xmr2p6qPqYhBr6mY5o2HEw1eFMvszxFQTPA'
+amount = 0
+reward = 7901479565968
+
+[[stake]]
+address = 'rFiWhUsdEpsmGh4HSYEWZCr6P8NuQ732ye9NDVdrh49KWQYB41pTFnWYt2e8ujCotA1EZpZm6vGYPKABNiwF3bVz3c3fc9Zotxe6MhsG2fBYRc8Au4s1fnpPvGBzQHwRej2'
+amount = 0
+reward = 120369731716968
+
+[[stake]]
+address = 'rGjnXmEYPRvF6YKxXihXb848bprK3t1GhEji6komWv7v65dNAdhURxFmwGxjtnmDrDzmj3P4V78Dw1eDLxC6ekGAjVQMKxEg6LpaLHYZSQYyXkRDeonhB6wpnpRmmjHastN'
+amount = 0
+reward = 7253111358097
+
+[[stake]]
+address = 'rJDGXiHS9VeK7JxWXQPy8BpbKgg3ix1rPc2aKKX3TWeWMiUamoa5ovdq2vNE49HtUARYHXqwLZP5E4Mhe4yL2KNRWsvkbTChh445HiAJzDaVBQjxeXLGYm9wcQXKF7TBpiX'
+amount = 0
+reward = 5501200000000
+
+[[stake]]
+address = 'rLHb3rJXQoVbx8F2BEbn4jkTcia2hY79XcSCwKQac2KGiNpzaji6WqPS9XuDUGJogUgmQdTJffhZHCFWx4Cyivb27r34e2DVQtAHb7MJzUrF9fKWhPVGnQK1XTuYmGi5eop'
+amount = 0
+reward = 15257600000000
+
+[[stake]]
+address = 'rLhm5Ct3eNZdZaG4tm86YFvJjK9Dd8sYSx18uYWaAABw1En8w7YUTTp8Vm8GB6DGpNcomNPSmXJjMPHRhx7Uv5hwg7C1GvAMZC7x1n8drEXuFyy7QzmuY8Foj1NN7LKf2EM'
+amount = 0
+reward = 29215200709199
+
+[[stake]]
+address = 'rMAiHCC6hf6vFvAfXsDgRRwHbmNV2VSE6NkTiqJGjPyQkdiygztkZ9F6g19MdWDYjnYc5HPnJx6iFqHG947b5KFHsAYCmf6CaDkXHz2x3uf7EwtJp9KoMmB6ihYeY8tHVBU'
+amount = 0
+reward = 6590938214355
+
+[[stake]]
+address = 'rP8XG26cbast2vHNfE7V1y3X1Lo9fFqm616PhW2XZtopP696VZc9CNts3zUewyfFW8ZMANpjhXyF3RQ1suQRevFTdEXMnuijLnB9xdGHSBQixPtXVpEUJHAnnXXyfhKfkDE'
+amount = 0
+reward = 36200481261580
+
+[[stake]]
+address = 'rPLftv5akA8hT1996Q57ofCTkGkpPyJr3ZRQrEhRqCbpcuy77KprDteZDZaoSDuzKG3JJgbcDiBt2yG5cBcoLnijo4PjcjHi6qeYMCoTctWvyRdSd81d9gYmrG16gzXMib1'
+amount = 0
+reward = 18000000000000
+
+[[stake]]
+address = 'rZ4YsASuX9Y2oeJhjzTv9RXxAqtqJQYaRbQvbkiXfEqwJ5waWUn2tWuhE1ZWiwjiHK7heB3tPfzh9gzBLbPmHNyKoWzLeziSCPxXt117TG1drQoQiHUjGceCLpAJKjVfxYF'
+amount = 0
+reward = 11149600000000
+
+[[stake]]
+address = 'raHQAn9SKW7HhTUZooDaDjXcFEPnhePSEGxfV8i5zEYcuDAQLzgSEdDf9whzJfTcUFNM9DWa5QXGJ6QFYs6YMMoa71C92PPnJYJqpaGUFAi1QSp981uAM8ySxTbdCVZQj2n'
+amount = 0
+reward = 10130000000000
+
+[[stake]]
+address = 'rb5zC89sQGRfRRH5m8VKCCf7Y5i2NVnxdAxkbQFvJZ941SCJKBdUFmDXX1tRzkeg19QSW8YFb65Adc8aCJTYGzw3MAHMbkQWrQbDiFZruw5CRh9En5qJ2LaGy1dnzWqC8vs'
+amount = 0
+reward = 6697600000000
+
+[[stake]]
+address = 'rhxkRkHKe2ZzFoQfWuuUfgDsSMTqQ173rR1QNbpPhffD9WrJTH16DQvFUpaQEmtboCaVXvY8V6Yx8iiS5n1zpftATo7fRkmCswS48baiXE57NuUA3viJsh1VGnyRCPzT5u7'
+amount = 0
+reward = 19770602960467
+
+[[stake]]
+address = 'rjMoWLdr5cG3PKwXUw7jmAsEzPv9Tk1QYdV5ASqCw4YEQXBLGDcVLepYUyuakd4wrhMuYZGgXKihd2o1YJVuufjGhLGV3nWZdVe2vup1yF4LFepABXmTybtDVHGsk2L8XZS'
+amount = 0
+reward = 400156238274898
+
+[[stake]]
+address = 'rn2Z6pqzKr4XYHA47S6McLcX2AGeDYMzMt6KQm445R6eYegccafK57QXVBqxfNi8f15KVKBSnQM5XZ3Jujkj6cydufTMdT35dR76cQ4wymdnFgqA75VopvzHkN6EFVpNAtS'
+amount = 0
+reward = 250441756185618
+
+[[stake]]
+address = 'rogBxKsqTJ6XHv2b7JoQ3UGGyYm5gCLvfnx6x4wXRAdJZXPaSSELitiAwuv6wJiwxNX43uw41FPGwHfoHcwJMBSNjCeKEBoEvdS2QgE2mt8DuatKPFKXu7Q3bCaeH6Bbpiu'
+amount = 0
+reward = 82476932713507
+
+[[stake]]
+address = 'rutEHbuJDm7N4WuQa7bR5JywjqYUZtaCmUYS25v9Q3CiAJBESLazbn6zWVr33tEbV91Xf2RXNYpuDsooEWQBhFYSrMtmtQ21vRjDtc5HT7WNVtyBfZ9XGFq5Z7nutHzDKHS'
+amount = 0
+reward = 21671308328783252
+
+[[stake]]
+address = 'rwrs8NYX8Q24aVPthSL6fNfL4AM8c66hbTTwAsCTjv5zjEbNLDbqjg8qMLSyNjqQ1CHMmML5oLsJb17FKh3C4Ke3v9Yg5yo8EnB4Z34RLG6NuNU2VWJvESCQdBav2yvBT1y'
+amount = 0
+reward = 6680400000000
+
+[[stake]]
+address = 'rynwxcWTyXSTcu9NjebjmdXotHwnPMQwVXrbHDwH8RD8aztdfFqLb8kZBeBw2Qnwk2pxv41RFkaAsd5Cy6Q5xR9MM9fNka9sXnpXKVxpUBXxBcuinBCisN82wKpTPu3QCBq'
+amount = 0
+reward = 7788000468347
+
+[[stake]]
+address = 'rzZsFKYjH7k2TPFrd53XhUep8FpCuDbBZ8ATdYoUbjyNwYFUY3iU4vrRMSJJ5tDQgcJCUYGHViC45SstFwjnKZU2a1E7xYfMtJT1mbTuELbpTmY94fMLVXzcRhJvMHFuozf'
+amount = 0
+reward = 5608400436807
+
+[[stake]]
+address = 's34mds1AiVPHpjv3bozk9vUcbKVYRjggdpWhAqMHtLjgWCmk6B2dCoLCoUk372xXgMLpq6Fug3Fw1gKjm3VGcugigAcup9L9zDRqqKAtbLoEV9hwJwacndqWSCn5JeokDER'
+amount = 0
+reward = 12572800000000
+
+[[stake]]
+address = 's4gBrQgvmm8MSfzzxg1jDY226kG1MeFAN7a63Y4nrLwg9nZTKDPGWEcYpwmjY6k7Bx2DEmLbi8MNQBuw6P16jX1LU6YFhkquoSLHak7zN45mxMxRymUZjD4mjnFjCGRu88L'
+amount = 0
+reward = 5464400000000
+
+[[stake]]
+address = 's9t5WdSfrj2JAoQy9Hf2A3zS1VuEQigBSWipLK1yGrFSnrTDbFpAQEvC8NM4WJQ9FxmAQqBJCm9YZEYjRqFt4y6nEA66RDPxVqfXJEEZF9wStzKeEc5s3TmW5eozwsBP4gf'
+amount = 0
+reward = 1720284046808227
+
+[[stake]]
+address = 'sEXLeRwwwY5ZVZyRDJj85VXWj9zoTGUkQby1aUr4wcjVhCCUydT2tGABKgStPkhDsNgMLMydZWDMqyKwjaAuQy6PFo9pQ6th7hWGt7vaf5y6s96D4Rhf4ea52uN9qzQm1vx'
+amount = 0
+reward = 147222128463444
+
+[[stake]]
+address = 'sKYi3Gw5FTZoipuf8iX3HU7UDhyWcP8cFycikFUsKR95FJyiqURNhgQ1JzGXiwBQp8paSvqnqf38rsvtBa1TRZizi1GuJBUpnAnCohCWVGo3SjgV6gBm1sfsxFeWtM7ppua'
+amount = 0
+reward = 268525701221888
+
+[[stake]]
+address = 'sMPzEDwM5xhgh5vHGcNEg1JNs1SCFpAsAtDm3SR4eys9quPvotEM5tMNWuUh9qmCWtQajr9NYi9aonDVpfKJRg7XpzT2Rg5RHFX7MnmMV9nYsH9c8rraPuSyMjDPAWVyxV7'
+amount = 0
+reward = 213026782765120
+
+[[stake]]
+address = 'sQrCiff7hiDSijtL796ihfqfuqdiCXe26P7o5p5umNEzbMBntGrTgmmZsERy5FWnmFShnXcouagQjDDabVRpaQWcBHHpGMVVtUPLeyUB9TsK9FiKqia7SszvRtU91WVZteX'
+amount = 0
+reward = 6908400974609
+
+[[stake]]
+address = 'sSmc5wpcrH5KxWu6KhAY2nPrVBK5md38WLTBs75tL4qfaz7porCD1iLs8Qnc4HVzwuPAKN4uADBxB3YZ6ucNzyXNXVCsMiNP5dwf31wLx5VT7CgQaSjxvDoHdshmYnNpZNt'
+amount = 0
+reward = 5566000000000
+
+[[stake]]
+address = 'sTHkTR3RnBEC4ipYXhAuFkUxN4YvK78dhHvhvbK4gHWBZzRfaEAytg669hAhefKfvsiRmAcw16Ckv7bvbjHRhgd9oi7NouJXYo7weRbssnHr6evtEb6J4qswBCKzYKPjAxm'
+amount = 0
+reward = 5350000000000
+
+[[stake]]
+address = 'sa2MdiJhznhPH64AVHYGoZkVW162AEB2UXUYCyLNnW6PdqLb3gCD98bRYUHYtBnrn8Swu2Hgx5ZshKwS68hPcXRncC9dsiiJqAwNDupteayAPmnR5hm1ABkNsKPNdXXZoi7'
+amount = 0
+reward = 506550600000000
+
+[[stake]]
+address = 'scRkV9xaMCNTsjEx2mwDABavD5exRSNAyCnTZT9hYi2HGKPRAYhqzff5BmdsXgqaYRxgSxkyiDUBFiyHGhuHxMC2R5ztdmG8QUe6jBXsyFMJoGx6H9faXfyA2XwXrJMpbfo'
+amount = 0
+reward = 594985632097446
+
+[[stake]]
+address = 'sfeCjqxLAsEpv4Y8nkMJRq5k9N6bdMuz27TNPXBx8HBnNATRxe4P2iiCriXY6PZAbnt1bFt4VY6vGzswFResCwFWeHRko5nSebJc1uxTx7Ct67y5V15kyYaEYtUtfoMwpLT'
+amount = 0
+reward = 24296284389805
+
+[[stake]]
+address = 'snoU2rVDYQHg9abS45uPa8MsCLauHiQWKj7i3U2cSrQJZrzPymYnTjdPvQmy9Syi3VowM8tZXMZNRoJfdtirminSgiVDLrV9GRhXM9Mp9q5NUen3xWsQpzLAR52e2Xv8PYG'
+amount = 0
+reward = 6782200000000
+
+[[stake]]
+address = 'stEepsCQ13uvpoDyizqGtiZPYPY6HdhLVqViCMuRE3aRucNPTPVCkEaAW8W1zw7Pr99v2BCEw5cNWCcdxBmJwu9sv2pYd7BS5gbnHYT2j9cLPvufKBKzXWC3pY6xw2wuBwd'
+amount = 0
+reward = 8856000000000
+
+[[stake]]
+address = 'sv9sfihYdVFBm5RWuZae8d4JqwEf8ifNxmAjFxAV1xY9YJkq4SQ1huaLV3MfbauSk9vAXgCcWVZkPHnfJdeaA7agCCNAJ3z8ZgLXeYW3qA2uWUyYBaBmqNRG4vAvVMtCdrC'
+amount = 0
+reward = 5658326994815
+
+[[stake]]
+address = 'swXdfo1CkNtns8BTxkGxS8B1KXZsgnwd3NPwn4UcL7849o3tSf3zq9qZFwUZRwBUhvVheyAjmhYt7DAtjSvf3nypr3V6UWD5ypSaX2ovspDv5s7bvxiNdLJTufGw3UCK67L'
+amount = 0
+reward = 9999052548047
+
+[[stake]]
+address = 'swt5oVf8T8vk4RyCCgqm8ZAHcEUwmv3cfWJxirK881kRsjgLp6X7bUGgnmTmiNjMsxHBsEVxiTFsx5iGdgJ26hoFTJ4tK5gUVtZkMeuuN6eQRibjBCqfsLFzvE95C1Lze7A'
+amount = 0
+reward = 5113600000000
+
+[[stake]]
+address = 'sxpZtmeqGXh49S23ftxzhMYNUdAgAMprAxocTNBWaqZ3LGF5KZ6VwgjKMWD5de9JC4kWucvcNiX9AAzKZW4v3cKqmnp7tq8KhZp55QUdTkfLSVSMtFewGE7rFosnsR2Fq67'
+amount = 0
+reward = 11143000268096
+
+[[stake]]
+address = 'sxwbTP5dLLu6sXYQBC7xDF3SRBK8LrTVw825CFocxxhfmszUQF5Fks8o2yk2p9xnyyu36Pzzvbbt4AFPVqxCAupTdbfp9m3FS91pgV92vmz3B6Fw5hUy62KYvSnTcyPWZt3'
+amount = 0
+reward = 6607200000000
+
+[[stake]]
+address = 't1CJG9ks9aAoh8SZRiPWNdhDBubfMxM6afrQLLUgcMdPCEX5o4V3uBQVr6wq9RJCc9QvCFnJgNbxGrfnhfcsSAtuXHAn7ZYtcFj1AWJB4gpejC6bci5TziTuECqiikGX1PB'
+amount = 0
+reward = 7285600524723
+
+[[stake]]
+address = 't7e39EETKLqNmaUWmKyKc9S7wi2hLjyzfzikWcpKmSukCvVgj4rzL92x5gBgNFQKASgm53p9RkKxm62X9WeoEPBgpPeNf8qt9MUaLbos64NfXSmFZdDK8Da56SBfpnVsBvj'
+amount = 0
+reward = 8270400272862
+
+[[stake]]
+address = 't9ph1a3NyuZUZdPDCQNzA4ypLPvUhMZW3WiJzDPEjJCrB39pG53qpfmHoigk42ARHDWzQXwdFXSNtu2zyZC5JRi4eZshUzVEGsJy4GEL3CKmKRQ9RwkRBMpkJqyPscbq4AD'
+amount = 0
+reward = 6000800000000
+
+[[stake]]
+address = 'tCR9c1pQU1jC5QgmRi3JRb2g1Rhtrc6AxT24VQPtMY3wrsuRrnMBMP6wSoKWXH2opKTeCm5aniEG2HH8ATcUHzeWe6814e8qdECGvLLZvhaRKsi7MJgLAA33PiWZ4b6ptNt'
+amount = 0
+reward = 195125697840907
+
+[[stake]]
+address = 'tHPPwLrkFMnXG6Ax9nj23peFwLtqKn5zf48433qWXRyWMu3QsL1ta6x1DrsdWH46CmV8DLFdU1tp5eTohfdL8Lq26tqgT2soNejN9mXaJAXvSJ4Ma8yauiTj6fUT1z5gNfy'
+amount = 0
+reward = 9899887809980
+
+[[stake]]
+address = 'tMKhKbfefQvC5Tqw8HT2NWEpuj34WHSvko2T7gQewGwQ2MvNXvuJy6LRoVKb7LBY7hyyrZVYt6mdr71sgnPpj493oy2f6yeQrbESAj5ms7sVh3ve866BsLuiSucjpdb9jv3'
+amount = 0
+reward = 16091200000000
+
+[[stake]]
+address = 'tT8VygN8dxQmmg7pDcNBT7hA2zKeEcVTQiYkMXdupjnehcmLQQziLTFG2E7xGP9U112brALxBJQXa4MnjHKxi4g4EFtFHfaviN9oddcxwVWpmuity1PZpnjYfVpnQ4FtkDv'
+amount = 0
+reward = 6669600000000
+
+[[stake]]
+address = 'tUFyVmch4NW8GrF73UdDA8hr1WK5Qu1ofrzuEyoq1d7Vxd28fAYiA2Rw4ZHpcp8nwch85sdiuDLxYw2eJuc9GGpXavckpd78ZuyND2rQrp6WP1hq3RC4h8YsDMzz1W4SGCS'
+amount = 0
+reward = 1202402016819536
+
+[[stake]]
+address = 'tZ9FShxGJjs3HDKCzsx99wU6KG9RMGrVT8Y1mkWMWUeNjm1WXn7dgeZ7PxirEcsjLGxppVoLTYsWSAGxbSnJNocjkYZHqVrHmDNAkszZaAYnqi2rNa6aQ8yQyvhrVewvzMB'
+amount = 0
+reward = 42700000000000
+
+[[stake]]
+address = 'tfWVRRo69w4aAKmG13DGg1dZyB8yCTL3uXNHWCbYugGWedGpQ1wwRA22BE6Z6nNmxeCd1jC7AzRHcqwGoVUck8WC5W85snoLLBb4k1GFEKxj7z4DjyRqoouefL5H1mKZzCE'
+amount = 0
+reward = 21413402402986
+
+[[stake]]
+address = 'tghFy5YuBGkD5ntBNwt6bSDMmYot5AS59q2Gte4udEBxJPqwY3XEnFKjuKKNfoyANutdP4AZTxoPB2kRr8ftELPoh73fVpSHHcLXaWkmWaomyS8zK9THunbWLr182xMw3yg'
+amount = 0
+reward = 8316800000000
+
+[[stake]]
+address = 'th1DAbbtJ4zbidXjB66AMjxPrtAnNVKEM6dQ2C3FM9gzbsKpVjkHHanWjqQg2Rno6guNf318wQLZKuaitMm55R3VacTZRsjXCfnMXWLh9UNW7QwLcbwDqsdhD45v7rBGQuZ'
+amount = 0
+reward = 17108000000000
+
+[[stake]]
+address = 'tjrjDcQkAjjsq1uHZJozQnZt9d1YJbTJSDpMaNLaxaHdSnmBHXaJGE9qDi6QVsYKbStoJ287Q5aP92seN4xKq8CKxyPXX8DrTXfJJSjfCguW17C9TFSmUv8Zax91U7XUjCf'
+amount = 0
+reward = 22500023368788
+
+[[stake]]
+address = 'tne3FzWMwuDf5gAFRSSign4NwTbt9cBJX7XsD1t1CE6uadAA67QckxNuHxaeHqbifrAk38cmS9bYsh3HjxmkUVwN69iiVmi8o6yxVUA9EzBGkZcD3FHLa7mEbunjceU5hcf'
+amount = 0
+reward = 11130274673124
+
+[[stake]]
+address = 'tp4Y9csNhSeAjEFZCc9byh66TpNMgqCU73KgBdtdyKhGwBui4anbBTVnS9TSfTZJQuxd5r3VwVMvpBogqcESQtB3o8PFsFZZ7gW7Ux7vZG1VzaewdxNqWBSqg6GZpFZ8hMd'
+amount = 0
+reward = 12656010419784
+
+[[stake]]
+address = 'tvWXpE6etEWNp2NKU6NbahyEP9maEaX9hD2oD9iWPrSCUkpAvcN36hyBWaXn6R8dE4ih2DmGBfcoUGnSBYj3NjB9Qv8YxtKNvFXDEmp5bVtA2DFwZnJKAb87zU6252UTonD'
+amount = 0
+reward = 5420000000000
+
+[[stake]]
+address = 'tvfqeATUMWrZgJNgGo1ZyExzZEx43qWkddTdDMgiXwEi4hD1v2P5pF6bDr71rZf8xmUn4NFovSrscDYMhFGtbybrPMytBT1LwveJ1dEof22AtGjxweEnsp3W6umMbDntDu7'
+amount = 0
+reward = 5528000000000
+
+[[stake]]
+address = 'u1kHrzF7WzQ3xypBoEkvESvvjUtgZ37oYE3E5fXG5PwX8Zcaj7HnUUatjBWLcVEG6k7vJ978TMZrAWovqHSM7hEudzXSZCMWZqCM33xiqEQMsPAdYCeK4J1HWQCRCnyJjQZ'
+amount = 0
+reward = 8070400000000
+
+[[stake]]
+address = 'u3KXp6oqtdkPpJLBdxEyuY4dXWK2QLrCE7LzGaz8bFUYKgmJ44SbiY5Twdohx27EV3FwkbH3V96rHLdVNXK8p884d6osaqVNyXvd9LAiePWwxuQ1QGhpbwiy4TmzC5gwiug'
+amount = 0
+reward = 6590000000000
+
+[[stake]]
+address = 'u3sDnKzNrVqtLEhSuCCxwftHErrwf4C1hUyhkv63onNJstVfcRyZ7f81Tec7Z6Y1ZDtam8BVrutRA2SskeCwBmHqhiAkAefLZHtW9gZU3FoygCZ2prur87rigciNenKxPWt'
+amount = 0
+reward = 7825400000000
+
+[[stake]]
+address = 'uANZNgU1ZwWNRaA1LaissV3HYEiDQoTxvPqLgdmeJrYEDjcd1pJmTMoPQDRwtkpP7eNk8Ga2kwbQdMguPPU5oe2xHGEVwktaw9sft3qMyf3Tz9p6SAAUpMeG4CBWpTGALPR'
+amount = 0
+reward = 5490000000000
+
+[[stake]]
+address = 'uBKP21CP5uveoZJXDX7M26iuCALqDQhkNu7U9HBpm7utzYgmhTp8dbAQk6grYxWzA7QTtXSkAR4ZJgqwBdBTaMaMvQ47dZX4ciKrtQxyUA9yiXqg3Z91hAM7ekzBsGpCR59'
+amount = 0
+reward = 251813600000000
+
+[[stake]]
+address = 'uBq7cEHwY8m6CC11dz6rSgYrJEUEUSCCF84kDYVRgfikAdmrrJhug6eXGstdygYUYEZfQF7tGcuNWG39eLhbmke7xTuJPmSCsJRcY9PDyjVthNTpmwdk2w1s2ef4rGAVWkU'
+amount = 0
+reward = 5388810403307
+
+[[stake]]
+address = 'uGhpjPggMZW6iAUtBEnXF72KLe765U49YQ4wo3nE8fdWWCbzi9Q4xrUFwcMkLzzpbgaN9eJQRmXnrS2g3vnKXY7pwGWJTr7zn8VxPXBNCLpCQNgbJLbxZyCwZE7oFCzaEQ6'
+amount = 0
+reward = 107484284275281
+
+[[stake]]
+address = 'uPqx9aWdRWgTQ83wpLucCexRNKGqKygZAHPVrjGqvGoRBza8R6gt6sc8z2oebuV8F2Eh8SDoUzYLqEoQhwh7Zi8YavHhCLn4CKC3VCxsFyKkqub7HKrLkCSKVRHTdnTN7Zb'
+amount = 0
+reward = 50491219447324
+
+[[stake]]
+address = 'uQF7v44trLFQYUGSLHJiDZGyNSKt96RfrAes1zxvx2ci7XCHcnmu6VKTE7x7w6RM8x7YbWexquXjBXSv3Ur9tnrsUXbA2eLifMSGhnnXeBG1oyczdC3GSBsjXXkXGPjr3nz'
+amount = 0
+reward = 11286401311774
+
+[[stake]]
+address = 'uWrQUSrs5gDruoPUGHGM5v4vgf4ENDqe953eZwR3mzu68zxYg6L62WEfACejLmBbp3N79AJ5QqmGv4oFdhNaNgBx65HE7VqZAD1ctcv1fqMziKDoxpd1gFxbeG25dMyjXQW'
+amount = 0
+reward = 9084810133807
+
+[[stake]]
+address = 'uZ3MBVBFQcawEZtNXym686drXshFumPJN4kN6mK2d1y9MzNkhb4Xy1dMzwKC9QF6pKjWrvXrrQsTpYvzbH8UZVb3Q6qD2J4TwVrmb9SygpgfDs3A4vK4CJs5ykExkHpNN5v'
+amount = 0
+reward = 183305872389953
+
+[[stake]]
+address = 'urGYn1mxup5RWLX3jVgBwtig3BWEcyLY1SSSuzeDxwP81oRgyC4JCc5yYVPU5j2EJhgjmjdkEAszt5zZc2D8JcWBNE5j1zDejtaLij3szttxWGjvGaUm8f3qAtePiuYRzwT'
+amount = 0
+reward = 10072800000000
+
+[[stake]]
+address = 'uty5NEZ27bQLwS4hSeUxPRrCeowfBy3gn8zsh1pnScurspMZJny2kiVaDuVZEUyr2BrmhhPKi44URyYYUoK3SYekQr44TTpgxTxGm1WrtBgWcFYcPw1bpaA385TfKvdJMS5'
+amount = 0
+reward = 262545243755726
+
+[[stake]]
+address = 'uuxVto5NVRDmBxHgyVdQ3DXzvfADjEdafcB8WVpw2jJ1b7i1xZTM4M9miuFHUoDfTX465EXfJMT91NU9Cww7Hp1hrpjtgc5PtD9wASzm9kRhZE3aLwmR7vZk1hMCW6ApMCg'
+amount = 0
+reward = 8401600000000
+
+[[stake]]
+address = 'uxXzwyqrAS14hxPA2Bpgy5a7Jq9yCetZ6kaY8dxQKnABW6WVSy95caSywheEr1ZvNtGid7N9KjJCATJ5rxucsX3wGNV11arHr94KW8iJoFCgaVKCo6Rym4kXyEu9VPJvx1G'
+amount = 0
+reward = 5072000000000
+
+[[stake]]
+address = 'uyNDdFT6f8ySYeDMBVuZNmGxWef7kM1BimdiTu5rH68r327ftDaTSLR2tJKxNhwnfFqdC3FnmDVL4YuTLTh9cZrRks8oM3tbL42bc3TdHXyGb2LBdK3MiVmkEiPCsDaRnbW'
+amount = 0
+reward = 21396827029865
+
+[[stake]]
+address = 'uzbp5YFi1RrWEmTv4yWfAhJucTxU5aFwD7Jpu5hXmrvwHXQ8NaFusWQDBE5ZiKHJdjMM1C6HriZarcTQ8o1uW4wQg7VMiCSGfGYz9CP4NXGXGp3aSbEdum6BVGjH339pmPC'
+amount = 0
+reward = 8824800000000
+
+[[stake]]
+address = 'v2UVzGyVJe1ZoFJnShjDbj6Q6q6E2qVh1WKHfpyapAp4JBWpDEV5MGbTeaCdFxNCAX3HdUCge7icoNPVNGDusmDTwfsxiR3d9BRfqq4XuW7ckamknT1evi9an3cbMFsGGpz'
+amount = 0
+reward = 9324200643433
+
+[[stake]]
+address = 'v3Fhh7Gxq6rcFWu8aCPoGxJ8keUbhZcChrDLeGzpUBj1q6wT6ihK8R6mP1Qic4b1rcKgyAheZohYbZ5Vm1PvPrSfPhihZoB2rrZfTr6vyzx9aZweCFYFHPLVw6o2SjLizEp'
+amount = 0
+reward = 7720000000000
+
+[[stake]]
+address = 'x8WBJWv4Kyoq12YKGS4D4kNy1Z8CHSQQuU3My4BH1AAcuCk2L9LPQqe92UZzyk1x2DYU2Wj1MMXGjAfFtwGjv9W7N1JnrdWTzNrNBnhVBCpe47narvC5hJUE4iKeUmv1c6H'
+amount = 0
+reward = 13240000000000
+
+[[stake]]
+address = 'x9eZscywy9zBmyXbvETQjeVPMVbxCq9AQkQvv9w61AwTGTYX9hDsXE9c8wnuZFxans2ZNzDr1e8KgZtLK2aoEjZPtcctyzmH1aqgtcucX2m5LCYkMvVWRpx7JsQWC2D15Ee'
+amount = 0
+reward = 7980000000000
+
+[[stake]]
+address = 'xFWTwqexxEqRmvU4SVXEQxidHHsSRy11KZJCFEm8VrsXc8tRKtPki8f239y2K8e5QBdpuhbixNsEBJWqw2zm9B5959Q3hr8AvNFA76ZWWCtM2MU4kSSXjsbLVH2gpc5h6rg'
+amount = 0
+reward = 11378800000000
+
+[[stake]]
+address = 'xG5bwCvarGdGd7xaD1eH7jpp6U4SESN4ZEUNU7s2da4AmUcCJmvXm9w87KrLgNHsaukxMAa2s3iYAgYHhXoRBzQFaJeY2aYf4geR5Ux6tc5huFjfQ6vbaNYsSUoW9xqXkZv'
+amount = 0
+reward = 18195201878395
+
+[[stake]]
+address = 'xSz12jSUHAYVPB2om5FYFzYB6ik4mQ4YziwUw1pPmLMfgaWr7KoDZS1V6yfeKZY3Ptgs28oA5TAM3RFC5FkwzJb7rCwpJR7nDVVKhPAVP1TYcSNZQiiuGXER67rQ4ruWmYU'
+amount = 0
+reward = 5443200000000
+
+[[stake]]
+address = 'xTCRQ4o7BqiVpuk9jUAN8NdvJGCvq7gMvEjaBGCmW4128SzeXmvbxvziz5fCE3dqntrKvD8PmGD3odawh2iQQXkgqgEYqTBfjpywroAR1kCWmKa5oUMN1Y8iexkrf9W2K3z'
+amount = 0
+reward = 7700800000000
+
+[[stake]]
+address = 'xVV9W5aF5K2jhrFMcAuu86cbVeypdCYJFSFghvw1GQsmmsLxU3i6eMb99hXfipordiRaMEtjw4vPxBjJDvpNSAokMAxJea4QzK6zAG6cLJ8QDothLEaezRmsfXnwZfcRpmj'
+amount = 0
+reward = 5878800000000
+
+[[stake]]
+address = 'xXa3GAGYrZ9ESbxeuR7GtCKHogVWCUp17fA3McPshu2RPJMFhmQwDfBNjPMiGgU88kkVuP9tgeCS5u2RumYA5ddxhVHKyQHiTz4aMfiBhzDpBZAhpivYqiHKFyuWhDctaHx'
+amount = 0
+reward = 12325200523328
+
+[[stake]]
+address = 'xcDjhg7yccQBiAJtL57nBQTUukbcJDrvX6PQRm2JVgLxAFpLC7Uuray9d8rrxbtBgUaCVHVQf7rxTaY8HEuLsV7KcTMiisQPVRhepEuMAjxgijpD2BjCkb9cKZMMLicqP9s'
+amount = 0
+reward = 64732000000000
+
+[[stake]]
+address = 'xdyUJMXqLb1NzSNbupE1GunBMuMmSdSzTKeL8TBd69coJvT5vvnj55z571Y4PiEXtXRJePcDps5x7ert6J3BYbSKLb99jF3rDqVExBFRT1C7AvhTXJfCiYstzdKZKm1QfPe'
+amount = 0
+reward = 5527800000000
+
+[[stake]]
+address = 'xiyiMEDmhCBtHEFcx529rZgaMh2sXWRx3gmFUuVJn78ohr5HZQufxPd5PnR9Q1g8rUndTbs6Vs5D3i2WerVwko4sE4FQGBZu3P17heGCpCp4BswALMU8MiDe6TSTNsQ31Dd'
+amount = 0
+reward = 10100800000000
+
+[[stake]]
+address = 'xnmexZ8DkifqtphgasgE33XYfy9yEo2oCmfbCQntiAyAAd4YWYrmjVpe27KenaubCa7b1asfm4ZH3kKziT8Xy8k37pgJm6zqmQbexAcayYtE1LURbCrq5BESYr6TEneoHHs'
+amount = 0
+reward = 10000000000000
+
+[[stake]]
+address = 'xujHsfcTZB2Wff1x9LXPqYwFVEqF2ogyEPzq3fWa2KH9tn95SivNTKJTBKyyptRPN4NDKr3yqnWcyVqSHR2RfKtrHJ3rQo8GbFDGZ1RD9Ptjh4CJ2uXWEb4SPwKGayaZADR'
+amount = 0
+reward = 196856024454238
+
+[[stake]]
+address = 'xwMHJQgF9EGawzuMt5Pvjp1tSWEQmWbeU9T34qTeTeoY8nPijm3qd7G6PrNVWCm53FGsHL5Pc442oLqwwLZZZoqky7Cz2yUYf9jEcMzsGKj45rBmG5CbdhLLmzFm8Tb2Lih'
+amount = 0
+reward = 3014586663848423
+
+[[stake]]
+address = 'xzAZihCwfS2UUDWnoEGvMZyYzusHDLe8VKcofqGgRrLDNg35Y1V31meqJfVx8Yx12QQap8HLdJz8Bgo3GyPGB3vdkMBZJQFqHkhuNWvSqvR9RdrJ12Ye1ugMp6rWDgTgzuo'
+amount = 0
+reward = 6960800000000
+
+[[stake]]
+address = 'y1q47PKFhxXHM3KuvArt1DBrGjyER2r4kt4BYcbWNFkjrWCtSuX1Ev2Lw6X1q6QsWHAvkAJawQ7MZyvZsjE5iTPXikbRS3HmsSwrRNC3vLRCMkfLPxqqFED7SHevaDrQzFK'
+amount = 0
+reward = 5290000000000
+
+[[stake]]
+address = 'y2rDpdHBAZj7a1TtviVssGtkwTXfB2xZngtYGNyoQTCn3J7B7m4Wqqzc1aUGosGdsdiMKP69j5FmLicWqnUdgVYPUBrHT2rm2Xc3VVrKML9DBwbk3feEWmGFE95fSfmyLpi'
+amount = 0
+reward = 20516812011357
+
+[[stake]]
+address = 'y46vKQCjqKdYrsuj2m7HvNMey8LTd3QhX15cebBzhEASXneWhbn55VaDfWFu7Vms5pN9Zr1CLR92i5vLbJK6pNaGkhfdGgVsZ6CDkzQ4mc7R9FZCYNLpR3tE99pifZ65Qor'
+amount = 0
+reward = 7028800000000
+
+[[stake]]
+address = 'yJvEprSVScDr7kKKfxHJ7U6H4LXoxa4akcAGGWJkTxhzhBUCHuHDAFs4uTCSwxTJdwKTsv4F8WiYf7zzKP5EUGhYwcn4aJes15Z9h6AkvL1Fb2R6gfpRqbbaymwK77G2bzB'
+amount = 0
+reward = 1284084981598327
+
+[[stake]]
+address = 'yKahEkwrYUvDoY3wnhK4rcToMrvBVHtNZqcLK3nNdggP9dFJz8ah5xJFt3MvSxQjxc5zTL93iDzTkA7MvWZL4yhRs2KWWjeyrnzhiNZ1jLmE4mBVCcCbdAeTuj1rvbRqL5r'
+amount = 0
+reward = 5135000000000
+
+[[stake]]
+address = 'yLWh6C8gGG3PhkzMTz7WUTyXQLudWLN7EXu5PZaEaKJT3aQa2Sf9kodH4HF3WQK3mUfh5edqsGEBjW9pq6JHLigezJPZyYnUAnjMRuKFstBktwf5rSw1TgD8Dwz1SmNi6nV'
+amount = 0
+reward = 32257600000000
+
+[[stake]]
+address = 'yMhGLXRiP9z8TNq6Y1tS4vCJXHHjWrtzbGzeQAedf3uGG8GCGdj5R9XraJNLzHcJtMeaRE9eeSkzLp7Rj2ARdpu5Do8R8wX2bqu7DmrjUzv2vApqFn997Y4u9pqh1hmJZRf'
+amount = 0
+reward = 8832210000000
+
+[[stake]]
+address = 'yNaJn5QMKKyrpbhuq5AawQuDLvW87Gskmh9p1xtCaLMQHhvksBEgSPe6WzteyK2gNPQgjeb55iGfKGrXmv1wQz8nndJtT1HjbU2RuptsefrWoSvDQRwd9D74A22ge8amPhb'
+amount = 0
+reward = 7868400446011
+
+[[stake]]
+address = 'ySLf2tp6ogU6dwgZDXf44MLiABDwVL2Dm3q9QbAWhtbLJSKVMB4T7Kua2dS2aaA3XxdpYuMkWNUNa4fVNrtoeZ43pgLv3NVYez2AE8S6P4Zp42mjtoRDjB3Tk7KJGXc4v7L'
+amount = 0
+reward = 10999926151426
+
+[[stake]]
+address = 'yTZu81m3G7tAWX77nX7HuZNx89Q3WbMiqfds5o8rYhnbt9bgA1BV6XDS2MbwggwziXb2uySJccodNp9MVFaMDMvFJJqrs7aQ6wRXsAz5QGFqct4xGw2fzN9jHRsjKqBoHZH'
+amount = 0
+reward = 5731200524205
+
+[[stake]]
+address = 'yUTVeY7a7Ci4cYefZg9vjyCgjNiuFJ2YKkZ3SF3zrKUCrs5PmfsTW4tNp767UDffR5ZpJkvKQSWgauDaJiP2J55Csj9EB1j6VMbB9UNQ1GKcPCb34o9c3qLBTPpRFzeVbaH'
+amount = 0
+reward = 2038616064106218
+
+[[stake]]
+address = 'yUxfsbLHQ1jZxw5VfhQpQ6BdZhLTxTQbeUezV12cStSCvhcdcSQJNyeuvPeQkFLvJRRpEKBrhUiWCHubQErZjyUiSPHh8mNZRyMUrhX2bn4QFbf79cLvbQkpy4kUbb8kWTQ'
+amount = 0
+reward = 8895000000000
+
+[[stake]]
+address = 'yVaYRuob5R9WSif9Jx1k5ttPRXNKZBfz2dy3PitqPvnJU1hWTyJKh6PMmEnv2ZX87Dvhdko1EggdcbkkXurQvSPY3y6rNR8Z7oWMBkdA6WutMuRwDxCyH3zGGSFuUJzw7Rg'
+amount = 0
+reward = 53564800000000
+
+[[stake]]
+address = 'yWNgmFY5CBDfoNYCCvgnpnN26hgmpWNYStfdpd289PtNwm6wJtgh8Ltpt1LQDRK4L6Q3m9LTNockGhfQuVwzdYtzj4R2oCfPdSytjRfCGDW1aMVVFiZwVi6JkjugJjhT2w4'
+amount = 0
+reward = 15573000000000
+
+[[stake]]
+address = 'yWynRKzN1BdKJQDtv848LdSRJrFqdrudoDTnre2fiWAC8XvZuTb4UAjAkStu9idW4N9R8ncnuk4dsMFPE63AgF3Jbdemax5pH2YMkngxkjEBBaRpEV1wHHZh2ecS3vKeGiN'
+amount = 0
+reward = 5600800000000
+
+[[stake]]
+address = 'yYX53cm5SWCLBGFBwNrspAyQN7M2kdpeyGY5R3tcUJKsYQNaNbqjPqWZisti3Bw2gXK9imRqdstqeHQPoejDkEb1rqeozmsu3JmEtYNjsN8ThGb9GxvNE4azi89Z7H6dxtk'
+amount = 0
+reward = 1018508974016800
+
+[[stake]]
+address = 'yYr2sH83nV3q9MKFjbNdMRVwkyAUtw2YeUh6X9cuzZ652KDUfk9yfhTaJ8EBPkdYLRFmo2Grcq3PmayAiyPHJGT2cXp7jUWyzktFqqe124KSaFZQNhs58HqwndfQ4uJp4Ny'
+amount = 0
+reward = 9071000451143
+
+[[stake]]
+address = 'ygyEFN1DYN2CNUmiWuGNHTK97avgmCspRKP61uW7ZPwQ79EQiXTZMD9E8XjbTF55DVwVvyCUAqoZ5vBBpoH2Lo6kA6Aq2UsZbc2fzZurnBj1nCumk1xDXKQRR4VB4kqUfHQ'
+amount = 0
+reward = 52029600267329
+
+[[stake]]
+address = 'ypg1hkUrxVuN781MVWMewVnPi6EZojkKEw7Ek3H7fbjJoaL1a4DaZAebLuaZjAkzfXk6J2UFt1D7fEYfiVEUGohQ3QwQcVYDj9VUUHg6MrE7UzgnV8NP9DNsnP7C6majid4'
+amount = 0
+reward = 7991400898989
+
+[[stake]]
+address = 'ywGDXL2dEoxcatrN5vcc8e8dZ7qyJqV8Jgvvq4Y18z32eNRXnFiZ3j8h8Nd4zwEJ4Y1eHxANEuZ4XrySgAyrbNFj2CN1qDNMJFyWvVdHDN2Z5CSgK5iSezsmuL5qFY8gpE5'
+amount = 0
+reward = 72532800000000
+
+[[stake]]
+address = 'z135yXX1WL91FuzC4nnF9NSSiCCpJhqQHpiUvdRGPzsYbSLJAtLT8pNptoMx6sDei7obXP6knmt6Q8ohk8oSRNw3uZKp5PGp4vrNEeQwqCHPg3497ssCpWAEEntrgLR7R7o'
+amount = 0
+reward = 10000000000000
+
+[[stake]]
+address = 'z5orATvpys3uVb55nYzLTakTQjbspR8zX6dfPmqw8wziy4a77quP4AeDqP9LQi9c1HrCnmoqjaH2xogeqQgRGKxq1aV95X6K9WzwGzpeZc88j7skrxAjoUVQU7YAyzUHUdw'
+amount = 0
+reward = 6528800000000
+
+[[stake]]
+address = 'zBBH6MSK6d2wcg7ZfgtByBqjdnj3H33LANQnswWJXN7NVV8ZFF7GeBH98WAWFPqEUf24VvKwnmMwjYrB8XKKy3LkgxkEvWBpVg9ikMGbEg3Ry9Bqji8qj9i26qTvTqYzZgQ'
+amount = 0
+reward = 10000000000000
+
+[[stake]]
+address = 'zBcFg68J7k8zqw6cZpz7XWbdJje6uJMgz5PhPdN3hRTjdsm3LDHFF36y3NYRW5L4DPsoqcHn5GR6TwkZFTU3tNS8MNoQ7yRwQnhp9rz8PentCpJR5vNziPcF9oZf1oJUFx9'
+amount = 0
+reward = 165941956517210
+
+[[stake]]
+address = 'zENbQ1SwNtCrkGRACZnxEp2L1CZkytdysS3qVAJ5BxSzgnMGhs5BxzDGdcZtQwNh5pGkj5hopVNW5LS6kwSvViXQ8vHqxixEethfFEAVeZDpQDBDVhpodaXxcVGhaic4QWP'
+amount = 0
+reward = 6712000000000
+
+[[stake]]
+address = 'zFGX4RrmCDdUx1o8krtPyJ26jR3qyZEctBN2tt9s1DwhsDLvz6Z2SA3wweCdHBAfobGmDtQ77v4qXfhJgzGLtj6TgVunRzwpwFmZJ2LzWBAgX5bLuskwQ2EwjEWXw5gvXC2'
+amount = 0
+reward = 31451201248407
+
+[[stake]]
+address = 'zNeNZmVeY4QAADxXUPS63BLE11BEuboRAuPV8QJ65YQfHjbiPYvsPZngrGj3vu4YtLhxfJ3dFEf1KxkiakWuYTxjAi7RXuhvy9g7jH29xb2zGSLpRLuoCvKFHYCWZwRf8VY'
+amount = 0
+reward = 47979209516401
+
+[[stake]]
+address = 'zQk8Mnum2E72ghQ9MXtDsr14vFyzNyGQEnxKBUUVMCmHcPdj1Ka2hu7qNnek4JgJ22n1yYMdy5cQ6PppmK1wbkZUBWTF6AynTDbZpBRVvw7GDduv1nJuXJyMWM9AakCBt6t'
+amount = 0
+reward = 8799899485443
+
+[[stake]]
+address = 'zSb3T89J88WQrek9uWM1qgtpdJVUSHV4e9XtmyAuUrvQ1pUABxvWChH4MVwAcrNxQ34WffsFGJdUsVndEHCWy6EmmQYBFHJNo4ym57CQwwJk5FzeNBB3YsHFRjpsbipfEX6'
+amount = 0
+reward = 8988000000000
+
+[[stake]]
+address = 'zSkQ1TAVPecVW1psstMzTGZYviX4Km6n9VotaEgqRhdSomygGBszQQGLyLxePZNcWZHssxsiP2XoM55TMXE9EP19EArR8y9ySKgGNhXBeeByBqCcZ8muZyn7LVoBWeRQG32'
+amount = 0
+reward = 13391000263070
+
+[[stake]]
+address = 'zSyACoVUroCpGhcGjvxjvQ2HvTuoSnVKpcZCjJhmxniACErgXmMmDQVZLAojmcdpzpFTxxGfDxkuxa9MoKEaPRsgaND7STdWwdZRZHtyMAxZnDJTgjJkdbWW45rmCD1XDc1'
+amount = 0
+reward = 10006200000000
+
+[[stake]]
+address = 'zUfqvS9HcohTwgQSU3ad6yEEs2wcDzgt91JN4SwGk6G67z8n8S6pZvnEBiWgb1Dkq5BFHtkVpX2i2xxm6S3n65JLCrVGKS7SjXeGw8sM9euZT5hqEyDj9NQAfbvj22TN16P'
+amount = 0
+reward = 5500000000000
+
+[[stake]]
+address = 'zW7ivcZEJHDnWMbKKQmEH2g6qsGY9Gjp6i6RyY3GkGfaSnYWhcYnBZW3MzbVtPpzWWMBUwcoBAcZ9TUt8RJkUgCzaE4NC1HnYhGv12kkw4f5zhNiB9g5rerpiPbEyTAeGCL'
+amount = 0
+reward = 10000000000000
+
+[[stake]]
+address = 'zYz7NZABzXhsCndD5aqNDm8zRD9p4Nyd4mwtJEtGKZ1eL3csrzBq71YawoLQKpmUX2cGHcHSFrRjdpAxVzdoLRbyYG3TffLwLkfY92kyTCrTsK1MnjKsfG7jwo9Bm5mmHRi'
+amount = 0
+reward = 5443200000000
+
+[[stake]]
+address = 'zdoJeiRaVJxNkyqWAmKrXgNbPJ1VKJ7dfgsrNGnDpBgJg6Rufo1eN4zZ3yFcVafh4PRbzXNLZVvBXV7s4hstNtjMTEE8X1Pm9PUt3Gi7sPupA9yA4Mbwgs4DRG3CmUCcFnu'
+amount = 0
+reward = 1040393799070571
+
+[[stake]]
+address = 'zfMiBiZkoar1e3gBmnpZoq9vpNyzGfyKKYo1GqvPMpjSEiUd279tYXwLY73SmWAniBCH1YgiB2cV7oEsRgbfT3muFxQDym4H36D5wBEpfYbfuakTm62drSYbz6DCJS95tAZ'
+amount = 0
+reward = 10057600000000
+
+[[stake]]
+address = 'zpbLi8Gs2rYpfj4cmUErgEKvv5sP19ncfTtYttBGLrqk1PsJriih9L3vcFywfTPbvvKEdimzVwagEzWLg5yAq45q47yFN2WfNSNUYwhtUs2F3yYnmB5vrppbNQ9aVZftdJK'
+amount = 0
+reward = 17043200000000
+
+[[stake]]
+address = 'zvpj2P5DPpjwxf72kb4cJYmPSEEcrPsUxL7pcpdgE4qXJYCSJxPvPniu94CNVXnEwLjMBEgL33jkv3Mw8fh7nKWsDgJPCT2PCzND8BMQ7cszuQR9PtB3a3Sm3xbLbr1ub4k'
+amount = 0
+reward = 7877824178977
+
+[[stake]]
+address = 'zxvZ6CdmnrMgUAHirRev38Uk6ANr3Nuxebzop1ywbTnfEBGmDjtgNCvzPSAFBUvS1zy7T524sGS2FAe7tAXBzZ86WYG1k2MdABQLcpJ4iCtszLFNJuEjg5rwXLejGJ39V8k'
+amount = 0
+reward = 47246800000000
+
+[[stake]]
+address = '211bUgLCxQmvsEDHuSLnUyAgwxjdQBFaC1jNcG4VRRxWWnwnT7SL4dRQNqQRAEEHTtKjzpYcCdzjjapKxPJA4D3Pf2ZfvfLEZB92UCgTUzsB59oTHqULz48jaeekiYAC8AjC'
+amount = 0
+reward = 6626400000000
+
+[[stake]]
+address = '2188oqHnty21XHkmJ8TW4VM2kC5X8HkVNLcAdjuNeiRdFtJnAj1nvFUMBCnEX6Jt5GDjJtK58miKr8Av2hdsJoKSaJNE8TuYF8EUFc6LDPQJT4crHCQEhLEpJc9z6M9NWvaC'
+amount = 0
+reward = 814763518329998
+
+[[stake]]
+address = '21AmKpzPeK6VG46NHEKFARz3NneMwNnPBu9kxdztPE3CnoGbzUZMQxMZuTc1dPdNNE1QQ6BJUqE4gE28bu4NdFxWgMov6moQwUpJVgYznVMA9un2kf3WpkQ8L15Rxw7MooBK'
+amount = 0
+reward = 5185600000000
+
+[[stake]]
+address = '21DBCGStPTHyEaP3K1woM6srQUBo6MKZrCh4V3H4qDWSQGpofbqb5BzafTUh4p1kxTJJZzgL4qH2PLkHB5o2bWetPXSEtDMYfCoNGfYW2RVRdJi1pyh8owmoBFTLdvmtjsa2'
+amount = 0
+reward = 9142000524894
+
+[[stake]]
+address = '21JEftF3fTvFJhhxLak7dVdmrxTXYuAYawJ4Gn57ULhVBteF6o9DDt4i9HzaSiombXDPKcA49ubdkW1GhDEh5JqHaYdoZWc94yqXYLw21aufNiTcV2NBAxAMpcAX2s11zdAk'
+amount = 0
+reward = 11619200704238
+
+[[stake]]
+address = '21KL9R1h2CWF4Su1RGkf6MucN92yUKMRKgBE4gns9mV1r8BW46APhvBBVX4Ut7f5Zxf639KTZUb2zanB4UZiYsEJkzkwoNJ1GQuKKPBNQkUGKwKq5iudjQJ2UiQFHZ71rMvN'
+amount = 0
+reward = 59309035905630
+
+[[stake]]
+address = '21TsQKKWEm4o2kn2U9oiuV4ryEa45KsFzp5qy1tCpFLX8x5exLuez1VvqXKyr3isbaTmMsazSeibLby8Cpqdv6TWDuPqNm2QdNaY8w7Nzz23jvnsyzFdJGiDHuk6JK71YvSe'
+amount = 0
+reward = 8143271354298
+
+[[stake]]
+address = '21VNkmNPA8A1ksJcgSVGBmYXL9Gr2qZyLmh8CS8hXuhmgKGZaxRAaHZ1wsTeQHWD1836SqHiD1YhRhhhbSEH1HPtyD2tVCeXN9oePb7sMwGhaSTpMKBkgrw88K28DuUG2uSo'
+amount = 0
+reward = 5499888013386
+
+[[stake]]
+address = '21VnoXyZKGmgn6qSDSpJaEP8mHcWpCAgrJRMtkNA2ffnSzZhhNZ7ET9vxhoPLm3bG2RKuWVyDwTWZrfU66PivRswjzWBc3eQuomRQAE4gkkSiBpp2iuWU6eguu4voFFYj278'
+amount = 0
+reward = 6503200000000
+
+[[stake]]
+address = '21abEbhtdAyFiLmN2wwMEHqdkTq9ispxrbjt1aJgUode64TTCqhCYG1vkQ8gWGXQNwZb8ou1tGgorERrqSt8gKSVDeeoYPzURxzz1tKK8t5pdzxLja7VjwKhFnmf45SDHJH3'
+amount = 0
+reward = 10000000000000
+
+[[stake]]
+address = '21dd7HTACGM9cm6wXmfzinkjVMs7R2F43oJ2xjLS4MUq8ypqLfmDVWpBRydj8oUFDgbNHwDvTKDEJrKVoKZ9tq1i5P4ie32Dy3FvRbEDYXjW7i7TVKUGtZS74ukHWtqF6h3r'
+amount = 0
+reward = 6079000000000
+
+[[stake]]
+address = '21e5AaF8k84BJjh4uUARKTyFVbafW5MbczPiQVQz1Rhb8J5oKKZ1TTnaXJYqkFV78P3UJscamW68NMivMDdhCLYMM8UYdGcLRbvHQDjHtphN1eC5gNV13ocwxzfM2Dad9JEd'
+amount = 0
+reward = 20998000000000
+
+[[stake]]
+address = '21gC1spPN8nGfo23AS33D3j5zmofXFLQuJfqFyqs6VXjAj1PkqDVyW63QRn6Y8EASYpKcyB9nohJcaziqox7f7XMcfbJy6GsZyJPCLeXRZQzMaMh22VUArHDQrgGTmgf25Sc'
+amount = 0
+reward = 8999000000000
+
+[[stake]]
+address = '21iMpzwGMDhnRGzw434RNyvPoyX4bHiJ3bLAGFFkWz96LXvjDTqTtMAczghCvekPs58Mbh3UmNN6J1PPpPU3zUPYPZgGu6NRZ5nJu5E6JkJfMDeoHBgcSRJGavPFE7L3LhiC'
+amount = 0
+reward = 7759224462961
+
+[[stake]]
+address = '21jZS71qjvaMs6G6tUqZcvKmD6sd4xSnahAQws9Jh8dsvAWEUECaKQEU3owrj1baYybXsB28csw2rft6G5tFbPWUiVRbdmYJUJKZ8z2jrMqT2wZJhXhRcp7b6NVztJnQTNw5'
+amount = 0
+reward = 11263819540711
+
+[[stake]]
+address = '21vpqs5CxSMLuQRr9fotfJYYaEdbSjqaAMmQYCcEDQ92zHahUQqaKN5cNLdnityZFCLBVxWRaWoZHjVBeWobxtvYLhHwzbs32kFcNfSXc9AtFfFAdtEUt6sw4diwkXf11tbC'
+amount = 0
+reward = 504734455667412
+
+[[stake]]
+address = '21zUAMeKZPKqrKtgKwsTV9jnFHj9EjQRiP16Qh5QiULbjFJEBzE7xHP7KfHh3HUxQZTtapoeZvDcdb34JsmK77KgrcAQuMqBWCF7QwvNrxmYaUEZiusQtMyrXWqgUcvMg413'
+amount = 0
+reward = 6625727610368
+
+[[stake]]
+address = '222TDbjqrGrySJiv8DuiS4nvrtkNZyfSdck9i8bG9z3fzCwRKBWetb4zxSa6ABhxwcr9jKZGUy9A2y1hmrPXdBDJWaXcUiFhT73Y8gUmwxhbaSAvka5MM1XKX6YbsYNNNYUo'
+amount = 0
+reward = 7521000000000
+
+[[stake]]
+address = '225P3Ppu1S18FgNAsC2D7ou4E9dBdZ6MAPBYNQJyFE9M1ntVFGFs3imxL7febHBAxPhiYEHrtRp72ySjmbza9iJcAnVrfDg1WhirwQs52VmvebYP7Z99tDNCiLGL2RpamrT3'
+amount = 0
+reward = 5620800000000
+
+[[stake]]
+address = '2262WQqqiFonBaKtdKdsAxurcYuD3Ag5C6QAfZXQXq6DwufZUbFP5CEvU6hYAvURQWY2iRmfQZD2HqniuYFqXTFE1R2wjBkoy7zNY9GWzduegdzTBYk5PpxT5W8t9U3P29xU'
+amount = 0
+reward = 5441600449891
+
+[[stake]]
+address = '229iYpKRZnEQKKaN8extESUjfUC39cPBXYXut1iACo1bsWSqkxNohRCeiBiyjS4TH8ptbwHhdtvC8kHVEsx1A97MA1TWAswVR863f5cH12emnQV1aPthWYLkgFdCGpYssT1a'
+amount = 0
+reward = 78027249699769
+
+[[stake]]
+address = '22DgXnsogaUJTKwX26ia6UtKgWrpDzBstzcFTSQRgA7EVBUMcaK5B1v91pNG8DXohsevAcs46z3zY9wyVxp8RSDD6NhKy3XR5P5d8krEajw8fc1wgEszc5JwYatDkJvrALmS'
+amount = 0
+reward = 6157600000000
+
+[[stake]]
+address = '22Fu1jXN4YyLBpTvE7GmwZBbSowUSuHUW8pXFr8FwSYeyy3nGkdfwMdGvKEs5soetQFvELMHFxLtptrLe9UYS5bWGLrT2WdhfCU9nZsEzYmWpwk7d2qqN2Wuyrs3ZYGfqcqi'
+amount = 0
+reward = 5587248358448
+
+[[stake]]
+address = '22GgyF3dW9D4UReJm5ZfhDrcqnXzGe1knLLsGdPRzjAg4T57uGSu65VBPm1u4MbYuWSCPNWgsmq6386vnP7vPfcBouyrsMdrfBxHf2M5s42ognrGjzXMNs7Q8xvbnjT4UFNk'
+amount = 0
+reward = 7312000000000
+
+[[stake]]
+address = '22KPWHTfyHyazUbLe9Ub2G89jisHZA63ANbwRFhVevjQkPH1dXv3CHedZdtkzRTiWyUPG1D4zWodg4VNE6T4oLaPbZuVtYFTaN43VkaWf7xqLLbjaNQgSP3RWSQokKovZMx9'
+amount = 0
+reward = 8879200000000
+
+[[stake]]
+address = '22UmXg3k2CJsPf3FepwAmoukeAUbgvP4ivj12gJF2CbrkXr2Cmmh6vfvnRWcVgEsDEf3R7RwRG9219sKAnMW5L7J5FScwQtqhQmCyKMBVpK9uNtg3aP2Ryvt2r977phViZ8U'
+amount = 0
+reward = 134692104718372
+
+[[stake]]
+address = '22VGggU8TUwPQdR6EJZBCD8MFEA3yrvk5GHHkC5d1mrVmtbxxKfwQS1xgwX4ARuXfbe9KRf4pAwBF7fZR9UdcTF8gjZeT2yw7CNz86iegjR7ZEoDDH9SBXaqWrciqQHGGi41'
+amount = 0
+reward = 18197202612085
+
+[[stake]]
+address = '22WcjM2zXTGqvMtUEA4ef6BCzPGTijqs49aBYok4X3xYZBp7LkWLxUy95AEdSbLU8of4LTtYJi855eL8Hk4THrQMHcgY1qYQ7WZgb9V6kvgYhrD9LRdLnaoVGn64wQgKYJY9'
+amount = 0
+reward = 5500000000000
+
+[[stake]]
+address = '22Y2adibhscn7noPkrv4cpiNYmV3Ft2d9WQrRygrttZhnFic4omqm9x1ViGQmm1voC71q99PqyG1SVrv8TFVgV84qx5babCVYdwSrESwFXL3NSeYs8ToiYZEYcQhZNmW8zM1'
+amount = 0
+reward = 7872000000000
+
+[[stake]]
+address = '22YqD7idXP3b5Q5eUzpGXm1E8cnxWcYmk8pjEo9NceGX6eJ1PAgcCM9bjVw26ofXQ2qyaUpRm1Xq2c3SSe5CXAcb3QDBAf5xMCTvqeRMxV4Ynxy8MJTL8ipsSYK4Yf6cSE2t'
+amount = 0
+reward = 10430400466252
+
+[[stake]]
+address = '22ZV8fwZmuoyBbeCPdnBFX4SRBXnBX719whCM6ZQLffiF58AqSA1RmyZ8rruZV27eD3Pd7m5ng6c2UnBZLyxkbrtHJ2w49Ygq9JxE7vg3QKujgSTSURNSWJap9q6gPFdvQE6'
+amount = 0
+reward = 6818400000000
+
+[[stake]]
+address = '22dJGLKaRdcUrGZV1TFTnSnp6y95jyvPEqqyuur5vpfrmiZB5cgU8xh1PyPZ2J5C1ioR4bHE1rQH1od6CdYYNqR88NfMgx3m9ueCLczXqbbirAwPMbC2HZaUA782n9hJQLw4'
+amount = 0
+reward = 6773600000000
+
+[[stake]]
+address = '22gGW8Zh1fFgtbknUW4PdxXoJZapZ6CGFaZ8joB8wLvCnRzKLED9rekUuq2oAqe2K43KYAMhmzxBBe8RzyNKagX1Th85sqdSyYTWiLeehrSX2ukbz4Z7eymXSBmAMiJ6un3U'
+amount = 0
+reward = 6297222850308835
+
+[[stake]]
+address = '22h5RtQYQt6buxfSNXgBmCpU2Z3Q8wDtHw6R4o3uNYtBfViy4s7m9C86QzmAqczwnn4x6MV4SRVe4VtVhe5HBtovEzdGJgPevAwLAq1L9SbFXGCmyC6ddz6Nv49G1XE8Bg7Z'
+amount = 0
+reward = 6728000000000
+
+[[stake]]
+address = '22iv75ExGi3hAvUezGwA3PVcKXc8rgTT457PG8XJg3wJgg12AjD5pwaAbQpwuQG79UhfHt7tfMVfV1TnkfcW9aJYTjQy1trh52nY8CqgqKGFfAvEyzQPzxX29XxQsUR4cWMr'
+amount = 0
+reward = 11072000000000
+
+[[stake]]
+address = '22oNCaUfKyrnrkxWZKdCCzWnWfksw4dchFAdqGonm4oCzuyuxn6jkwVpYyU8aZdDLzq1TRvS4K8ApZifv1uE9EB37Geqos82DY22FpxMFpS5DUpBffa2HyiFNn8RWC3eAVaf'
+amount = 0
+reward = 10215800000000
+
+[[stake]]
+address = '22pjfKwVXqRSWQH8MKFYZDMDUe4EdXGPowmnScUjyQktofTd3zntL2J4TafdHhr1VyMGtFQmhoR53XMKAd3S31X8GaaMvC3qzf44MqjwQoGtL1Q7XnZXwQynTGAUzUcV51gn'
+amount = 0
+reward = 8007200000000
+
+[[stake]]
+address = '22yz3aSfzdT4t5b5GmQSwFHWwcCNVQgc1qNvqGCUxnrQd6LXFMobxRR3JG7ZXG1Dbn2zN5gX5BDPA34UvyEqicySwRA4Rf8uLboLcRR6QrQ1LkFRCZ2hnKFFETLEvsqJxcjC'
+amount = 0
+reward = 5486400000000
+
+[[stake]]
+address = '23SMLJFJuwA6HETvWjdx923qfAoMBmGXjrVHKa8voQbEBVaYubezfS8xuZYs5QVK3YiUZEdsPACdfTupbYvfxSV7RJeVYbetNWRBpWiWA4ryFP4zQ74K3K1jAhhcqXCH6WLb'
+amount = 0
+reward = 422887596504216
+
+[[stake]]
+address = '23Xq6SRmWoSjehJ7ZH5Yk43zAvo7gFVThoEH7XApHNwCQEr5DkhoGeX65QAea9muMJyXH77VCnNNitxWErLncQBze959RGYsfr4C6nWWvUKtha7EKA5wnudr1ZoEgCjHaN86'
+amount = 0
+reward = 39879228412689
+
+[[stake]]
+address = '23esVsLQ9ZA2fikVMdifHzLvi1HFqWAXqRwK5jfNVNb2t7MFMFNcVEcuFEATrxuptQSEZPu4EmwECgoFZDciMaVrKBozJUWbPDAhTYa33NZWQHLGzUHyaV51Sx2wBJSrb4TS'
+amount = 0
+reward = 5634000000000
+
+[[stake]]
+address = '23jFPiYSVEabmdo3zENKt4qSdBsVMDRTcneZ7LYKhfuB7E8UHXCLiPKDwXWTx4DAQirk2PhVkh6PiZKzaYhAkHuRwsKc7EAaB44yETLLzaWPoBGYDeoiwE82x9oY913RFUPH'
+amount = 0
+reward = 119428448619037
+
+[[stake]]
+address = '23kFt6zjr93HKDcCpj6oLCkG8Qvd4FYgYAD8SdsBkhepdwQLb4MEAthQWEwrThVoqEPnYEdzGwUGPWqXq9rmN72yuqauiVqyoFxWHFUqDceYFkmUeZY2kAYmEaz7JFrPNr6f'
+amount = 0
+reward = 35820404207891
+
+[[stake]]
+address = '23ku6X344VffeD9qH228Q83TJXZtWwfnugc2mVipWYLh1FNVuWXg8XHEYyF8zg9ykK6MAJrKvi4mLXH9hz6MZh8bzwEyaAHKKo9ttFB5UdneiLPQNJgi9oK93EmH3Npf6WLC'
+amount = 0
+reward = 33333000000000
+
+[[stake]]
+address = '23oZwXzMs7MwcBLKBexma7jGzLwDenQkNzkbL15rFeNB2N9fKBCfdTHDgGNncScqgKM7iBF4wn5FoB9iWUp9AAvdCPiCFAa7EsGLFV33XeSJSLNbCeRsxPmCx9pFnkoTHUU3'
+amount = 0
+reward = 6638498897482
+
+[[stake]]
+address = '23tQbtUhEih3hCZSHnQV6JWRyWJYgU6KrehoDDP4Ga6xVQEypCHxYLwSFEYoiVGaFcUuDDPuSMSjy1r76wZDe1GSWLeBpi1akMRTMD4WBztfREZdao5HuRiS1Zv8hYpU9W9n'
+amount = 0
+reward = 67045600000000
+
+[[stake]]
+address = '23uW7My963Vbf7YvD6DWYX3QafQa7xEQYkpxZNcurm6tdmPB8U7UqzTfYjXuy4Uw52nMPgj1We59xV12Qqwj7VbJWbk6UtfnyV4MJ36yoN5T5KiBm9gLPRntNVpewGH4h1yw'
+amount = 0
+reward = 5043200000000
+
+[[stake]]
+address = '23uWoHkBm7qQPRWRr1deANtvKXew8fA7H8oRBfuMo4HNhrY3AnxGX6FcnfdGTjynBgk7rvy2QKDohYcCzDJYajDox8X2hJhTAvobmGYVV6NKXchzr6NifVpZxo1ojZg9B7yJ'
+amount = 0
+reward = 51914003704610
+
+[[stake]]
+address = '23yRmDP3VxFzJbhnweMnFJEeVAJvjo5H2A1BbvfJYAWJYSw1CeK47YU9zHpe4gUfao7SCNbG14nkzbYWhCkDVZcZiUgMrBjChYLTb1kvhNWhcYkKCstTn5N7H9z6Ufe8wnRE'
+amount = 0
+reward = 5435202066749
+
+[[stake]]
+address = '244JNuKVneRjRDYGnYUKTAfcgA4wn36JG5XJyP4j3vcECQNPWKCYV2yNhwN9ERA8F8QAtyHyGojRUvDvpBi54rCoRqZaWjDrTES9DyVwNxAcjsFZbVboYeKXzPeCFYmPRGQV'
+amount = 0
+reward = 7698000000000
+
+[[stake]]
+address = '2457tV7h776iFzyh9aicXARLfPTdthkAiZyVzyxC7M2daSAQbei5jGbMoPJVWUK8yRpqp66S7zMcytSYdCdfU8iziJYrYAuoZFk42RVa6T8u7B154qMGdrDpNcvsmo2ASa1k'
+amount = 0
+reward = 6500000000000
+
+[[stake]]
+address = '24LaJTrgM9dczt1eRXjxeTdg1pGoyiGTGqWmdQrTfN8XwXD61ooEGiifhMDFcRZ6ZJyuniwwy9GtUUQAxzkGT8YHF71NrUn9fnaaBNfMCDZTpnmkK4JihDyuPoSLjQQDPbzE'
+amount = 0
+reward = 5100800000000
+
+[[stake]]
+address = '24Pj8252ssT5UVZaJ26Xps7wPHujAHRZhXrQGT5bgdjYLF22TPc1fdFDuJ4CqEvzdZN9fVuBjdo8HnBnHKHrZaPbwKmoUSTE9DqY9a29yjtkYL9hWuDoiNCqVJgEZ4Evp2gT'
+amount = 0
+reward = 9081200000000
+
+[[stake]]
+address = '24S9mCTzrH6H9Z8T7cjk69t28AkYx82vatnQCbNTfiiuSumePuEX5iB2rtzhb1ognZKwgpb2q58zEY4mDTxLjst83xCH5Wc3bKaen6VnC6SwstSSrcAiGhZ63ULqgymrzX75'
+amount = 0
+reward = 147300000000000
+
+[[stake]]
+address = '24SwSTWfVhozFBQYBS7pCW5A3gnxbw1oCGD4a3BLiCoj5wGmgptqnQskrwtKyCMzE4eVmdsVLEJzRWPQ8kBs6hpiiD4VCbPeRiraKF8zhKDSUnP3WcWCubiZrCtCAFnR1uKs'
+amount = 0
+reward = 11111000000000
+
+[[stake]]
+address = '24TmZV7YSCnBaN587ViKeMzq4KhqkuEHiaau9CqZHduB2HpLuF6QHsNScnDza9RHpYp42eQVPj8SX3ApQFyuExE1wribJknvSQksRb1AVKo8246MWv2PxXVe9hm3MfoWN2uG'
+amount = 0
+reward = 5479926479714
+
+[[stake]]
+address = '24Ujm5AZ1JfSXe1PsVohP4aeuFRRM3TY9sHVULR5WKh7qkK5JxVR7xJBSEFDd81bsFtTFXq9ANuiEEF9jZRVDVHEWSXVmS249fkgc3KnxWse2wrQrVGLmDLzNtySddyiJuCS'
+amount = 0
+reward = 172541600260993
+
+[[stake]]
+address = '24WTeF1pK7cY7L6BMi6XG1APuJMmXFDVyw7r8ZHkHMBWxSgjfoNnD8skQNDYWKNXyZoP3C8kt6kM5JQcmWdDYVe88NBeSjv4v3Ff8nZ8U37PMzicVUs336QqG9Nf8iUa4pPE'
+amount = 0
+reward = 102624004006336
+
+[[stake]]
+address = '24ZoKfWVppDApT7LhyfbAEWyAHgGUeGgqAVdGbgTocjmsmS3YJQtKRsSXZ3Ekyn6BotZQhQwAaNshAZk7e5oGWJ2p1UN4DJRakCWYoLVZYHoPQRQXUPbEtmhp4hvKiCHa5RV'
+amount = 0
+reward = 10910400000000
+
+[[stake]]
+address = '24adNFu3zfFjc7Bc56ktvNV7isGqKU2EbkPHAEsrAUkyJEzuMpCUTA8LRdTBHVpQsFkayEj5ajT7jw58qxCs7t81jo7yfu8NMwFxhaXSPncYhX6cJyWLCUKn2bSuduoFza4b'
+amount = 0
+reward = 5695600452423
+
+[[stake]]
+address = '24baRKVFkkS13HURrWsPpjbNZ7HWBwCDaPs6JZc5Ry5f4y3XknztzqoueU6zFbH5C9vqHW4gsw6LqMCDtCt3FWyXTyctAFgGQnua9qPdFofqBFWU2bxYsYhr2NPFb6znVmVZ'
+amount = 0
+reward = 21032000000000
+
+[[stake]]
+address = '24dkpUUU9gAbEhsrPjXHVB2oPSA55yEaNNJFTZ1uHktYpbzHfnreDZAWNPHjonHNoaFijDUWdsiMaWKbYwSBCDj87m5wq8R9xbrpgNJF3Y2jkhJwJQiiErZy9a5RLco8hGfa'
+amount = 0
+reward = 6000000000000
+
+[[stake]]
+address = '24gJHyDmFQxXzeTS7d6PYjTe3E4a7GcmUF1kNbD8dWRzGcCpX2PgkrFRGUQdTSksRHka6yUMLAn1bZhKReZCPgWyoaGB716S1wCcPg3Kh8zeQhjFnf9GVb7P18F839yd6CoL'
+amount = 0
+reward = 5500000000000
+
+[[stake]]
+address = '24hBGdobzcyw16WvvH7vdmo8weVwqPRw16K8Bfy5XvuKphW77h4PCWuiYRWHR2Cq3WcxsJv63cDB1SMj6LzcDmMo47ZdtZvK8Wk8t3b5DLoUNDTDtffGMJ6U5EzyqTFNWjxe'
+amount = 0
+reward = 6794800262024
+
+[[stake]]
+address = '24mgbjMGwBvdruzCjCwa8vxYPLoAnp9DHjhx6xwDm1rmiKkLkT9heHJ56rxLcjj4uYP38Ubw3GHRxKsFmGbQAEijanKc5yKB2Ng4i3udnBpwkFSyETnzK1nZQTvEcoH2HwJ2'
+amount = 0
+reward = 14460800262466
+
+[[stake]]
+address = '24qrGKg3o3Cbsxo1Mt7LsTyk9bzmUW32iJQgYGKwv4Ek8digxBr27vvvTB5obfyrqHR4354ykxnL7C4j2NfUPJaLBumWBGgHdcYVg5MAQBu86c5osNX6RWpwGyCDp13S9gXm'
+amount = 0
+reward = 11130410135976
+
+[[stake]]
+address = '24r4QSsv8GknEN4tqxF6nSxeiq1hS4GLuDVyCnTQRWWuHRfaPrnuKCmkaGmS7GL7y84DsHEkAGg47TBsKWi1n3kMKLLWasNUURfPdRFYh1GZV8Bdqxf5Nhoh3JswTuNfn3D5'
+amount = 0
+reward = 21559203857141
+
+[[stake]]
+address = '24rzmANCHnfWc1g8gPUnQXcQtQeaEyr2AWoTN2tNHf9SwJhCjtueDkKj4zQXK1qtjti84SfugNbwff5c8fQ6RPWYrarxwK3pCnzLNtc3fx5aSqwPao34yJb1uGbqWDSXSxz5'
+amount = 0
+reward = 5901624452309
+
+[[stake]]
+address = '24tRR3tz72AAdeJbRQ41EjrmJyGdnn83HJQFknCnrw4pJiSMXVmP2qWDzeRbP7YyJQ4b54nNWTKWx5pB4rJmd813tKqFr6E8ZpqeD52iKtV5BKqcqzC1a69x1dSADuCzuhuK'
+amount = 0
+reward = 5608400267642
+
+[[stake]]
+address = '24xnNjE4zZWEhYtLdtKLLkE5HM4FPpx7NVFcePwx7UAnFYMENaDKNSRb8YM7QTBvBNjnXfPJN5sqv7XA8G5WXDhwpdDzq65gYBKVVwswmdZ2D4Yr9e28Z2rQAtXtHrhNUX5Z'
+amount = 0
+reward = 10718150678681
+
+[[stake]]
+address = '251rgqjRMpRkGyLAXpLaP7qfW6MWdSS6Cw6qvYrCE52ehvbJLX8KiHggDBnNXU1FrEZkyF8WcbNbGZbPzLMjpPJ22TLQtYe2jmodkBhx17xhxn7kXvftoMAqBXXXnmD1feiS'
+amount = 0
+reward = 50962473604344
+
+[[stake]]
+address = '2528hUdZbLmzDv5EvyozenEcZhSXw2in9HGm5wB1UaoADpCLQHoFgAZNZvukps8FtRt3RDDkfv3EMaQqsRaF9S2fpHjnrFi8caSD1Qsyrox8SByH9GztUx48uRAiVKDxYWnu'
+amount = 0
+reward = 16500000000000
+
+[[stake]]
+address = '25DS4UaodE6Dax76EKSu2EVQob71VFSn9dewQNXfMt7dsLrDdVoavTvuzEHuQqkaCHJfDCySz5QqCof8hzK2V72tseEUCbg8BKkGwqjGwUsKHNpdKfjQx13VXAkynVLeG8kF'
+amount = 0
+reward = 6414376174648
+
+[[stake]]
+address = '25HS2S3Sx5gMRBv5H7XJKAbuU3FP5bcoszKAJXGkk7MMdEgChpaH8rtCxkKnQZjPdPCXe7ao2Lnkz9jwXjWfmsBkL29nxzEsH1ux6rPunB8KaDV3mQEhFfnds5tMUJRcRSXi'
+amount = 0
+reward = 5547800448699
+
+[[stake]]
+address = '25HruDCwRM4qc96e6NMu3eWF3Jfwt4i7kpJPM4Vteh5neZf1PRLnXoTad8F8NaxEskQFHzDYkccBCUTAirvakT56Up2KWXDH7w8mKCkTbQYY7fRPwLy2bytwvraT6djBA5zL'
+amount = 0
+reward = 5443200000000
+
+[[stake]]
+address = '25Jq7UFjfVf94mGDem2iy7K9pDtgo8tNWyYdF57V1Xjo2XCwkPNwME2bKosChUYvrbySiGKoU5ffaZZkYaEdChDinHs8uvFzLjrnoNh8ZjtNNPpDKiS3qwCAQZNA6ChqhaWF'
+amount = 0
+reward = 5555200449980
+
+[[stake]]
+address = '25KVegFD3Bxmoi87MU2fkvNM7PburSBx5qA7kaw5yUMKVrNs6uQG7Xf8wZdJr34mJbXcXRLPwPXaqf8Pnoztd86Shy9n6DLiMXjsEkJexMnEu3ADHH7rSaANMBtSq5XiNqkd'
+amount = 0
+reward = 51939850000000
+
+[[stake]]
+address = '25LAWNqy2XDXnsdi7ruc83MEa1Uveibvkh5vZ1XurXtMity7m17Vbxa652a5YZKN3iX9JDbMS5JK5TtjFhEeWp1CvXNs7nL6zrMLnGYZcNf57MkZ4KMr7GNcS2w5bUHdN7qR'
+amount = 0
+reward = 77592018708996
+
+[[stake]]
+address = '25LiRxJx7LEviv7PQYUXa5ihFbJDSy2XJKrperZLSJKqzR4zPwxeLqVco7cgLiJpJbmwDDy7BPPBWGNmL8rPE2a5r6pgGXpupD9pxAA79eAeSVjnd5GGtWqh2ocPViH1CvCt'
+amount = 0
+reward = 2501218219969554
+
+[[stake]]
+address = '25Uq6FJwzM6s2vPMD9CMUY8rwh9gars2KiUMM7kLTLVv8JuQzjLrayKJFWWguk8uPGLG333wJcavwBaZ67w7QM1Nc4uebwR8f5N4j3g9HLZSpV2jGPCp8hDh6hmbXc8eP69R'
+amount = 0
+reward = 8384900718622
+
+[[stake]]
+address = '25VVzgDRCTM4GXZGhq3DnZEKUvTpSaNFx3YMzH3yRTFehs6CU7HxZDtbr1ri8tMHY6SSmp6CLe2LFRXhDMD2vRAenvr5zZNFPbgXCMqEhvJGon9hTCQPJ5PJKnj226UpP9hZ'
+amount = 0
+reward = 106092900567800
+
+[[stake]]
+address = '25YoGbhRYMmPioz7XfUUQJTeiPMjaJ6YVoSbg2Rh5QUXNwz3cAUg8NTPdFbnQs38pnhuXxQJxnS6muLVuVCtLRqtP5RdRE4dtpsY9n25dUQLQjHDdtaCdAWcT4wJH4ySbW5h'
+amount = 0
+reward = 218244908365169
+
+[[stake]]
+address = '25YuvCqyNCzKSngi4LdLG1VRCF5agY82ceyznQsSeqFrAwQ4AHYfRxRBTKhNpA5bjhg2GgxKUY8BDi3GnvYgA9Q4iBUMtnEai7X39G4ymgsh2mDxGNyzMUofFnxkQ7RCGU3X'
+amount = 0
+reward = 6670400000000
+
+[[stake]]
+address = '25c3YekLzr4Pdz6YKaRjGTqaK5SDnu752qoDoLhoDzo7Ts6Hf1jLZBCZVercFpi5nMrvgGW3kCQRVp4PYw6E3pjzdLSDUtHPQ4zU8xS8qQEehjxFTC6wAEXaBRxAhMxz1tGF'
+amount = 0
+reward = 88310717088553
+
+[[stake]]
+address = '25npbaG6zNbDfbJFCbfaUBi8KgbVRKu1RgvmJZTC1rofphbf6P5cELdzCPeJQJC9Bd9GfurXM9ntyxaC6yrqgMk5eo7BH3N6bpDMrFje7ogW3ZU57zHorJWky7ztWJrHUjWG'
+amount = 0
+reward = 5645810000000
+
+[[stake]]
+address = '25oS9Um1eqVBpbvLxNm7niCwKgC4bA1Hq2umUM182y4b79N1bQ7AnotV26sK2W9yjrK2sskweFKWzA35zJm6kkRicJxmYmL7pH5FEthAJ1t7wfxWzwtjk99Vkkfkza8bDbw9'
+amount = 0
+reward = 536667786991572
+
+[[stake]]
+address = '25qGrk7rpoeoQH83NLLsgr8x3BiqFwsEmiU2qTjsiUJjdMBscA7zDEVfcjoPnxn462Yye9ztoHAUPmzLG4da7QYhHinmGHyre9HxFDgqkRs2PjD7E6v5Wa48H4sdRfzgSS2K'
+amount = 0
+reward = 7079621873814
+
+[[stake]]
+address = '25wy1DHR51t1PkhYhMGujjZZyQRBW27G1ykmKnyNyEwwQLhHe4fPAcCyv7uh2EhRgx16LptSvwnFo9VRgS7jKwZriFMN4qiCX9iAZQG6NPGk1tyU5NHotGVwYecVJsed6CaY'
+amount = 0
+reward = 105195610541298
+
+[[stake]]
+address = '25xRzpViWjweW1vB1EADyksgVzUrxhxjEdqVyE5P3jeFXNqx3T9y29nKCyaSNaHwK1n18agnqwK1H4C7At61sUekqPT7pCkW4yJ6PZZuK1SkkZLFovxCVcqcXhdH5HmMhnQ2'
+amount = 0
+reward = 6432001426352
+
+[[stake]]
+address = '268TuebiFmaqQYuWA5qT3j5GcQfLt1eCpXfjQixgycg49evgEeeNNc8zhyXLDoRduCZgZCM9SDxHKQrbh6cVudBPfYFNmboZrRLNw79HU5vqThy57daQJzJKh1QzYcupMv2e'
+amount = 0
+reward = 69818600527679
+
+[[stake]]
+address = '26A7czdjDiKJDbWb6RcZagf2CiqRvtXmEE4KTJJS7KfkRASDHaKw3hrCTXYXqxgZpWwZSTkhkezPpUWTR5ec3nrDvaMmAaNnoc4F1c9f2p6JB486AMPydirf2He6vvNqKgT9'
+amount = 0
+reward = 126921631311845
+
+[[stake]]
+address = '26DXWeuszw7gStdctvVpRmLWjUjmby4CkSXypmm62ADcC2Bcm6Xy7kuJqe5uXVrpATrRMoHe2T7rgKxdgMgnQxUBcth23UHnXfSUSS8bdN21TuXDVDkcJomaJWwN1kSrZbCQ'
+amount = 0
+reward = 121856014324602
+
+[[stake]]
+address = '26Tx84EZfjWN7bXGAKgP5MWnnfJ53jdPBn9oJbyHfGd8Vu2DNQKatnLoCkxYu1udqe73b1RCmCFWgJVpooj6dXFkfyVudbn4YGHAAmy1JWHPzKUxMSYPvCLGvaci6UfB4YPo'
+amount = 0
+reward = 17076000262476
+
+[[stake]]
+address = '26XX4Y3qf5MpfE5BjmwMw1NzDvAVBGvqfTTtH1ksTsZ4EadNEk3bdjrSdpfJLWb9Wc2nh7J9P75Gxe7EfxHLR6N1VG73xS9dZAx7ijy7tfQXK3W5LCabgZA7JqUP6YUKv6yW'
+amount = 0
+reward = 5588800523790
+
+[[stake]]
+address = '26d92JjRZZic6LgmKHU96TJnrtc8yezRuTFx5HbwRiwrdMUbGqGGT3CTeVZvpKpTUjL2sL6h8cw9DRwH5SSVT6ihLT243FuzCuvvEDk1pvu3Y7nkmpThw2dFsfgYN7rzgwmX'
+amount = 0
+reward = 10112200525132
+
+[[stake]]
+address = '26f9Bq3htZLpHWPGi8nhfna4kXhTNhiUq3PkZx1gAY4LnhzhyHKnXSzMzqUHB5Bef8hBc4yvu68tdLsgFM4SruvXiagJQ4gXb8941EYzdER5tBT9MFJ1vf1MuCuDT2nBdNvA'
+amount = 0
+reward = 5682800000000
+
+[[stake]]
+address = '26fo4EiE3ZoZxT3mfZpzf91AhdD1Gjpdz3UhKcF7aRs65phJpuRdaxot3soY7foEtben4gYkMbuzeshcKgiCsPbezCvzA9VnEphrcyd6JcAddMc6V19Zy32wWVkEjirNNGzs'
+amount = 0
+reward = 10199801420673
+
+[[stake]]
+address = '26sLNdu4ZZQZWc27Kw9V2LVrURxep7i75eyCcKBLby46gDSSCABm269p9PHfvaBBQuKaLfa6QdmgH1hvzp8KU5kM3mRx1N2iSxgERY7BgBLzwRArjhMXTS7DPkvS4Ek4s4np'
+amount = 0
+reward = 101154400000000
+
+[[stake]]
+address = '271Kgzh1TWeYPf1CU7BbnGHJZDJttZ7FRKZ7Wt68wwUWPuJjQZQRsseYjaLDxbJhP4TVuLzRVfXd6H8sJHM216VEMKcArdunLqLNh1mMdsaCdtinNFUjqyRTztwoHYskhXpq'
+amount = 0
+reward = 52315800000000
+
+[[stake]]
+address = '271zWxBm6QnM2qjfypWjE2h2RP7yYmc7nUqsozWCoZewDCUaBs86y7rmqCN6ejwoc6BPzrdu3erPBAev1yNRGdnVtemubxAQPPjzKK6bsHZrwKLPTHCJ8bZKXByaD4F9MFrk'
+amount = 0
+reward = 8331482328410616

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -134,11 +134,11 @@ fn generate_stake_state(
     let theme = Theme::default();
     snapshot.stakes().enumerate().for_each(|(idx, staker)| {
         info!("{} provisioner #{}", theme.action("Generating"), idx);
+        let amount = (staker.amount > 0)
+            .then(|| (staker.amount, staker.eligibility.unwrap_or_default()));
+
         let stake = StakeData {
-            amount: Some((
-                staker.amount,
-                staker.eligibility.unwrap_or_default(),
-            )),
+            amount,
             reward: staker.reward.unwrap_or_default(),
             counter: 0,
         };


### PR DESCRIPTION
Data retrieved with

```sh
curl -s -L 'https://nodes.dusk.network/02/rusk' \
--data-raw '{"topic": "provisioners","data": ""}' \ |
jq -r '.[] | select(.amount+.eligibility != 500000000000000) | . + {itn_val: (.amount + .reward)} | select (.itn_val > 5000000000000) | "[[stake]]\naddress = '\''\(.key)'\''\namount = 0\nreward= \(.itn_val | tostring )\n"'
```


1. Get the current provisioner list
2. Filter out our 30 genesis provisioners with `select(.amount+.eligibility != 500000000000000)`
3. Calculating a new field with the sum of staked amount and the accrued reward `{itn_val: (.amount + .reward)}`
4. Filter out member with less of 5k dusk accrued `select (.itn_val > 5000000000000)`
5., Change representation to the one expected by genesis.toml `| "[[stake]]\naddress = '\''\(.key)'\''\namount = 0\nreward = \(.itn_val | tostring )\n"`