### PR TITLE
execution-core: Add `tx` module to `execution-core`

### DIFF
--- a/execution-core/Cargo.toml
+++ b/execution-core/Cargo.toml
@@ -30,3 +30,4 @@ rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
 bytecheck = { version = "0.6", default-features = false }
 poseidon-merkle = { version = "0.5", features = ["rkyv-impl"] }
 piecrust-uplink = { version = "0.12" }
+blake2b_simd = { version = "1", default-features = false }

--- a/execution-core/Cargo.toml
+++ b/execution-core/Cargo.toml
@@ -4,12 +4,29 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dusk-bls12_381 = { version = "0.13", default-features = false, features = ["rkyv-impl"] }
-dusk-jubjub = { version = "0.14", default-features = false, features = ["rkyv-impl"] }
-dusk-poseidon = { version = "0.33", default-features = false, features = ["rkyv-impl", "alloc"] }
-bls12_381-bls = { version = "0.2", default-features = false, features = ["rkyv-impl"] }
-jubjub-schnorr = { version = "0.2", default-features = false, features = ["rkyv-impl"] }
-phoenix-core = { version = "0.26", default-features = false, features = ["rkyv-impl", "alloc"] }
+dusk-bls12_381 = { version = "0.13", default-features = false, features = [
+    "rkyv-impl",
+] }
+dusk-jubjub = { version = "0.14", default-features = false, features = [
+    "rkyv-impl",
+] }
+dusk-poseidon = { version = "0.33", default-features = false, features = [
+    "rkyv-impl",
+    "alloc",
+] }
+bls12_381-bls = { version = "0.2", default-features = false, features = [
+    "rkyv-impl",
+] }
+jubjub-schnorr = { version = "0.2", default-features = false, features = [
+    "rkyv-impl",
+    "double",
+] }
+phoenix-core = { version = "0.26", default-features = false, features = [
+    "rkyv-impl",
+    "alloc",
+] }
 dusk-bytes = "0.1"
-rkyv = { version = "0.7", default-features = false,  features = ["size_32"] }
+rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
 bytecheck = { version = "0.6", default-features = false }
+poseidon-merkle = { version = "0.5", features = ["rkyv-impl"] }
+piecrust-uplink = { version = "0.12" }

--- a/execution-core/src/hash.rs
+++ b/execution-core/src/hash.rs
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Hashing utilities.
+
+use blake2b_simd::{Params, State};
+use dusk_bls12_381::BlsScalar;
+use dusk_bytes::Serializable;
+
+/// Hashes scalars and arbitrary slices of bytes using Blake2b-256, returning
+/// a valid [`BlsScalar`].
+///
+/// The hashing cannot be proved inside a circuit, if that is desired, use
+/// `poseidon_hash` instead.
+pub struct Hasher {
+    state: State,
+}
+
+impl Default for Hasher {
+    fn default() -> Self {
+        Hasher {
+            state: Params::new().hash_length(BlsScalar::SIZE).to_state(),
+        }
+    }
+}
+
+impl Hasher {
+    /// Create new hasher instance.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Process data, updating the internal state.
+    pub fn update(&mut self, data: impl AsRef<[u8]>) {
+        self.state.update(data.as_ref());
+    }
+
+    /// Process input data in a chained manner.
+    pub fn chain_update(self, data: impl AsRef<[u8]>) -> Self {
+        let mut hasher = self;
+        hasher.state.update(data.as_ref());
+        hasher
+    }
+
+    /// Get the output of the hasher.
+    pub fn output(self) -> [u8; BlsScalar::SIZE] {
+        let hasher = self;
+        let mut buf = [0u8; BlsScalar::SIZE];
+        buf.copy_from_slice(hasher.state.finalize().as_ref());
+
+        // This is a workaround for the fact that `Blake2b` does not support
+        // bitlengths that are not a multiple of 8.
+        // We're going to zero out the last nibble of the hash to ensure
+        // that the result can fit in a `BlsScalar`.
+        buf[BlsScalar::SIZE - 1] &= 0xf;
+
+        buf
+    }
+
+    /// Retrieve result and consume hasher instance.
+    pub fn finalize(self) -> BlsScalar {
+        BlsScalar::from_bytes(&self.output()).expect(
+            "Conversion to BlsScalar should never fail after truncation",
+        )
+    }
+
+    /// Compute hash of arbitrary data into a valid [`BlsScalar`].
+    pub fn digest(data: impl AsRef<[u8]>) -> BlsScalar {
+        let mut hasher = Hasher::new();
+        hasher.update(data.as_ref());
+        hasher.finalize()
+    }
+}

--- a/execution-core/src/lib.rs
+++ b/execution-core/src/lib.rs
@@ -10,11 +10,14 @@
 #![deny(missing_docs)]
 #![deny(clippy::pedantic)]
 
+extern crate alloc;
+
 /// Block height type alias
 pub type BlockHeight = u64;
 
 pub mod stake;
 pub mod transfer;
+pub mod tx;
 
 // elliptic curve types
 pub use dusk_bls12_381::BlsScalar;

--- a/execution-core/src/lib.rs
+++ b/execution-core/src/lib.rs
@@ -8,7 +8,7 @@
 
 #![no_std]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
+#![deny(clippy::must_use_unit)]
 
 extern crate alloc;
 

--- a/execution-core/src/lib.rs
+++ b/execution-core/src/lib.rs
@@ -15,6 +15,7 @@ extern crate alloc;
 /// Block height type alias
 pub type BlockHeight = u64;
 
+pub mod hash;
 pub mod stake;
 pub mod transfer;
 pub mod tx;

--- a/execution-core/src/tx.rs
+++ b/execution-core/src/tx.rs
@@ -1,0 +1,183 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Types used by the wallets and the circuit to represent transations
+//! before proving. This will be used by the wallets and other users
+//! who wish to sign transations offline
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use dusk_bytes::{DeserializableSlice, Error as BytesError};
+use jubjub_schnorr::SignatureDouble;
+use piecrust_uplink::{ContractId, CONTRACT_ID_BYTES};
+use poseidon_merkle::Opening as PoseidonOpening;
+
+use super::*;
+
+/// Constant depth of the merkle tree that provides the opening proofs.
+pub const POSEIDON_TREE_DEPTH: usize = 17;
+
+/// An input to a transaction that is yet to be proven.
+#[derive(Debug, Clone)]
+#[allow(unused)]
+pub struct UnprovenTransactionInput {
+    nullifier: BlsScalar,
+    opening: PoseidonOpening<(), POSEIDON_TREE_DEPTH, 4>,
+    note: Note,
+    value: u64,
+    blinder: JubJubScalar,
+    npk_prime: JubJubExtended,
+    sig: SignatureDouble,
+}
+
+/// A transaction that is yet to be proven. The purpose of this is solely to
+/// send to the node to perform a circuit proof.
+/// The fields are made public to avoid clippy warnings and constructors which
+/// require rng and hashing crates
+#[derive(Debug, Clone)]
+#[allow(unused)]
+pub struct UnprovenTransaction {
+    inputs: Vec<UnprovenTransactionInput>,
+    outputs: Vec<(Note, u64, JubJubScalar)>,
+    anchor: BlsScalar,
+    fee: Fee,
+    crossover: Option<(Crossover, u64, JubJubScalar)>,
+    call: Option<(ContractId, String, Vec<u8>)>,
+}
+
+impl UnprovenTransaction {
+    /// Deserialize the transaction from a bytes buffer.
+    pub fn from_slice(buf: &[u8]) -> Result<Self, BytesError> {
+        let mut buffer = buf;
+
+        let num_inputs = u64::from_reader(&mut buffer)?;
+        let mut inputs = Vec::with_capacity(num_inputs as usize);
+        for _ in 0..num_inputs {
+            let size = u64::from_reader(&mut buffer)? as usize;
+            inputs.push(UnprovenTransactionInput::from_slice(&buffer[..size])?);
+            buffer = &buffer[size..];
+        }
+
+        let num_outputs = u64::from_reader(&mut buffer)?;
+        let mut outputs = Vec::with_capacity(num_outputs as usize);
+        for _ in 0..num_outputs {
+            let note = Note::from_reader(&mut buffer)?;
+            let value = u64::from_reader(&mut buffer)?;
+            let blinder = JubJubScalar::from_reader(&mut buffer)?;
+
+            outputs.push((note, value, blinder));
+        }
+
+        let anchor = BlsScalar::from_reader(&mut buffer)?;
+        let fee = Fee::from_reader(&mut buffer)?;
+
+        let crossover = read_crossover_value_blinder(&mut buffer)?;
+
+        let call = read_optional_call(&mut buffer)?;
+
+        Ok(Self {
+            inputs,
+            outputs,
+            anchor,
+            fee,
+            crossover,
+            call,
+        })
+    }
+}
+
+impl UnprovenTransactionInput {
+    /// Deserializes the the input from bytes.
+    pub fn from_slice(buf: &[u8]) -> Result<Self, BytesError> {
+        let mut bytes = buf;
+
+        let nullifier = BlsScalar::from_reader(&mut bytes)?;
+        let note = Note::from_reader(&mut bytes)?;
+        let value = u64::from_reader(&mut bytes)?;
+        let blinder = JubJubScalar::from_reader(&mut bytes)?;
+        let npk_prime =
+            JubJubExtended::from(JubJubAffine::from_reader(&mut bytes)?);
+        let sig = SignatureDouble::from_reader(&mut bytes)?;
+
+        // `to_vec` is required here otherwise `rkyv` will throw an alignment
+        // error
+        #[allow(clippy::unnecessary_to_owned)]
+        let opening = rkyv::from_bytes(&bytes.to_vec())
+            .map_err(|_| BytesError::InvalidData)?;
+
+        Ok(Self {
+            note,
+            value,
+            blinder,
+            sig,
+            nullifier,
+            opening,
+            npk_prime,
+        })
+    }
+}
+
+/// Reads an optional crossover from the given buffer.
+fn read_crossover_value_blinder(
+    buffer: &mut &[u8],
+) -> Result<Option<(Crossover, u64, JubJubScalar)>, BytesError> {
+    let ser = match u64::from_reader(buffer)? {
+        0 => None,
+        _ => {
+            let crossover = Crossover::from_reader(buffer)?;
+            let value = u64::from_reader(buffer)?;
+            let blinder = JubJubScalar::from_reader(buffer)?;
+            Some((crossover, value, blinder))
+        }
+    };
+
+    Ok(ser)
+}
+
+/// Reads an optional call from the given buffer. This should be called at the
+/// end of parsing other fields since it consumes the entirety of the buffer.
+fn read_optional_call(
+    buffer: &mut &[u8],
+) -> Result<Option<(ContractId, String, Vec<u8>)>, BytesError> {
+    let mut call = None;
+
+    if u64::from_reader(buffer)? != 0 {
+        let buf_len = buffer.len();
+
+        // needs to be at least the size of a contract ID and have some call
+        // data.
+        if buf_len < CONTRACT_ID_BYTES {
+            return Err(BytesError::BadLength {
+                found: buf_len,
+                expected: CONTRACT_ID_BYTES,
+            });
+        }
+        let (mid_buffer, mut buffer_left) = {
+            let (buf, left) = buffer.split_at(CONTRACT_ID_BYTES);
+
+            let mut mid_buf = [0u8; CONTRACT_ID_BYTES];
+            mid_buf.copy_from_slice(buf);
+
+            (mid_buf, left)
+        };
+
+        let contract_id = ContractId::from(mid_buffer);
+
+        let buffer = &mut buffer_left;
+
+        let cname_len = u64::from_reader(buffer)?;
+        let (cname_bytes, buffer_left) = buffer.split_at(cname_len as usize);
+
+        let cname = String::from_utf8(cname_bytes.to_vec())
+            .map_err(|_| BytesError::InvalidData)?;
+
+        let call_data = Vec::from(buffer_left);
+        call = Some((contract_id, cname, call_data));
+    }
+
+    Ok(call)
+}

--- a/rusk-prover/Cargo.toml
+++ b/rusk-prover/Cargo.toml
@@ -7,7 +7,6 @@ autobins = false
 
 [dependencies]
 dusk-bytes = { version = "0.1" }
-dusk-wallet-core = { version = "0.25.0-phoenix.0.26", default-features = false }
 
 ## feature local_prover
 once_cell = { version = "1.9", optional = true }

--- a/rusk-prover/src/prover/execute.rs
+++ b/rusk-prover/src/prover/execute.rs
@@ -6,8 +6,7 @@
 
 use super::*;
 use crate::prover::fetch_prover;
-use dusk_wallet_core::UnprovenTransaction;
-use execution_core::transfer::TRANSFER_TREE_DEPTH;
+use execution_core::{transfer::TRANSFER_TREE_DEPTH, tx::UnprovenTransaction};
 use rand::{CryptoRng, RngCore};
 use transfer_circuits::{
     ExecuteCircuitFourTwo, ExecuteCircuitOneTwo, ExecuteCircuitThreeTwo,

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -45,7 +45,6 @@ sha3 = "0.10"
 dusk-plonk = "0.19"
 dusk-bytes = "0.1"
 kadcast = "0.6.0-rc"
-dusk-wallet-core = "0.25.0-phoenix.0.26"
 pin-project = "1"
 tungstenite = "0.21"
 hyper-tungstenite = "0.13"
@@ -62,7 +61,9 @@ async-trait = "0.1"
 execution-core = { version = "0.1.0", path = "../execution-core" }
 transfer-circuits = { version = "0.5", path = "../circuits/transfer" }
 rusk-profile = { version = "0.6", path = "../rusk-profile" }
-rusk-abi = { version = "0.13.0-rc", path = "../rusk-abi", default-features = false, features = ["host"] }
+rusk-abi = { version = "0.13.0-rc", path = "../rusk-abi", default-features = false, features = [
+    "host",
+] }
 rusk-prover = { version = "0.3", path = "../rusk-prover", optional = true }
 
 ## node dependencies
@@ -85,10 +86,15 @@ futures = { version = "0.3", optional = true }
 [dev-dependencies]
 test-context = "0.1"
 reqwest = "0.12"
-rusk-recovery = { version = "0.6", path = "../rusk-recovery", features = ["state"] }
+rusk-recovery = { version = "0.6", path = "../rusk-recovery", features = [
+    "state",
+] }
 ff = { version = "0.13", default-features = false }
-rusk-prover = { version = "0.3", path = "../rusk-prover", features = ["no_random"] }
+rusk-prover = { version = "0.3", path = "../rusk-prover", features = [
+    "no_random",
+] }
 criterion = "0.5"
+dusk-wallet-core = "0.25.0-phoenix.0.26"
 
 [build-dependencies]
 rustc_tools_util = "0.3"

--- a/rusk/src/lib/verifier.rs
+++ b/rusk/src/lib/verifier.rs
@@ -9,7 +9,7 @@
 use crate::error::Error;
 use crate::Result;
 
-use dusk_wallet_core::Transaction;
+use execution_core::Transaction;
 use rusk_profile::Circuit as CircuitProfile;
 use transfer_circuits::CircuitOutput;
 

--- a/rusk/tests/common/state.rs
+++ b/rusk/tests/common/state.rs
@@ -13,8 +13,7 @@ use rusk::{Result, Rusk};
 use rusk_recovery_tools::state::{self, Snapshot};
 
 use dusk_consensus::operations::CallParams;
-use dusk_wallet_core::Transaction as PhoenixTransaction;
-use execution_core::StakePublicKey;
+use execution_core::{StakePublicKey, Transaction as PhoenixTransaction};
 use node_data::{
     bls::PublicKeyBytes,
     ledger::{Block, Certificate, Header, IterationsInfo, SpentTransaction},


### PR DESCRIPTION
Closes #1853

Move `UnprovenTransaction` to `execution-core`
Move `dusk-wallet-core` to dev dependency

This adds some duplicate constants to avoid dependency loop with `rusk-abi` but Ideally those should be removed from `rusk-abi` and put in `execution-core` 

The `dusk-wallet-core` should also use it via `execution-core` as dependency 

opened issue https://github.com/dusk-network/rusk/issues/1859 to remove those duplicates

