### PR TITLE
transfer: add bridge function

### DIFF
--- a/contracts/transfer-types/Cargo.toml
+++ b/contracts/transfer-types/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 dusk-bls12_381 = { version = "0.13", default-features = false, features = ["rkyv-impl"] }
+bls12_381-bls = { version = "0.2", default-features = false, features = ["rkyv-impl"] }
 dusk-jubjub = { version = "0.14", default-features = false, features = ["rkyv-impl"] }
 dusk-poseidon = { version = "0.33", default-features = false, features = ["rkyv-impl", "alloc"] }
 phoenix-core = { version = "0.26", default-features = false, features = ["rkyv-impl", "alloc"] }

--- a/contracts/transfer-types/src/lib.rs
+++ b/contracts/transfer-types/src/lib.rs
@@ -14,6 +14,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use dusk_bls12_381::BlsScalar;
+use bls12_381_bls::PublicKey;
 
 use bytecheck::CheckBytes;
 use phoenix_core::{Note, StealthAddress};
@@ -89,4 +90,26 @@ pub struct Mint {
     pub value: u64,
     /// A nonce to prevent replay.
     pub nonce: BlsScalar,
+}
+
+/// Locked staked amount for the bridge.
+#[derive(Debug, Clone, Archive, Deserialize, Serialize)]
+#[archive_attr(derive(CheckBytes))]
+pub struct Bridge {
+    /// Address of the sequencer that performed the bridge operation.
+    pub sequencer: PublicKey,
+    /// Benefitiary of the bridge operation.
+    pub receiver: PublicKey,
+    /// Block number of the operation.
+    pub block: u64,
+    /// Fee paid to the sequencer.
+    pub fee: u64,
+    /// Value to be minted for the receiver.
+    pub value: u64,
+    /// Block number that contains the event.
+    pub event_block: u64,
+    /// Bridge event on L1.
+    pub event: Vec<u8>,
+    /// Proof of validity of the sequencer authorship.
+    pub proof: Vec<u8>,
 }

--- a/contracts/transfer/Cargo.toml
+++ b/contracts/transfer/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 dusk-bls12_381 = { version = "0.13", default-features = false, features = ["rkyv-impl"] }
+bls12_381-bls = { version = "0.2", default-features = false, features = ["rkyv-impl"] }
 dusk-bytes = "0.1"
 dusk-jubjub = { version = "0.14", default-features = false, features = ["rkyv-impl"] }
 jubjub-schnorr = { version = "0.2", default-features = false, features = ["rkyv-impl"] }


### PR DESCRIPTION
This commit introduces a new bridge functionality to the transfer contract's state. This function enables any sequencer to register as a bridge provider upon staking a balance into the bridge. The authorized sequencer can then facilitate up to the amount of their stake in bridge operations.

Adopting an optimistic approach, the bridge will process transactions without immediately verifying L1 associated events. However, it will keep track of these events and wait for several blocks before considering a transaction finalized. If a fraud proof is presented, demonstrating that a bridge operation was carried out without a valid L1 event, the responsible sequencer stands to lose all rewards and staked amount. In contrast, the individual who exposed the fraudulent activity will be rewarded with the ill-gotten amount.