### PR TITLE
Reintroduce timestamp checks

### DIFF
--- a/consensus/src/commons.rs
+++ b/consensus/src/commons.rs
@@ -34,6 +34,7 @@ pub struct RoundUpdate {
     seed: Seed,
     hash: [u8; 32],
     cert: Certificate,
+    timestamp: u64,
 
     pub base_timeouts: TimeoutSet,
 }
@@ -53,6 +54,7 @@ impl RoundUpdate {
             cert: mrb_header.cert,
             hash: mrb_header.hash,
             seed: mrb_header.seed,
+            timestamp: mrb_header.timestamp,
             base_timeouts,
         }
     }
@@ -67,6 +69,10 @@ impl RoundUpdate {
 
     pub fn cert(&self) -> &Certificate {
         &self.cert
+    }
+
+    pub fn timestamp(&self) -> u64 {
+        self.timestamp
     }
 }
 
@@ -100,6 +106,7 @@ pub enum ConsensusError {
     InvalidQuorumType,
     InvalidVote(Vote),
     InvalidMsgIteration(u8),
+    InvalidTimestamp,
     FutureEvent,
     PastEvent,
     NotCommitteeMember,

--- a/node/src/chain/header_validation.rs
+++ b/node/src/chain/header_validation.rs
@@ -8,6 +8,7 @@ use crate::database;
 use crate::database::Ledger;
 use anyhow::anyhow;
 use dusk_bytes::Serializable;
+use dusk_consensus::commons::get_current_timestamp;
 use dusk_consensus::quorum::verifiers;
 use dusk_consensus::quorum::verifiers::QuorumResult;
 use dusk_consensus::user::committee::CommitteeSet;
@@ -95,6 +96,14 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
 
         if candidate_block.prev_block_hash != self.prev_header.hash {
             return Err(anyhow!("invalid previous block hash"));
+        }
+
+        if candidate_block.timestamp > get_current_timestamp() {
+            return Err(anyhow!("invalid future timestamp"));
+        }
+
+        if candidate_block.timestamp < self.prev_header.timestamp {
+            return Err(anyhow!("invalid timestamp"));
         }
 
         // Ensure block is not already in the ledger

--- a/node/src/chain/header_validation.rs
+++ b/node/src/chain/header_validation.rs
@@ -80,31 +80,31 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
         candidate_block: &'a ledger::Header,
     ) -> anyhow::Result<()> {
         if candidate_block.version > 0 {
-            return Err(anyhow!("unsupported block version"));
+            anyhow::bail!("unsupported block version");
         }
 
         if candidate_block.hash == [0u8; 32] {
-            return Err(anyhow!("empty block hash"));
+            anyhow::bail!("empty block hash");
         }
 
         if candidate_block.height != self.prev_header.height + 1 {
-            return Err(anyhow!(
+            anyhow::bail!(
                 "invalid block height block_height: {:?}, curr_height: {:?}",
                 candidate_block.height,
                 self.prev_header.height,
-            ));
+            );
         }
 
         if candidate_block.prev_block_hash != self.prev_header.hash {
-            return Err(anyhow!("invalid previous block hash"));
+            anyhow::bail!("invalid previous block hash");
         }
 
         if candidate_block.timestamp > get_current_timestamp() {
-            return Err(anyhow!("invalid future timestamp"));
+            anyhow::bail!("invalid future timestamp");
         }
 
         if candidate_block.timestamp < self.prev_header.timestamp {
-            return Err(anyhow!("invalid timestamp"));
+            anyhow::bail!("invalid timestamp");
         }
 
         if candidate_block.iteration < RELAX_ITERATION_THRESHOLD {
@@ -123,7 +123,7 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
         // Ensure block is not already in the ledger
         self.db.read().await.view(|v| {
             if Ledger::get_block_exists(&v, &candidate_block.hash)? {
-                return Err(anyhow!("block already exists"));
+                anyhow::bail!("block already exists");
             }
 
             Ok(())


### PR DESCRIPTION
Added the following checks:
- Timestamp of block with height=`H` must be greater or equal to timestamp of block with height=`H-1`
- Timestamp of any block must be lower or equal than current OS timestamp
- Timestamp of block with height=`H` generated at iteration=`I` must be lower or equal to the timestamp of block with height=`H-1` plus `I*MAX_ITER_TIMEOUT` [^1]


See also #1649
See also dusk-network/dips#13

------------------------------------------------
EDIT: This PR has to be repurposed to address #1494 

[^1]: This check is enforced only if the iteration `I` is not relaxed -> `I` < `RELAX_ITERATION_THRESHOLD`