### PR TITLE
Add RUES dispatch

### DIFF
--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -55,7 +55,7 @@ tungstenite = "0.20"
 hyper-tungstenite = "0.11"
 hyper = { version = "0.14", features = ["server", "stream", "http1", "http2"] }
 
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tokio-rustls = "0.25"
 rustls-pemfile = "2"

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -51,9 +51,12 @@ dusk-bytes = "0.1"
 kadcast = "0.6.0-rc"
 dusk-wallet-core = "0.25.0-phoenix.0.26"
 phoenix-core = { version = "0.26", default-features = false, features = ["rkyv-impl", "alloc"] }
-tungstenite = "0.20"
-hyper-tungstenite = "0.11"
-hyper = { version = "0.14", features = ["server", "stream", "http1", "http2"] }
+pin-project = "1"
+tungstenite = "0.21"
+hyper-tungstenite = "0.13"
+hyper = { version = "1", features = ["server", "http1", "http2"] }
+hyper-util = { version = "0.1", features = ["server", "http1", "http2"] }
+http-body-util = "0.1"
 
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["rt"] }
@@ -86,7 +89,7 @@ futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 test-context = "0.1"
-reqwest = "0.11"
+reqwest = "0.12"
 rusk-recovery = { version = "0.6", path = "../rusk-recovery", features = ["state"] }
 ff = { version = "0.13", default-features = false }
 rusk-prover = { version = "0.3", path = "../rusk-prover", features = ["no_random"] }

--- a/rusk/src/lib/chain.rs
+++ b/rusk/src/lib/chain.rs
@@ -19,7 +19,7 @@ use node::network::Kadcast;
 use rusk_abi::dusk::{dusk, Dusk};
 use rusk_abi::VM;
 
-use crate::http::ContractEvent;
+use crate::http::RuesEvent;
 
 pub const MINIMUM_STAKE: Dusk = dusk(1000.0);
 
@@ -36,7 +36,7 @@ pub struct Rusk {
     dir: PathBuf,
     pub(crate) generation_timeout: Option<Duration>,
     pub(crate) feeder_gas_limit: u64,
-    pub(crate) event_sender: broadcast::Sender<ContractEvent>,
+    pub(crate) event_sender: broadcast::Sender<RuesEvent>,
 }
 
 #[derive(Clone)]

--- a/rusk/src/lib/chain/rusk.rs
+++ b/rusk/src/lib/chain/rusk.rs
@@ -30,7 +30,7 @@ use rusk_profile::to_rusk_state_id_path;
 use tokio::sync::broadcast;
 
 use super::{coinbase_value, emission_amount, Rusk, RuskTip};
-use crate::http::ContractEvent;
+use crate::http::RuesEvent;
 use crate::{Error, Result};
 
 pub static DUSK_KEY: LazyLock<StakePublicKey> = LazyLock::new(|| {
@@ -44,7 +44,7 @@ impl Rusk {
         dir: P,
         generation_timeout: Option<Duration>,
         feeder_gas_limit: u64,
-        event_sender: broadcast::Sender<ContractEvent>,
+        event_sender: broadcast::Sender<RuesEvent>,
     ) -> Result<Self> {
         let dir = dir.as_ref();
         let commit_id_path = to_rusk_state_id_path(dir);

--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -562,15 +562,6 @@ async fn handle_stream_rues<H: HandleRequest>(
                 // If the event is subscribed, we send it to the client.
                 if is_subscribed {
                     let event = event.to_bytes();
-                    //let event = match serde_json::to_string(&event) {
-                    //    Ok(event) => event,
-                    //    // If we fail to serialize the event, we log the error
-                    //    // and continue processing further.
-                    //    Err(err) => {
-                    //        warn!("Failed serializing event: {err}");
-                    //        continue;
-                    //    }
-                    //};
 
                     // If the event fails sending we close the socket on the client
                     // and stop processing further.

--- a/rusk/src/lib/http/event.rs
+++ b/rusk/src/lib/http/event.rs
@@ -8,9 +8,16 @@ use super::RUSK_VERSION_HEADER;
 
 use base64::engine::{general_purpose::STANDARD as BASE64, Engine};
 use bytecheck::CheckBytes;
-use futures_util::{stream, StreamExt};
+use futures_util::stream::Iter as StreamIter;
+use futures_util::{stream, Stream, StreamExt};
+use http_body_util::{BodyExt, Either, Full, StreamBody};
+use hyper::body::{Buf, Frame};
 use hyper::header::{InvalidHeaderName, InvalidHeaderValue};
-use hyper::{Body, Request, Response};
+use hyper::{
+    body::{Body, Bytes, Incoming},
+    Request, Response,
+};
+use pin_project::pin_project;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 use rkyv::Archive;
@@ -19,12 +26,13 @@ use semver::{Version, VersionReq};
 use serde::de::{Error, MapAccess, Unexpected, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_with::serde_as;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
+use std::pin::Pin;
 use std::str::FromStr;
 use std::str::Split;
 use std::sync::mpsc;
+use std::task::{Context, Poll};
 use tungstenite::http::HeaderValue;
 
 /// A request sent by the websocket client.
@@ -133,7 +141,7 @@ impl MessageRequest {
     }
 
     pub async fn from_request(
-        req: hyper::Request<Body>,
+        req: Request<Incoming>,
     ) -> anyhow::Result<(Self, bool)> {
         let headers = req
             .headers()
@@ -198,11 +206,11 @@ impl MessageResponse {
     pub fn into_http(
         self,
         is_binary: bool,
-    ) -> anyhow::Result<hyper::Response<Body>> {
+    ) -> anyhow::Result<Response<FullOrStreamBody>> {
         if let Some(error) = &self.error {
             return Ok(hyper::Response::builder()
                 .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Body::from(error.to_string()))?);
+                .body(Full::new(error.to_string().into()).into())?);
         }
 
         let mut headers = HashMap::new();
@@ -214,30 +222,29 @@ impl MessageResponse {
                         true => wrapper.inner,
                         false => hex::encode(wrapper.inner).as_bytes().to_vec(),
                     };
-                    Body::from(data)
+                    Full::from(Bytes::from(data)).into()
                 }
-                DataType::Text(text) => Body::from(text),
+                DataType::Text(text) => Full::from(Bytes::from(text)).into(),
                 DataType::Json(value) => {
                     headers.insert(CONTENT_TYPE, CONTENT_TYPE_JSON.clone());
-                    Body::from(value.to_string())
+                    Full::from(Bytes::from(value.to_string())).into()
                 }
-                DataType::Channel(channel) => {
-                    Body::wrap_stream(stream::iter(channel).map(move |e| {
-                        match is_binary {
-                            true => Ok::<_, anyhow::Error>(e),
-                            false => Ok::<_, anyhow::Error>(
-                                hex::encode(e).as_bytes().to_vec(),
-                            ),
-                        }
-                    }))
-                }
-                DataType::None => Body::empty(),
+                DataType::Channel(receiver) => FullOrStreamBody {
+                    either: Either::Right(StreamBody::new(
+                        BinaryOrTextStream {
+                            is_binary,
+                            stream: stream::iter(receiver),
+                        },
+                    )),
+                },
+                DataType::None => Full::new(Bytes::new()).into(),
             }
         };
-        let mut response = hyper::Response::new(body);
+        let mut response = Response::new(body);
         for (k, v) in headers {
             response.headers_mut().insert(k, v);
         }
+
         Ok(response)
     }
 
@@ -253,6 +260,61 @@ impl MessageResponse {
         } else {
             self.headers.insert(key.into(), value);
         }
+    }
+}
+
+#[pin_project]
+pub struct FullOrStreamBody {
+    #[pin]
+    either: Either<Full<Bytes>, StreamBody<BinaryOrTextStream>>,
+}
+
+impl From<Full<Bytes>> for FullOrStreamBody {
+    fn from(body: Full<Bytes>) -> Self {
+        Self {
+            either: Either::Left(body),
+        }
+    }
+}
+
+impl Body for FullOrStreamBody {
+    type Data =
+        <Either<Full<Bytes>, StreamBody<BinaryOrTextStream>> as Body>::Data;
+    type Error =
+        <Either<Full<Bytes>, StreamBody<BinaryOrTextStream>> as Body>::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.project();
+        this.either.poll_frame(cx)
+    }
+}
+
+#[pin_project]
+pub struct BinaryOrTextStream {
+    is_binary: bool,
+    #[pin]
+    stream: StreamIter<<mpsc::Receiver<Vec<u8>> as IntoIterator>::IntoIter>,
+}
+
+impl Stream for BinaryOrTextStream {
+    type Item = anyhow::Result<Frame<Bytes>>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        this.stream.poll_next(cx).map(|next| {
+            next.map(|x| match this.is_binary {
+                true => Ok(Frame::data(Bytes::from(x))),
+                false => Ok(Frame::data(Bytes::from(
+                    hex::encode(x).as_bytes().to_vec(),
+                ))),
+            })
+        })
     }
 }
 
@@ -378,7 +440,7 @@ impl Event {
         })
     }
     pub async fn from_request(
-        req: hyper::Request<Body>,
+        req: Request<Incoming>,
     ) -> anyhow::Result<(Self, bool)> {
         let (parts, req_body) = req.into_parts();
         // HTTP REQUEST
@@ -391,7 +453,7 @@ impl Event {
 
         let target = parts.uri.path().try_into()?;
 
-        let body = hyper::body::to_bytes(req_body).await?;
+        let body = req_body.collect().await?.to_bytes();
 
         let mut event = match binary_request {
             true => Event::parse(&body)
@@ -671,7 +733,7 @@ impl RuesSubscription {
 }
 
 /// A contract event that is sent to a websocket client.
-#[serde_as]
+#[serde_with::serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ContractEvent {
     pub target: WrappedContractId,

--- a/rusk/src/lib/http/stream.rs
+++ b/rusk/src/lib/http/stream.rs
@@ -13,7 +13,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use hyper::body::HttpBody;
+use hyper::body::Body;
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use tokio::io::{self, AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};


### PR DESCRIPTION
Allows for the client to dispatch events, and receive "response" events on the connected websocket according to the [RUES specification](https://github.com/dusk-network/rusk/wiki/RUES-(Rusk-Universal-Event-System)). This effectively means the RUES API is, with this PR, just as powerful as the previous API.