### PR TITLE
web-wallet: Icon scaling issue when used in Button

### DIFF
--- a/web-wallet/src/routes/components-showcase/Buttons.svelte
+++ b/web-wallet/src/routes/components-showcase/Buttons.svelte
@@ -28,34 +28,34 @@
 </section>
 <br />
 <section>
-  <AnchorButton href="/" icon={{ path: mdiHome }} text="Anchor - Primary" />
+  <AnchorButton href="#" icon={{ path: mdiHome }} text="Anchor - Primary" />
   <AnchorButton
-    href="/"
+    href="#"
     disabled={true}
     icon={{ path: mdiHome }}
     text="Anchor - Primary - Disabled"
   />
   <AnchorButton
-    href="/"
+    href="#"
     icon={{ path: mdiHome }}
     text="Anchor - Secondary"
     variant="secondary"
   />
   <AnchorButton
-    href="/"
+    href="#"
     disabled={true}
     icon={{ path: mdiHome }}
     text="Anchor - Secondary - Disabled"
     variant="secondary"
   />
   <AnchorButton
-    href="/"
+    href="#"
     icon={{ path: mdiHome }}
     text="Anchor - Tertiary"
     variant="tertiary"
   />
   <AnchorButton
-    href="/"
+    href="#"
     disabled={true}
     icon={{ path: mdiHome }}
     text="Tertiary - Disabled"
@@ -120,6 +120,60 @@
   />
   <Button icon={{ path: mdiHome }} size="small" variant="tertiary" />
   <Button
+    disabled={true}
+    icon={{ path: mdiHome }}
+    size="small"
+    variant="tertiary"
+  />
+</section>
+<hr />
+<section>
+  <AnchorButton href="#" icon={{ path: mdiHome }} />
+  <AnchorButton href="#" disabled={true} icon={{ path: mdiHome }} />
+  <AnchorButton href="#" icon={{ path: mdiHome }} variant="secondary" />
+  <AnchorButton
+    href="#"
+    disabled={true}
+    icon={{ path: mdiHome }}
+    variant="secondary"
+  />
+  <AnchorButton href="#" icon={{ path: mdiHome }} variant="tertiary" />
+  <AnchorButton
+    href="#"
+    disabled={true}
+    icon={{ path: mdiHome }}
+    variant="tertiary"
+  />
+</section>
+<section>
+  <AnchorButton href="#" icon={{ path: mdiHome }} size="small" />
+  <AnchorButton
+    href="#"
+    disabled={true}
+    icon={{ path: mdiHome }}
+    size="small"
+  />
+  <AnchorButton
+    href="#"
+    icon={{ path: mdiHome }}
+    size="small"
+    variant="secondary"
+  />
+  <AnchorButton
+    href="#"
+    disabled={true}
+    icon={{ path: mdiHome }}
+    size="small"
+    variant="secondary"
+  />
+  <AnchorButton
+    href="#"
+    icon={{ path: mdiHome }}
+    size="small"
+    variant="tertiary"
+  />
+  <AnchorButton
+    href="#"
     disabled={true}
     icon={{ path: mdiHome }}
     size="small"

--- a/web-wallet/src/style/dusk-components/button.css
+++ b/web-wallet/src/style/dusk-components/button.css
@@ -15,7 +15,7 @@
   transform-origin: center center;
   transition-delay: 0s;
   transition-duration: 0.2s;
-  transition-property: background-color, border-color, color, transform;
+  transition-property: background-color, border-color, color, scale;
   transition-timing-function: ease-in-out;
 }
 
@@ -102,5 +102,11 @@
 
 .dusk-anchor.dusk-icon-button:hover,
 .dusk-icon-button:not(:disabled):hover {
-  scale: 1.2;
+  scale: 1.1;
+}
+
+.dusk-icon-button:enabled:active,
+.dusk-anchor-button.dusk-icon-button:active,
+.dusk-button--active {
+  scale: 0.9;
 }

--- a/web-wallet/src/style/dusk-components/checkbox.css
+++ b/web-wallet/src/style/dusk-components/checkbox.css
@@ -9,6 +9,7 @@
   width: var(--checkbox-control-size);
   height: var(--checkbox-control-size);
   flex-shrink: 0;
+  transition: background-color 0.2s ease-in-out 0s;
 }
 
 .dusk-checkbox:checked {

--- a/web-wallet/src/style/main.css
+++ b/web-wallet/src/style/main.css
@@ -104,16 +104,6 @@ svg {
   z-index: 4;
 }
 
-.dusk-anchor-button:not(.dusk-anchor-button__disabled),
-.dusk-button:enabled,
-.dusk-checkbox:enabled,
-.dusk-select:enabled,
-.dusk-switch[aria-disabled="false"],
-.dusk-textbox:enabled,
-*[role="menuitem"] {
-  transition: all 0.2s linear 0s;
-}
-
 :is(
     .dusk-anchor-button:not(.dusk-anchor-button__disabled),
     .dusk-button:enabled,


### PR DESCRIPTION
- Added specific transform for checkbox background-color
- Fixed scaling for icon buttons in active state
- Removed unused transform that was overriding the easing function in buttons
- Updated the scaling up of icon buttons on hover to 1.1

Resolves #1637