### PR TITLE
node: fix `verify_failed_iterations`

### DIFF
--- a/node/src/chain/header_validation.rs
+++ b/node/src/chain/header_validation.rs
@@ -185,7 +185,7 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
         Ok(())
     }
 
-    /// Return true if there is a attestation for each failed iteration, and if
+    /// Return true if there is an attestation for each failed iteration, and if
     /// that attestation has a quorum in the ratification phase.
     ///
     /// If there are no failed iterations, it returns true
@@ -193,8 +193,10 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
         &self,
         candidate_block: &'a ledger::Header,
     ) -> anyhow::Result<bool> {
-        // Verify Failed iterations
-        let mut all_failed = true;
+        // Iteration is 0 based. Eg: having a candidate with iter=2 means we
+        // should expect 2 failed attestation for iter=0 and iter=1
+        let expected_failed_atts = candidate_block.iteration;
+        let mut actual_failed_atts = 0u8;
 
         for (iter, att) in candidate_block
             .failed_iterations
@@ -217,7 +219,7 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
 
                 anyhow::ensure!(pk == &expected_pk, "Invalid generator. Expected {expected_pk:?}, actual {pk:?}");
 
-                let quorums = verify_block_att(
+                let (_, rat_quorum) = verify_block_att(
                     self.prev_header.hash,
                     self.prev_header.seed,
                     self.provisioners.current(),
@@ -227,14 +229,13 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
                 )
                 .await?;
 
-                // Ratification quorum is enough to consider the iteration
-                // failed
-                all_failed = all_failed && quorums.1.quorum_reached();
-            } else {
-                all_failed = false;
+                if rat_quorum.quorum_reached() {
+                    actual_failed_atts += 1;
+                }
             }
         }
 
+        let all_failed = actual_failed_atts == expected_failed_atts;
         Ok(all_failed)
     }
 


### PR DESCRIPTION
Ensure the function returns true if all failed iterations (according to the candidate block iteration) have a quorum. 
Fixed a bug where the function incorrectly returned true if no failed attestations were added to the list and the candidate iteration was non-zero.

Resolves #1871