### PR TITLE
explorer: Failed query notices don't disappear

### DIFF
--- a/explorer/src/lib/components/navbar/Navbar.svelte
+++ b/explorer/src/lib/components/navbar/Navbar.svelte
@@ -58,6 +58,7 @@
 
   afterNavigate(() => {
     hidden = true;
+    showSearchNotification = false;
   });
 </script>
 


### PR DESCRIPTION
Resolves #1716