### PR TITLE
web-wallet: Different letter spacing on Button and AnchorButton

### DIFF
--- a/web-wallet/CHANGELOG.md
+++ b/web-wallet/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update font family and letter spacing in buttons, textboxes and selects [#1565]
 - Update copy on Reset Wallet while syncing [#1552]
 - Trigger the Restore flow if a user tries to access a new wallet [#1535]
 - Clear the login info storage on "Reset Wallet" (Settings) [#1551]
@@ -202,6 +203,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1545]: https://github.com/dusk-network/rusk/issues/1545
 [#1547]: https://github.com/dusk-network/rusk/issues/1547
 [#1552]: https://github.com/dusk-network/rusk/issues/1552
+[#1565]: https://github.com/dusk-network/rusk/issues/1565
 [#1576]: https://github.com/dusk-network/rusk/issues/1576
 
 <!-- VERSIONS -->

--- a/web-wallet/src/style/dusk-components/button.css
+++ b/web-wallet/src/style/dusk-components/button.css
@@ -4,6 +4,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  font-family: inherit;
+  letter-spacing: inherit;
   line-height: 1;
   border-radius: var(--control-border-radius-size);
   border-style: solid;

--- a/web-wallet/src/style/dusk-components/select.css
+++ b/web-wallet/src/style/dusk-components/select.css
@@ -1,7 +1,9 @@
 .dusk-select {
   display: inline-block;
   appearance: none;
+  font-family: inherit;
   font-size: var(--control-font-size);
+  letter-spacing: inherit;
   padding: var(--control-padding);
   padding-right: 2.25em;
   background-color: var(--control-bg-color);

--- a/web-wallet/src/style/dusk-components/textbox.css
+++ b/web-wallet/src/style/dusk-components/textbox.css
@@ -1,5 +1,7 @@
 .dusk-textbox {
+  font-family: inherit;
   font-size: var(--control-font-size);
+  letter-spacing: inherit;
   padding: var(--control-padding);
   background-color: var(--control-bg-color);
   border-color: var(--control-border-color);


### PR DESCRIPTION
- Fix `font-family` and `letter-spacing` on `Button`, `AnchorButton`, `Textbox` and `Select`

Resolves #1565