### PR TITLE
Implement a basic telemetry service 

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -38,6 +38,8 @@ smallvec = "1.10.0"
 
 serde = "1.0"
 thiserror = "1"
+metrics = "0.22.3"
+metrics-exporter-prometheus = { version = "0.14.0" }
 
 [dev-dependencies]
 fake = { version = "2.5", features = ['derive'] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -38,8 +38,8 @@ smallvec = "1.10.0"
 
 serde = "1.0"
 thiserror = "1"
-metrics = "0.22.3"
-metrics-exporter-prometheus = { version = "0.14.0" }
+metrics = "0.22"
+metrics-exporter-prometheus = "0.14"
 
 [dev-dependencies]
 fake = { version = "2.5", features = ['derive'] }

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -418,6 +418,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
         let block_time =
             blk.header().timestamp - mrb.inner().header().timestamp;
 
+        let header_verification_start = std::time::Instant::now();
         // Verify Block Header
         let attested = verify_block_header(
             self.db.clone(),
@@ -426,6 +427,10 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
             blk.header(),
         )
         .await?;
+
+        // Elapsed time header verification
+        histogram!("dusk_block_header_elapsed")
+            .record(header_verification_start.elapsed());
 
         // Final from rolling
         let mut ffr = false;

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -26,6 +26,7 @@ use crate::chain::metrics::AverageElapsedTime;
 use crate::database::rocksdb::{
     MD_AVG_PROPOSAL, MD_AVG_RATIFICATION, MD_AVG_VALIDATION,
 };
+use metrics::gauge;
 use node_data::{ledger, Serializable, StepName};
 use std::sync::Arc;
 use std::time::Duration;
@@ -119,6 +120,9 @@ impl Task {
             all = all_num,           // all provisioners count
             eligible = eligible_num  // eligible provisioners count
         );
+
+        gauge!("dusk_provisioners_eligible").set(eligible_num as f64);
+        gauge!("dusk_provisioners_all").set(all_num as f64);
 
         let id = self.task_id;
         let result_queue = self.result.clone();

--- a/node/src/chain/fsm.rs
+++ b/node/src/chain/fsm.rs
@@ -10,6 +10,7 @@ use crate::database;
 use crate::{vm, Network};
 
 use crate::database::{Candidate, Ledger};
+use metrics::counter;
 use node_data::ledger::{to_str, Block, Label};
 use node_data::message::payload::{
     GetBlocks, GetData, RatificationResult, Vote,
@@ -431,6 +432,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> InSyncImpl<DB, VM, N> {
                     .await
                 {
                     Ok(_) => {
+                        counter!("dusk_fallback_count").increment(1);
                         if remote_height == acc.get_curr_height().await + 1 {
                             acc.try_accept_block(remote_blk, true).await?;
                             return Ok(None);

--- a/node/src/chain/header_validation.rs
+++ b/node/src/chain/header_validation.rs
@@ -53,7 +53,7 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
     /// * `disable_winner_cert_check` - disables the check of the winning
     /// certificate
     ///
-    /// Returns true if there is a cerificate for each failed iteration, and if
+    /// Returns true if there is a certificate for each failed iteration, and if
     /// that certificate has a quorum in the ratification phase.
     ///
     /// If there are no failed iterations, it returns true
@@ -162,7 +162,7 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
         Ok(())
     }
 
-    /// Return true if there is a cerificate for each failed iteration, and if
+    /// Return true if there is a certificate for each failed iteration, and if
     /// that certificate has a quorum in the ratification phase.
     ///
     /// If there are no failed iterations, it returns true

--- a/node/src/database.rs
+++ b/node/src/database.rs
@@ -45,13 +45,14 @@ pub trait DB: Send + Sync + 'static {
 /// Implements both read-write and read-only transactions to DB.
 
 pub trait Ledger {
-    // Read-write transactions
+    /// Read-write transactions
+    /// Returns disk footprint of the committed transaction
     fn store_block(
         &self,
         header: &ledger::Header,
         txs: &[SpentTransaction],
         label: Label,
-    ) -> Result<()>;
+    ) -> Result<usize>;
 
     fn delete_block(&self, b: &ledger::Block) -> Result<()>;
     fn fetch_block_header(

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -11,6 +11,7 @@ pub mod database;
 pub mod databroker;
 pub mod mempool;
 pub mod network;
+pub mod telemetry;
 pub mod vm;
 
 use async_trait::async_trait;

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -87,6 +87,8 @@ impl<const N: usize> kadcast::NetworkListen for Listener<N> {
                 counter!("dusk_bytes_recv").increment(msg_size as u64);
                 counter!(format!("dusk_inbound_{:?}_size", msg.topic()))
                     .increment(msg_size as u64);
+                counter!(format!("dusk_inbound_{:?}_count", msg.topic()))
+                    .increment(1);
 
                 // Update Transport Data
                 msg.metadata = Some(Metadata {

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -12,6 +12,7 @@ use crate::{BoxedFilter, Message};
 use async_trait::async_trait;
 use kadcast::config::Config;
 use kadcast::{MessageInfo, Peer};
+use metrics::counter;
 use node_data::message::Metadata;
 use node_data::message::{AsyncQueue, Topics};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -78,9 +79,14 @@ impl<const N: usize> Listener<N> {
 
 impl<const N: usize> kadcast::NetworkListen for Listener<N> {
     fn on_message(&self, blob: Vec<u8>, md: MessageInfo) {
+        let msg_size = blob.len();
         match frame::Pdu::decode(&mut &blob.to_vec()[..]) {
             Ok(d) => {
                 let mut msg = d.payload;
+
+                counter!("dusk_bytes_recv").increment(msg_size as u64);
+                counter!(format!("dusk_inbound_{:?}_size", msg.topic()))
+                    .increment(msg_size as u64);
 
                 // Update Transport Data
                 msg.metadata = Some(Metadata {
@@ -174,6 +180,11 @@ impl<const N: usize> Kadcast<N> {
     pub fn conf(&self) -> &Config {
         &self.conf
     }
+
+    async fn send_with_metrics(&self, bytes: &Vec<u8>, recv_addr: SocketAddr) {
+        counter!("dusk_bytes_sent").increment(bytes.len() as u64);
+        self.peer.send(bytes, recv_addr).await;
+    }
 }
 
 #[async_trait]
@@ -189,6 +200,10 @@ impl<const N: usize> crate::Network for Kadcast<N> {
             error!("could not encode message {msg:?}: {err}");
             anyhow::anyhow!("failed to broadcast: {err}")
         })?;
+
+        counter!("dusk_bytes_cast").increment(encoded.len() as u64);
+        counter!(format!("dusk_outbound_{:?}_size", msg.topic()))
+            .increment(encoded.len() as u64);
 
         trace!("broadcasting msg ({:?})", msg.topic());
         self.peer.broadcast(&encoded, height).await;
@@ -209,8 +224,7 @@ impl<const N: usize> crate::Network for Kadcast<N> {
         let topic = msg.topic();
 
         info!("sending msg ({topic:?}) to peer {recv_addr}");
-
-        self.peer.send(&encoded, recv_addr).await;
+        self.send_with_metrics(&encoded, recv_addr).await;
 
         Ok(())
     }
@@ -227,8 +241,7 @@ impl<const N: usize> crate::Network for Kadcast<N> {
 
         for recv_addr in self.peer.alive_nodes(amount).await {
             trace!("sending msg ({topic:?}) to peer {recv_addr}");
-
-            self.peer.send(&encoded, recv_addr).await;
+            self.send_with_metrics(&encoded, recv_addr).await;
         }
 
         Ok(())

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -239,6 +239,8 @@ impl<const N: usize> crate::Network for Kadcast<N> {
             .map_err(|err| anyhow::anyhow!("failed to encode: {err}"))?;
         let topic = msg.topic();
 
+        counter!(format!("dusk_requests_{:?}", topic)).increment(1);
+
         for recv_addr in self.peer.alive_nodes(amount).await {
             trace!("sending msg ({topic:?}) to peer {recv_addr}");
             self.send_with_metrics(&encoded, recv_addr).await;

--- a/node/src/telemetry.rs
+++ b/node/src/telemetry.rs
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::{database, vm, LongLivedService, Network};
+use async_trait::async_trait;
+use metrics::{describe_counter, describe_histogram, Unit};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(Default)]
+pub struct TelemetrySrv {}
+
+#[async_trait]
+impl<N: Network, DB: database::DB, VM: vm::VMExecution>
+    LongLivedService<N, DB, VM> for TelemetrySrv
+{
+    /// Assigns a description to any metric collected
+    async fn initialize(
+        &mut self,
+        _network: Arc<RwLock<N>>,
+        _db: Arc<RwLock<DB>>,
+        _vm: Arc<RwLock<VM>>,
+    ) -> anyhow::Result<()> {
+        describe_histogram!(
+            "dusk_block_est_elapsed",
+            "The elapsed time of EST call on block acceptance."
+        );
+        describe_counter!(
+            "dusk_block_{Final,Accepted, Attested}",
+            "The Cumulative number of all blocks by label."
+        );
+
+        describe_counter!(
+            "dusk_outbound_Quorum_size",
+            Unit::Bytes,
+            "The Cumulative size of inbound messages by type."
+        );
+
+        // TODO: add it
+        // TODO: consider other metrics
+        // Slashed_all/Shashed_this/ Generator/ Provisioners / Bytes_sent/
+        // Bytes_recv / Latency block
+        describe_counter!(
+            "dusk_fallbacks",
+            "The Cumulative number of fallback execution."
+        );
+
+        Ok(())
+    }
+
+    /// Initialize and spawn Prometheus Exporter and Recorder
+    /// By default, recorder exposes metrics to localhost:9000/metrics
+    async fn execute(
+        &mut self,
+        _network: Arc<RwLock<N>>,
+        _db: Arc<RwLock<DB>>,
+        _vm: Arc<RwLock<VM>>,
+    ) -> anyhow::Result<usize> {
+        // TODO: Disable/Enable by Toml config
+
+        // If PrometheusBuilder Recorder is not enabled then a NOOP
+        // (No-overhead) Recorder is used by default.
+        let (recorder, exporter) = PrometheusBuilder::new().build()?;
+        metrics::set_global_recorder(recorder)?;
+        exporter.await?;
+        Ok(0)
+    }
+
+    /// Returns service name.
+    fn name(&self) -> &'static str {
+        "telemetry"
+    }
+}

--- a/node/src/telemetry.rs
+++ b/node/src/telemetry.rs
@@ -40,13 +40,14 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
             "The Cumulative size of inbound messages by type."
         );
 
-        // TODO: add it
-        // TODO: consider other metrics
-        // Slashed_all/Shashed_this/ Generator/ Provisioners / Bytes_sent/
-        // Bytes_recv / Latency block
         describe_counter!(
-            "dusk_fallbacks",
-            "The Cumulative number of fallback execution."
+            "dusk_fallback_count",
+            "The Cumulative number of fallback executions."
+        );
+
+        describe_counter!(
+            "dusk_txn_count",
+            "The Cumulative number of all executed transactions."
         );
 
         Ok(())

--- a/node/src/telemetry.rs
+++ b/node/src/telemetry.rs
@@ -6,73 +6,56 @@
 
 use crate::{database, vm, LongLivedService, Network};
 use async_trait::async_trait;
-use metrics::{describe_counter, describe_histogram, Unit};
 use metrics_exporter_prometheus::PrometheusBuilder;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 #[derive(Default)]
-pub struct TelemetrySrv {}
+pub struct TelemetrySrv {
+    addr: Option<String>,
+}
 
 #[async_trait]
 impl<N: Network, DB: database::DB, VM: vm::VMExecution>
     LongLivedService<N, DB, VM> for TelemetrySrv
 {
-    /// Assigns a description to any metric collected
+    /// Returns service name.
+    fn name(&self) -> &'static str {
+        "telemetry"
+    }
+
     async fn initialize(
         &mut self,
         _network: Arc<RwLock<N>>,
         _db: Arc<RwLock<DB>>,
         _vm: Arc<RwLock<VM>>,
     ) -> anyhow::Result<()> {
-        describe_histogram!(
-            "dusk_block_est_elapsed",
-            "The elapsed time of EST call on block acceptance."
-        );
-        describe_counter!(
-            "dusk_block_{Final,Accepted, Attested}",
-            "The Cumulative number of all blocks by label."
-        );
-
-        describe_counter!(
-            "dusk_outbound_Quorum_size",
-            Unit::Bytes,
-            "The Cumulative size of inbound messages by type."
-        );
-
-        describe_counter!(
-            "dusk_fallback_count",
-            "The Cumulative number of fallback executions."
-        );
-
-        describe_counter!(
-            "dusk_txn_count",
-            "The Cumulative number of all executed transactions."
-        );
-
         Ok(())
     }
 
     /// Initialize and spawn Prometheus Exporter and Recorder
-    /// By default, recorder exposes metrics to localhost:9000/metrics
     async fn execute(
         &mut self,
-        _network: Arc<RwLock<N>>,
-        _db: Arc<RwLock<DB>>,
-        _vm: Arc<RwLock<VM>>,
+        _: Arc<RwLock<N>>,
+        _: Arc<RwLock<DB>>,
+        _: Arc<RwLock<VM>>,
     ) -> anyhow::Result<usize> {
-        // TODO: Disable/Enable by Toml config
-
         // If PrometheusBuilder Recorder is not enabled then a NOOP
-        // (No-overhead) Recorder is used by default.
-        let (recorder, exporter) = PrometheusBuilder::new().build()?;
-        metrics::set_global_recorder(recorder)?;
-        exporter.await?;
+        // (No-overhead) recorder is used by default.
+        if let Some(addr) = &self.addr {
+            let addr = addr.parse::<SocketAddr>()?;
+            let (recorder, exporter) =
+                PrometheusBuilder::new().with_http_listener(addr).build()?;
+            metrics::set_global_recorder(recorder)?;
+            exporter.await?;
+        }
         Ok(0)
     }
+}
 
-    /// Returns service name.
-    fn name(&self) -> &'static str {
-        "telemetry"
+impl TelemetrySrv {
+    pub fn new(addr: Option<String>) -> Self {
+        Self { addr }
     }
 }

--- a/node/testbed.sh
+++ b/node/testbed.sh
@@ -1,101 +1,69 @@
-	#!/bin/bash
-	killall rusk
+#!/bin/bash
 
-	# Determines how many pre-loaded provisioners will be in use.
-	PROV_NUM=$1
-	MODE=$2
-	#GENESIS_PATH="/home/tech/repo/dusk-network/dusk-blockchain/harness/tests/rusk_localnet_state.toml"
-	GENESIS_PATH="./rusk-recovery/config/testnet.toml"
+# Function to run a single node
+run_node() {
+    local BOOTSTRAP_ADDR="$1"
+    local PUBLIC_ADDR="$2"
+    local LOG_LEVEL="$3"
+    local KEYS_PATH="$4"
+    local ID="$5"
+    local TEMPD="$6"
+    local WS_LISTEN_ADDR="$7"
+    local TELEMETRY_LISTEN_ADDR="$8"
+    
+    local NODE_FOLDER="${TEMPD}/node_${ID}"
+    local RUSK_STATE_PATH="${NODE_FOLDER}/state"
 
-	#BOOTSTRAP_ADDR="127.0.0.1:10000"
-	BOOTSTRAP_ADDR="127.0.0.1:7000"
-	# DUSK_WALLET_DIR is the path to the directory containing a set of consensus keys files.
-	if [ -z "$DUSK_WALLET_DIR" ]; then
-	    echo "Warning: DUSK_WALLET_DIR is not set"
-	fi
-
-	# Create a temporary directory.`
-	TEMPD=/tmp/rust-harness/
-	rm -fr $TEMPD
-	mkdir $TEMPD
-
-	# Exit if the temp directory wasn't created successfully.
-	if [ ! -e "$TEMPD" ]; then
-	    >&2 echo "Failed to create temp directory"
-	    exit 1
-	fi
-
-	echo "test harness folder:$TEMPD"
-
-	run_node() {
-	  if [ "$MODE" = "--with_telemetry" ]; then
-	    run_node_with_telemetry "$@"
-	  else
-	    run_node_debug_mode "$@"
-	  fi
-	}
-
-	run_node_debug_mode() {
-	  local BOOTSTRAP_ADDR="$1"
-	  local PUBLIC_ADDR="$2"
-	  local LOG_LEVEL="$3"
-	  local KEYS_PATH="$4"
-	  local ID="$5"
-	  local TEMPD="$6"
-	  local WS_LISTEN_ADDR="$7"
-
-    local NODE_FOLDER=${TEMPD}/node_${ID}
-
-	  local RUSK_STATE_PATH=${NODE_FOLDER}/state
-
-	  RUSK_STATE_PATH=${RUSK_STATE_PATH} cargo r --release -p rusk -- recovery-state --init $GENESIS_PATH
-	  echo "starting node $ID ..."
-    echo "${KEYS_PATH}/node_$ID.keys"
-	  RUSK_STATE_PATH=${RUSK_STATE_PATH} ./target/release/rusk --kadcast-bootstrap "$BOOTSTRAP_ADDR" --kadcast-public-address "$PUBLIC_ADDR" --log-type="json" --log-level="info" --log-filter="dusk_consensus=debug"  --consensus-keys-path="${KEYS_PATH}/node_$ID.keys" --db-path="$NODE_FOLDER" --http-listen-addr "$WS_LISTEN_ADDR" --delay-on-resp-msg=10 > "${TEMPD}/node_${ID}.log" &
-	}
-
-	## Use ~/.cargo/bin/tokio-console --retain-for 0s http://127.0.0.1:10000 to connect console to first node
-	run_node_with_telemetry() {
-	  local BOOTSTRAP_ADDR="$1"
-	  local PUBLIC_ADDR="$2"
-	  local LOG_LEVEL="$3"
-	  local KEYS_PATH="$4"
-	  local ID="$5"
-	  local TEMPD="$6"
-	  
-	  T_BIND_PORT=$((10000+$ID))
-
-	  echo "starting node $ID ..."
-
-	  RUST_LOG="info" TOKIO_CONSOLE_BIND="127.0.0.1:$T_BIND_PORT" \
-	  cargo --config 'build.rustflags = ["--cfg", "tokio_unstable"]' run --features with_telemetry --bin rusk-node --\
-	  --kadcast_bootstrap "$BOOTSTRAP_ADDR" --kadcast_public_address "$PUBLIC_ADDR" --log-level="$LOG_LEVEL" --log-filter="dusk_consensus=debug" \
-  --consensus-keys-path="${KEYS_PATH}/node_$ID.keys" --db-path="${TEMPD}/db/${ID}" --config="default.config.toml" > "${TEMPD}/node_${ID}.log" &
+    RUSK_STATE_PATH="${RUSK_STATE_PATH}" cargo r --release -p rusk -- recovery-state --init "$GENESIS_PATH"
+    
+    echo "Starting node $ID ..."
+    RUSK_STATE_PATH="${RUSK_STATE_PATH}" ./target/release/rusk --kadcast-bootstrap "$BOOTSTRAP_ADDR" \
+        --kadcast-public-address "$PUBLIC_ADDR" --log-type="json" --log-level="info" \
+        --log-filter="dusk_consensus=debug" --consensus-keys-path="${KEYS_PATH}/node_$ID.keys" \
+        --db-path="$NODE_FOLDER" --http-listen-addr "$WS_LISTEN_ADDR" --telemetry-listen-addr "$TELEMETRY_LISTEN_ADDR" --delay-on-resp-msg=10 \
+        >"${TEMPD}/node_${ID}.log" &
 }
 
-# Spawn N (up to 9) nodes
-for (( i=0; i<$PROV_NUM; i++ ))
-do
-  PORT=$((7000+$i))
-  WS_PORT=$((8000+$i))
+# Cleanup function to stop all running rusk-node processes
+cleanup() {
+    echo "Stopping all running rusk-node processes..."
+    killall rusk || true
+    rm -rf "$TEMPD"
+    echo "Cleanup complete."
+}
 
-  #delay=$(($i))
-  #sleep 20
+# Set up trap to execute cleanup function
+trap cleanup INT TERM EXIT
 
-  run_node "$BOOTSTRAP_ADDR" "127.0.0.1:$PORT" "info" "$DUSK_WALLET_DIR" "$i" "$TEMPD" "127.0.0.1:$WS_PORT" &
+# Kill all existing rusk processes
+killall rusk
 
-  # wait for bootstrappers 
-  # TODO
+# Determine number of pre-loaded provisioners and mode
+PROV_NUM="$1"
+
+# Set paths and addresses
+GENESIS_PATH="./rusk-recovery/config/testnet.toml"
+BOOTSTRAP_ADDR="127.0.0.1:7000"
+DUSK_WALLET_DIR="${DUSK_WALLET_DIR:-}" # Default value if DUSK_WALLET_DIR is not set
+
+# Check if DUSK_WALLET_DIR is set
+if [ -z "$DUSK_WALLET_DIR" ]; then
+    echo "Warning: DUSK_WALLET_DIR is not set"
+fi
+
+# Create a temporary directory
+TEMPD=$(mktemp -d -t rust-harness.XXXX) || { echo "Failed to create temp directory"; exit 1; }
+echo "Test harness folder: $TEMPD"
+
+# Spawn nodes
+for ((i = 0; i < PROV_NUM; i++)); do
+    PORT=$((7000 + $i))
+    WS_PORT=$((8000 + $i))
+    TELEMETRY_PORT=$((9000 + $i))
+    run_node "$BOOTSTRAP_ADDR" "127.0.0.1:$PORT" "info" "$DUSK_WALLET_DIR" "$i" "$TEMPD" "127.0.0.1:$WS_PORT" "127.0.0.1:$TELEMETRY_PORT" &
 done
 
-
-# monitor
+# Monitor nodes
 sleep 10
-tail -F ${TEMPD}node_*.log | grep -e "accepted\|ERROR\|gen_candidate"
-# tail -F ${TEMPD}node_*.log
+tail -F "${TEMPD}node_*.log" | grep -e "accepted\|ERROR\|gen_candidate"
 
-# Stop all running rusk-node processes when script is interrupted or terminated
-trap 'killall rusk || true; rm -rf "$TEMPD"' INT TERM EXIT
-
-# Wait for all child processes to complete
-wait

--- a/node/testbed.sh
+++ b/node/testbed.sh
@@ -65,5 +65,5 @@ done
 
 # Monitor nodes
 sleep 10
-tail -F "${TEMPD}node_*.log" | grep -e "accepted\|ERROR\|gen_candidate"
+tail -F "${TEMPD}/node_*.log" | grep -e "accepted\|ERROR\|gen_candidate"
 

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -72,8 +72,6 @@ node = { version = "0.1", path = "../node", optional = true }
 dusk-consensus = { version = "0.1.1-rc.3", path = "../consensus", optional = true }
 node-data = { version = "0.1", path = "../node-data", optional = true }
 
-## Bump to 0.8.7 requires rust 1.71.0 due to `build_hasher_simple_hash_one` feature stabilization
-ahash = "=0.8.6"
 
 ## GraphQL deps
 async-graphql = "5.0"

--- a/rusk/src/bin/args.rs
+++ b/rusk/src/bin/args.rs
@@ -67,6 +67,10 @@ pub struct Args {
     /// Address http server should listen on
     pub http_listen_addr: Option<String>,
 
+    #[clap(long)]
+    /// Address telemetry server should listen on
+    pub telemetry_listen_addr: Option<String>,
+
     #[clap(long, env = "KADCAST_BOOTSTRAP", verbatim_doc_comment)]
     /// Kadcast list of bootstrapping server addresses
     pub kadcast_bootstrap: Option<Vec<String>>,

--- a/rusk/src/bin/config.rs
+++ b/rusk/src/bin/config.rs
@@ -10,6 +10,8 @@ pub mod chain;
 pub mod databroker;
 #[cfg(feature = "node")]
 pub mod kadcast;
+#[cfg(feature = "node")]
+pub mod telemetry;
 
 pub mod http;
 
@@ -26,6 +28,8 @@ use self::chain::ChainConfig;
 use self::databroker::DataBrokerConfig;
 #[cfg(feature = "node")]
 use self::kadcast::KadcastConfig;
+#[cfg(feature = "node")]
+use self::telemetry::TelemetryConfig;
 
 use self::http::HttpConfig;
 
@@ -49,6 +53,10 @@ pub(crate) struct Config {
 
     #[serde(default = "HttpConfig::default")]
     pub(crate) http: HttpConfig,
+
+    #[cfg(feature = "node")]
+    #[serde(default = "TelemetryConfig::default")]
+    pub(crate) telemetry: TelemetryConfig,
 }
 
 /// Default log_level.
@@ -94,6 +102,7 @@ impl From<&Args> for Config {
             rusk_config.kadcast.merge(args);
             rusk_config.chain.merge(args);
             rusk_config.databroker.merge(args);
+            rusk_config.telemetry.merge(args);
         }
 
         rusk_config

--- a/rusk/src/bin/config/telemetry.rs
+++ b/rusk/src/bin/config/telemetry.rs
@@ -19,7 +19,6 @@ impl TelemetryConfig {
     }
 
     pub(crate) fn merge(&mut self, args: &Args) {
-        // Overwrite config ws-listen-addr
         if let Some(listen_addr) = &args.telemetry_listen_addr {
             self.listen_address = Some(listen_addr.into());
         }

--- a/rusk/src/bin/config/telemetry.rs
+++ b/rusk/src/bin/config/telemetry.rs
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use serde::{Deserialize, Serialize};
+
+use crate::args::Args;
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct TelemetryConfig {
+    listen_address: Option<String>,
+}
+
+impl TelemetryConfig {
+    pub fn listen_addr(&self) -> Option<String> {
+        self.listen_address.clone()
+    }
+
+    pub(crate) fn merge(&mut self, args: &Args) {
+        // Overwrite config ws-listen-addr
+        if let Some(listen_addr) = &args.telemetry_listen_addr {
+            self.listen_address = Some(listen_addr.into());
+        }
+    }
+}

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -114,7 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Box::<MempoolSrv>::default(),
             Box::new(ChainSrv::new(config.chain.consensus_keys_path())),
             Box::new(DataBrokerSrv::new(config.clone().databroker.into())),
-            Box::<TelemetrySrv>::default(),
+            Box::new(TelemetrySrv::new(config.telemetry.listen_addr())),
         ];
 
         #[cfg(feature = "ephemeral")]

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -20,6 +20,7 @@ use node::{
     databroker::DataBrokerSrv,
     mempool::MempoolSrv,
     network::Kadcast,
+    telemetry::TelemetrySrv,
     LongLivedService, Node,
 };
 #[cfg(feature = "node")]
@@ -113,6 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Box::<MempoolSrv>::default(),
             Box::new(ChainSrv::new(config.chain.consensus_keys_path())),
             Box::new(DataBrokerSrv::new(config.clone().databroker.into())),
+            Box::<TelemetrySrv>::default(),
         ];
 
         #[cfg(feature = "ephemeral")]


### PR DESCRIPTION
fixes #1610 

All of the `localnet` nodes exposes metrics data at `localhost` ports 9000..9029

Example output: 
```
# TYPE dusk_outbound_Candidate_size counter
dusk_outbound_Candidate_size 18602

# TYPE dusk_inbound_Candidate_size counter
dusk_inbound_Candidate_size 21008

# TYPE dusk_bytes_recv counter
dusk_bytes_recv 386842

# TYPE dusk_txn_count counter
dusk_txn_count 0

# TYPE dusk_outbound_Quorum_size counter
dusk_outbound_Quorum_size 6800

# TYPE dusk_inbound_GetCandidate_size counter
dusk_inbound_GetCandidate_size 371

# TYPE dusk_bytes_cast counter
dusk_bytes_cast 270195

# TYPE dusk_outbound_Ratification_size counter
dusk_outbound_Ratification_size 139970

# TYPE dusk_bytes_sent counter
dusk_bytes_sent 7757

# TYPE dusk_inbound_Quorum_size counter
dusk_inbound_Quorum_size 27184

# TYPE dusk_outbound_Validation_size counter
dusk_outbound_Validation_size 104823

# TYPE dusk_inbound_GetBlocks_size counter
dusk_inbound_GetBlocks_size 1113

# TYPE dusk_inbound_Validation_size counter
dusk_inbound_Validation_size 138170

# TYPE dusk_inbound_Ratification_size counter
dusk_inbound_Ratification_size 198996

# TYPE dusk_block_Final counter
dusk_block_Final 22

# TYPE dusk_block_Attested counter
dusk_block_Attested 3

# TYPE dusk_block_Accepted counter
dusk_block_Accepted 3

# TYPE dusk_provisioners_eligible gauge
dusk_provisioners_eligible 29

# TYPE dusk_provisioners_all gauge
dusk_provisioners_all 363

# TYPE dusk_stored_candidates_count gauge
dusk_stored_candidates_count 10

# TYPE dusk_block_iter summary
dusk_block_iter{quantile="0"} 0

# TYPE dusk_slashed_count summary
dusk_slashed_count{quantile="1"} 0

# TYPE dusk_block_est_elapsed summary
dusk_block_est_elapsed{quantile="1"} 0.01662995
dusk_block_est_elapsed_sum 0.6494382420000001
dusk_block_est_elapsed_count 22
```