### PR TITLE
Upgrade `piecrust` to version `0.18`

### DIFF
--- a/contracts/license/tests/license.rs
+++ b/contracts/license/tests/license.rs
@@ -163,6 +163,7 @@ fn license_issue_get_merkle() {
             LICENSE_CONTRACT_ID,
             "get_licenses",
             &bh_range,
+            u64::MAX,
             feeder,
         )
         .expect("Querying of the licenses should succeed")
@@ -241,6 +242,7 @@ fn multiple_licenses_issue_get_merkle() {
             LICENSE_CONTRACT_ID,
             "get_licenses",
             &bh_range,
+            u64::MAX,
             feeder,
         )
         .expect("Querying of the licenses should succeed")
@@ -344,6 +346,7 @@ fn use_license_get_session() {
             LICENSE_CONTRACT_ID,
             "get_licenses",
             &bh_range,
+            u64::MAX,
             feeder,
         )
         .expect("Querying the license should succeed")

--- a/contracts/stake/benches/get_provisioners.rs
+++ b/contracts/stake/benches/get_provisioners.rs
@@ -69,7 +69,13 @@ fn do_get_provisioners(
     session: &mut Session,
 ) -> Result<impl Iterator<Item = (PublicKey, StakeData)>, Error> {
     let (sender, receiver) = mpsc::channel();
-    session.feeder_call::<_, ()>(STAKE_CONTRACT, "stakes", &(), sender)?;
+    session.feeder_call::<_, ()>(
+        STAKE_CONTRACT,
+        "stakes",
+        &(),
+        u64::MAX,
+        sender,
+    )?;
     Ok(receiver.into_iter().map(|bytes| {
         rkyv::from_bytes::<(PublicKey, StakeData)>(&bytes)
             .expect("The contract should only return (pk, stake_data) tuples")

--- a/contracts/stake/tests/common/utils.rs
+++ b/contracts/stake/tests/common/utils.rs
@@ -30,6 +30,7 @@ pub fn leaves_from_height(
         TRANSFER_CONTRACT,
         "leaves_from_height",
         &height,
+        u64::MAX,
         feeder,
     )?;
 

--- a/contracts/transfer/tests/transfer.rs
+++ b/contracts/transfer/tests/transfer.rs
@@ -126,6 +126,7 @@ fn leaves_from_height(
         TRANSFER_CONTRACT,
         "leaves_from_height",
         &height,
+        u64::MAX,
         feeder,
     )?;
 
@@ -142,6 +143,7 @@ fn leaves_from_pos(session: &mut Session, pos: u64) -> Result<Vec<TreeLeaf>> {
         TRANSFER_CONTRACT,
         "leaves_from_pos",
         &pos,
+        u64::MAX,
         feeder,
     )?;
 

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -22,8 +22,8 @@ dusk-bytes = "0.1"
 bytecheck = { version = "0.6", default-features = false }
 dusk-plonk = { version = "0.16", default-features = false, features = ["rkyv-impl", "alloc"] }
 
-piecrust-uplink = { version = "0.11.0" }
-piecrust = { version = "0.17.0", optional = true }
+piecrust-uplink = { version = "0.11" }
+piecrust = { version = "0.18", optional = true }
 
 # These are patches since these crates don't seem to like semver.
 rkyv = { version = "=0.7.39", default-features = false, features = ["size_32"] }

--- a/rusk/src/bin/config/http.rs
+++ b/rusk/src/bin/config/http.rs
@@ -16,18 +16,25 @@ pub struct HttpConfig {
     pub key: Option<PathBuf>,
     #[serde(default = "default_listen")]
     pub listen: bool,
+    #[serde(default = "default_feeder_call_gas")]
+    pub feeder_call_gas: u64,
     listen_address: Option<String>,
 }
 
 impl Default for HttpConfig {
     fn default() -> Self {
         Self {
-            listen: default_listen(),
-            listen_address: None,
             cert: None,
             key: None,
+            listen: default_listen(),
+            feeder_call_gas: default_feeder_call_gas(),
+            listen_address: None,
         }
     }
+}
+
+const fn default_feeder_call_gas() -> u64 {
+    u64::MAX
 }
 
 const fn default_listen() -> bool {

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -99,7 +99,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rusk, node, mut service_list) = {
         let state_dir = rusk_profile::get_rusk_state_dir()?;
         info!("Using state from {state_dir:?}");
-        let rusk = Rusk::new(state_dir, config.chain.generation_timeout())?;
+
+        let rusk = Rusk::new(
+            state_dir,
+            config.chain.generation_timeout(),
+            config.http.feeder_call_gas,
+        )?;
 
         info!("Rusk VM loaded");
 

--- a/rusk/src/lib/chain.rs
+++ b/rusk/src/lib/chain.rs
@@ -32,6 +32,7 @@ pub struct Rusk {
     pub(crate) vm: Arc<VM>,
     dir: PathBuf,
     pub(crate) generation_timeout: Option<Duration>,
+    pub(crate) feeder_gas_limit: u64,
 }
 
 #[derive(Clone)]

--- a/rusk/src/lib/chain/rusk.rs
+++ b/rusk/src/lib/chain/rusk.rs
@@ -41,6 +41,7 @@ impl Rusk {
     pub fn new<P: AsRef<Path>>(
         dir: P,
         generation_timeout: Option<Duration>,
+        feeder_gas_limit: u64,
     ) -> Result<Self> {
         let dir = dir.as_ref();
         let commit_id_path = to_rusk_state_id_path(dir);
@@ -71,6 +72,7 @@ impl Rusk {
             vm,
             dir: dir.into(),
             generation_timeout,
+            feeder_gas_limit,
         })
     }
 

--- a/rusk/src/lib/chain/vm/query.rs
+++ b/rusk/src/lib/chain/vm/query.rs
@@ -110,6 +110,7 @@ impl Rusk {
             contract_id,
             call_name,
             call_arg,
+            u64::MAX,
             feeder,
         )?;
 
@@ -135,6 +136,7 @@ impl Rusk {
             contract_id,
             call_name.as_ref(),
             call_arg,
+            u64::MAX,
             feeder,
         )?;
 

--- a/rusk/src/lib/chain/vm/query.rs
+++ b/rusk/src/lib/chain/vm/query.rs
@@ -110,7 +110,7 @@ impl Rusk {
             contract_id,
             call_name,
             call_arg,
-            u64::MAX,
+            self.feeder_gas_limit,
             feeder,
         )?;
 
@@ -136,7 +136,7 @@ impl Rusk {
             contract_id,
             call_name.as_ref(),
             call_arg,
-            u64::MAX,
+            self.feeder_gas_limit,
             feeder,
         )?;
 

--- a/rusk/tests/common/state.rs
+++ b/rusk/tests/common/state.rs
@@ -30,7 +30,8 @@ pub fn new_state<P: AsRef<Path>>(dir: P, snapshot: &Snapshot) -> Result<Rusk> {
     let (_, commit_id) = state::deploy(dir, snapshot)
         .expect("Deploying initial state should succeed");
 
-    let rusk = Rusk::new(dir, None).expect("Instantiating rusk should succeed");
+    let rusk = Rusk::new(dir, None, u64::MAX)
+        .expect("Instantiating rusk should succeed");
 
     assert_eq!(
         commit_id,


### PR DESCRIPTION
We also add a configuration option to be able to stipulate the maximum gas used by feeder calls. The default value is set as `u64::MAX`, but this should probably be discussed.