### PR TITLE
Insufficient limit when contract charges fee fix

### DIFF
--- a/contracts/charlie/src/state.rs
+++ b/contracts/charlie/src/state.rs
@@ -80,7 +80,7 @@ impl Charlie {
     }
 
     /// calling this method will cause the transaction fee to be
-    /// increased, yet its sets the charge to a value  too small to cover
+    /// increased, yet it sets the charge to a value too small to cover
     /// the actual execution cost, as a result the transaction will fail
     /// and contract balance won't be affected
     pub fn earn_and_fail(&mut self) {

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -270,7 +270,11 @@ impl TransferState {
         charge: u64,
         gas_spent: u64,
         gas_price: u64,
+        gas_limit: u64,
     ) -> u64 {
+        if gas_limit * gas_price < charge {
+            panic!("Gas limit not sufficient")
+        }
         let cost = gas_spent * gas_price;
         if charge > cost {
             let earning = charge * gas_price - cost;
@@ -372,6 +376,7 @@ impl TransferState {
                         charge,
                         gas_spent,
                         fee.gas_price,
+                        fee.gas_limit,
                     ),
                 EconomicMode::Allowance(allowance) if allowance != 0 => self
                     .apply_allowance(


### PR DESCRIPTION
When contract charges a fee, the gas limit (in value) must be equal or greater than the charge.
"in value" means that gas limit in points must be multiplied by the gas price and then compared with the charge.
If it is smaller than the charge, the transaction must fail.

Implements #1837
