### PR TITLE
explorer: Disable "previous" button in blocks when the height is `0`

### DIFF
--- a/explorer/src/lib/components/__tests__/BlockDetails.spec.js
+++ b/explorer/src/lib/components/__tests__/BlockDetails.spec.js
@@ -1,7 +1,10 @@
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render } from "@testing-library/svelte";
+import { setPathIn } from "lamb";
+
 import { gqlBlock } from "$lib/mock-data";
 import { transformBlock } from "$lib/chain-info";
+
 import { BlockDetails } from "../";
 
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
@@ -9,6 +12,16 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   observe: vi.fn(),
   unobserve: vi.fn(),
 }));
+
+/**
+ * @param {HTMLElement} container
+ * @param {"next" | "prev"} which
+ * @returns {HTMLAnchorElement?}
+ */
+const getBlockNavLink = (container, which) =>
+  container.querySelector(
+    `.block-details__list-anchor:nth-of-type(${which === "prev" ? "1" : "2"})`
+  );
 
 describe("Block Details", () => {
   vi.useFakeTimers();
@@ -30,5 +43,43 @@ describe("Block Details", () => {
     const { container } = render(BlockDetails, baseProps);
 
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("should disable the previous block link if the prev block hash is empty or if the current height is `0`", async () => {
+    const { container, rerender } = render(
+      BlockDetails,
+      setPathIn(baseProps, "data.header.prevblockhash", "")
+    );
+
+    expect(getBlockNavLink(container, "prev")).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    );
+
+    rerender(baseProps);
+
+    expect(getBlockNavLink(container, "prev")).toHaveAttribute(
+      "aria-disabled",
+      "false"
+    );
+
+    rerender(setPathIn(baseProps, "data.header.height", 0));
+
+    expect(getBlockNavLink(container, "prev")).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    );
+  });
+
+  it("should disable the next block link if the next block hash is empty", () => {
+    const { container } = render(
+      BlockDetails,
+      setPathIn(baseProps, "data.header.nextblockhash", "")
+    );
+
+    expect(getBlockNavLink(container, "next")).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    );
   });
 });

--- a/explorer/src/lib/components/block-details/BlockDetails.svelte
+++ b/explorer/src/lib/components/block-details/BlockDetails.svelte
@@ -89,7 +89,7 @@
           className="block-details__list-anchor"
           href="/blocks/block?id={data.header.prevblockhash}"
           icon={{ path: mdiArrowLeft }}
-          disabled={!data.header.prevblockhash}
+          disabled={!data.header.prevblockhash || data.header.height === 0}
         />
         {formatter(data.header.height)}
         <AppAnchorButton


### PR DESCRIPTION
Resolves #1817