### PR TITLE
Small `execution-core` cleanup

### DIFF
--- a/contracts/stake/tests/common/utils.rs
+++ b/contracts/stake/tests/common/utils.rs
@@ -345,9 +345,9 @@ pub fn create_transaction<const I: usize>(
             .expect("The input notes should be the correct ammount"),
         tx_output_notes,
         payload_hash,
-        tx_payload.tx_skeleton().root,
-        tx_payload.tx_skeleton().deposit,
-        tx_payload.tx_skeleton().max_fee,
+        tx_payload.tx_skeleton.root,
+        tx_payload.tx_skeleton.deposit,
+        tx_payload.tx_skeleton.max_fee,
         sender_pk,
         (sig_a, sig_b),
         [transfer_sender_blinder, change_sender_blinder],
@@ -360,5 +360,5 @@ pub fn create_transaction<const I: usize>(
         .expect("creating a proof should succeed");
 
     // build the transaction from the payload and proof
-    Transaction::new(tx_payload, proof.to_bytes().into())
+    Transaction::new(tx_payload, proof.to_bytes())
 }

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -164,7 +164,7 @@ impl TransferState {
         &mut self,
         tx: Transaction,
     ) -> Result<Vec<u8>, ContractError> {
-        let tx_skeleton = tx.payload().tx_skeleton();
+        let tx_skeleton = &tx.payload().tx_skeleton;
 
         // panic if the root is invalid
         if !self.root_exists(&tx_skeleton.root) {
@@ -190,8 +190,8 @@ impl TransferState {
             .extend_notes(block_height, tx_skeleton.outputs.clone());
 
         // if present, place the contract deposit on the state
-        if tx.payload().tx_skeleton().deposit > 0 {
-            let contract = match tx.payload().contract_call() {
+        if tx.payload().tx_skeleton.deposit > 0 {
+            let contract = match &tx.payload().contract_call {
                 Some(call) => ContractId::from_bytes(call.contract),
                 None => {
                     panic!("There needs to be a contract call when depositing funds");
@@ -202,7 +202,7 @@ impl TransferState {
 
         // perform contract call if present
         let mut result = Ok(Vec::new());
-        if let Some(call) = tx.payload().contract_call() {
+        if let Some(call) = &tx.payload().contract_call {
             result = rusk_abi::call_raw(
                 ContractId::from_bytes(call.contract),
                 &call.fn_name,
@@ -368,7 +368,7 @@ fn verify_tx_proof(tx: &Transaction) -> bool {
         .to_vec();
 
     // verify the proof
-    rusk_abi::verify_proof(vd, tx.proof().clone(), pis)
+    rusk_abi::verify_proof(vd, tx.proof().to_vec(), pis)
 }
 
 #[cfg(test)]

--- a/contracts/transfer/tests/common.rs
+++ b/contracts/transfer/tests/common.rs
@@ -137,7 +137,7 @@ pub fn execute(session: &mut Session, tx: Transaction) -> Result<u64, Error> {
         TRANSFER_CONTRACT,
         "spend_and_execute",
         &tx,
-        tx.payload().fee().gas_limit,
+        tx.payload().fee.gas_limit,
     )?;
 
     // Ensure all gas is consumed if there's an error in the contract call
@@ -359,9 +359,9 @@ pub fn create_transaction<const I: usize>(
             .expect("The input notes should be the correct ammount"),
         tx_output_notes,
         payload_hash,
-        tx_payload.tx_skeleton().root,
-        tx_payload.tx_skeleton().deposit,
-        tx_payload.tx_skeleton().max_fee,
+        tx_payload.tx_skeleton.root,
+        tx_payload.tx_skeleton.deposit,
+        tx_payload.tx_skeleton.max_fee,
         sender_pk,
         (sig_a, sig_b),
         [transfer_sender_blinder, change_sender_blinder],
@@ -374,5 +374,5 @@ pub fn create_transaction<const I: usize>(
         .expect("creating a proof should succeed");
 
     // build the transaction from the payload and proof
-    Transaction::new(tx_payload, proof.to_bytes().into())
+    Transaction::new(tx_payload, proof.to_bytes())
 }

--- a/contracts/transfer/tests/transfer.rs
+++ b/contracts/transfer/tests/transfer.rs
@@ -313,7 +313,7 @@ fn deposit_and_withdraw() {
         transfer_value
             + tx.payload().tx_skeleton.deposit
             + tx.payload().tx_skeleton.max_fee
-            + tx.payload().tx_skeleton().outputs[1]
+            + tx.payload().tx_skeleton.outputs[1]
                 .value(Some(&ViewKey::from(&sender_sk)))
                 .unwrap()
     );

--- a/execution-core/src/transfer.rs
+++ b/execution-core/src/transfer.rs
@@ -173,12 +173,14 @@ impl ContractCall {
 #[derive(Debug, Clone, Copy, Archive, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]
 pub struct Fee {
-    /// The gas limit set for the fee
+    /// Gas limit set for a phoenix transaction
     pub gas_limit: u64,
-    /// the gas price set for the fee
+    /// Gas price set for a phoenix transaction
     pub gas_price: u64,
-    pub(crate) stealth_address: StealthAddress,
-    pub(crate) sender: Sender,
+    /// Address to send the remainder note
+    pub stealth_address: StealthAddress,
+    /// Sender to use for the remainder
+    pub sender: Sender,
 }
 
 impl PartialEq for Fee {
@@ -199,6 +201,7 @@ impl Fee {
         gas_price: u64,
     ) -> Self {
         let r = JubJubScalar::random(&mut *rng);
+
         let sender_blinder = [
             JubJubScalar::random(&mut *rng),
             JubJubScalar::random(&mut *rng),
@@ -228,18 +231,6 @@ impl Fee {
         }
     }
 
-    /// Return the [`StealthAddress`] to which return the unspend fee to.
-    #[must_use]
-    pub fn stealth_address(&self) -> &StealthAddress {
-        &self.stealth_address
-    }
-
-    /// Return the [`Sender`] of the unspend fee note.
-    #[must_use]
-    pub fn sender(&self) -> &Sender {
-        &self.sender
-    }
-
     /// Calculate the max-fee.
     #[must_use]
     pub fn max_fee(&self) -> u64 {
@@ -249,7 +240,7 @@ impl Fee {
     /// Return a hash represented by `H(gas_limit, gas_price, H([note_pk]))`
     #[must_use]
     pub fn hash(&self) -> BlsScalar {
-        let npk = self.stealth_address().note_pk().as_ref().to_hash_inputs();
+        let npk = self.stealth_address.note_pk().as_ref().to_hash_inputs();
 
         let hash_inputs = [
             BlsScalar::from(self.gas_limit),

--- a/execution-core/tests/serialization.rs
+++ b/execution-core/tests/serialization.rs
@@ -71,7 +71,11 @@ fn transaction_from_to_bytes() -> Result<(), Error> {
     };
 
     // build the payload
-    let payload = Payload::new(tx_skeleton, fee, Some(call));
+    let payload = Payload {
+        tx_skeleton,
+        fee,
+        contract_call: Some(call),
+    };
 
     // set a random proof
     let proof = [42; 42].to_vec();

--- a/node-data/src/ledger/transaction.rs
+++ b/node-data/src/ledger/transaction.rs
@@ -60,13 +60,13 @@ impl Transaction {
     }
 
     pub fn gas_price(&self) -> u64 {
-        self.inner.payload().fee().gas_price
+        self.inner.payload().fee.gas_price
     }
     pub fn to_nullifiers(&self) -> Vec<[u8; 32]> {
         self.inner
             .payload()
-            .tx_skeleton()
-            .nullifiers()
+            .tx_skeleton
+            .nullifiers
             .iter()
             .map(|n| n.to_bytes())
             .collect()
@@ -150,7 +150,11 @@ pub mod faker {
         let contract_call =
             ContractCall::new([21; 32], "some_method", &()).unwrap();
 
-        let payload = Payload::new(tx_skeleton, fee, Some(contract_call));
+        let payload = Payload {
+            tx_skeleton,
+            fee,
+            contract_call: Some(contract_call),
+        };
         let proof = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
         PhoenixTransaction::new(payload, proof).into()

--- a/node/src/database/rocksdb.rs
+++ b/node/src/database/rocksdb.rs
@@ -586,7 +586,7 @@ impl<'db, DB: DBAccess> Mempool for DBTransaction<'db, DB> {
 
         // Add Secondary indexes //
         // Nullifiers
-        for n in tx.inner.payload().tx_skeleton().nullifiers().iter() {
+        for n in tx.inner.payload().tx_skeleton.nullifiers.iter() {
             let key = n.to_bytes();
             self.put_cf(self.nullifiers_cf, key, hash)?;
         }
@@ -626,7 +626,7 @@ impl<'db, DB: DBAccess> Mempool for DBTransaction<'db, DB> {
 
             // Delete Secondary indexes
             // Delete Nullifiers
-            for n in tx.inner.payload().tx_skeleton().nullifiers().iter() {
+            for n in tx.inner.payload().tx_skeleton.nullifiers.iter() {
                 let key = n.to_bytes();
                 self.inner.delete_cf(self.nullifiers_cf, key)?;
             }

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -147,8 +147,8 @@ impl MempoolSrv {
             let nullifiers: Vec<_> = tx
                 .inner
                 .payload()
-                .tx_skeleton()
-                .nullifiers()
+                .tx_skeleton
+                .nullifiers
                 .iter()
                 .map(|nullifier| nullifier.to_bytes())
                 .collect();
@@ -156,8 +156,8 @@ impl MempoolSrv {
             // ensure nullifiers do not exist in the mempool
             for m_tx_id in view.get_txs_by_nullifiers(&nullifiers) {
                 if let Some(m_tx) = view.get_tx(m_tx_id)? {
-                    if m_tx.inner.payload().fee().gas_price
-                        < tx.inner.payload().fee().gas_price
+                    if m_tx.inner.payload().fee.gas_price
+                        < tx.inner.payload().fee.gas_price
                     {
                         view.delete_tx(m_tx_id)?;
                     } else {

--- a/rusk-prover/src/tx.rs
+++ b/rusk-prover/src/tx.rs
@@ -168,7 +168,7 @@ pub struct UnprovenTransaction {
 impl UnprovenTransaction {
     /// Consumes self and a proof to generate a transaction.
     pub fn gen_transaction(self, proof: Proof) -> Transaction {
-        Transaction::new(self.payload, proof.to_bytes().to_vec())
+        Transaction::new(self.payload, proof.to_bytes())
     }
 
     /// Serialize the transaction to a variable length byte buffer.
@@ -329,7 +329,7 @@ impl UnprovenTransaction {
 
     /// Returns the payload-hash of the transaction.
     pub fn payload_hash(&self) -> BlsScalar {
-        self.payload().hash()
+        self.payload.hash()
     }
 }
 

--- a/rusk/src/lib/chain/rusk.rs
+++ b/rusk/src/lib/chain/rusk.rs
@@ -112,7 +112,7 @@ impl Rusk {
                 }
             }
             let tx_id = hex::encode(unspent_tx.id());
-            if unspent_tx.inner.payload().fee().gas_limit > block_gas_left {
+            if unspent_tx.inner.payload().fee.gas_limit > block_gas_left {
                 info!("Skipping {tx_id} due gas_limit greater than left: {block_gas_left}");
                 continue;
             }

--- a/rusk/src/lib/chain/vm.rs
+++ b/rusk/src/lib/chain/vm.rs
@@ -100,7 +100,7 @@ impl VMExecution for Rusk {
         info!("Received preverify request");
         let tx = &tx.inner;
         let existing_nullifiers = self
-            .existing_nullifiers(&tx.payload().tx_skeleton().nullifiers)
+            .existing_nullifiers(&tx.payload().tx_skeleton.nullifiers)
             .map_err(|e| anyhow::anyhow!("Cannot check nullifiers: {e}"))?;
 
         if !existing_nullifiers.is_empty() {

--- a/rusk/src/lib/http/chain/graphql.rs
+++ b/rusk/src/lib/http/chain/graphql.rs
@@ -83,7 +83,7 @@ impl Query {
                                 t.0.inner
                                     .inner
                                     .payload()
-                                    .contract_call()
+                                    .contract_call
                                     .as_ref()
                                     .map(|c| c.contract)
                                     .unwrap_or(

--- a/rusk/src/lib/http/chain/graphql/data.rs
+++ b/rusk/src/lib/http/chain/graphql/data.rs
@@ -249,24 +249,24 @@ impl Transaction<'_> {
         let mut map = Map::new();
         map.insert(
             "root".into(),
-            json!(hex::encode(tx.payload().tx_skeleton().root.to_bytes())),
+            json!(hex::encode(tx.payload().tx_skeleton.root.to_bytes())),
         );
         let nullifiers: Vec<_> = tx
             .payload()
-            .tx_skeleton()
-            .nullifiers()
+            .tx_skeleton
+            .nullifiers
             .iter()
             .map(|n| hex::encode(n.to_bytes()))
             .collect();
         map.insert("nullifier".into(), json!(nullifiers));
         map.insert(
             "deposit".into(),
-            json!(hex::encode(tx.payload().tx_skeleton().deposit.to_bytes())),
+            json!(hex::encode(tx.payload().tx_skeleton.deposit.to_bytes())),
         );
         let notes: Vec<_> = tx
             .payload()
-            .tx_skeleton()
-            .outputs()
+            .tx_skeleton
+            .outputs
             .iter()
             .map(|n| {
                 let mut map = Map::new();
@@ -301,22 +301,20 @@ impl Transaction<'_> {
         map.insert("notes".into(), json!(notes));
 
         let mut fee = Map::new();
-        fee.insert("gas_limit".into(), json!(tx.payload().fee().gas_limit));
-        fee.insert("gas_price".into(), json!(tx.payload().fee().gas_price));
+        fee.insert("gas_limit".into(), json!(tx.payload().fee.gas_limit));
+        fee.insert("gas_price".into(), json!(tx.payload().fee.gas_price));
         fee.insert(
             "stealth_address".into(),
-            json!(bs58::encode(
-                tx.payload().fee().stealth_address().to_bytes()
-            )
-            .into_string()),
+            json!(bs58::encode(tx.payload().fee.stealth_address.to_bytes())
+                .into_string()),
         );
         fee.insert(
             "sender".into(),
-            json!(hex::encode(tx.payload().fee().sender().to_bytes())),
+            json!(hex::encode(tx.payload().fee.sender.to_bytes())),
         );
         map.insert("fee".into(), json!(fee));
 
-        if let Some(c) = tx.payload().contract_call() {
+        if let Some(c) = &tx.payload().contract_call {
             let mut call = Map::new();
             call.insert("contract".into(), json!(hex::encode(c.contract)));
             call.insert("fn_name".into(), json!(&c.fn_name));
@@ -332,18 +330,18 @@ impl Transaction<'_> {
     }
 
     pub async fn gas_limit(&self) -> u64 {
-        self.0.inner.payload().fee().gas_limit
+        self.0.inner.payload().fee.gas_limit
     }
 
     pub async fn gas_price(&self) -> u64 {
-        self.0.inner.payload().fee().gas_price
+        self.0.inner.payload().fee.gas_price
     }
 
     pub async fn call_data(&self) -> Option<CallData> {
         self.0
             .inner
             .payload()
-            .contract_call()
+            .contract_call
             .as_ref()
             .map(|call| CallData {
                 contract: hex::encode(call.contract),

--- a/rusk/src/lib/verifier.rs
+++ b/rusk/src/lib/verifier.rs
@@ -45,7 +45,7 @@ pub fn verify_proof(tx: &Transaction) -> Result<bool> {
 
     // Maybe we want to handle internal serialization error too, currently
     // they map to `false`.
-    Ok(rusk_abi::verify_proof(vd.to_vec(), tx.proof().clone(), pi))
+    Ok(rusk_abi::verify_proof(vd.to_vec(), tx.proof().to_vec(), pi))
 }
 
 fn fetch_verifier(circuit_name: &str) -> Vec<u8> {

--- a/rusk/tests/services/multi_transfer.rs
+++ b/rusk/tests/services/multi_transfer.rs
@@ -122,14 +122,14 @@ fn wallet_transfer(
         .get_balance(0)
         .expect("Failed to get the balance")
         .value;
-    let fee_0 = txs[0].payload().fee();
+    let fee_0 = txs[0].payload().fee;
     let fee_0 = fee_0.gas_limit * fee_0.gas_price;
 
     let final_balance_1 = wallet
         .get_balance(1)
         .expect("Failed to get the balance")
         .value;
-    let fee_1 = txs[1].payload().fee();
+    let fee_1 = txs[1].payload().fee;
     let fee_1 = fee_1.gas_limit * fee_1.gas_price;
 
     assert!(

--- a/rusk/tests/services/transfer.rs
+++ b/rusk/tests/services/transfer.rs
@@ -117,7 +117,7 @@ fn wallet_transfer(
         .get_balance(0)
         .expect("Failed to get the balance")
         .value;
-    let fee = tx.inner.inner.payload().fee();
+    let fee = tx.inner.inner.payload().fee;
     let fee = gas_spent * fee.gas_price;
 
     assert_eq!(

--- a/test-wallet/src/imp.rs
+++ b/test-wallet/src/imp.rs
@@ -763,7 +763,11 @@ fn new_unproven_tx<Rng: RngCore + CryptoRng, SC: StateClient>(
         deposit,
     };
 
-    let payload = Payload::new(tx_skeleton, fee, call);
+    let payload = Payload {
+        tx_skeleton,
+        fee,
+        contract_call: call,
+    };
     let payload_hash = payload.hash();
 
     let inputs: Vec<UnprovenTransactionInput> = inputs


### PR DESCRIPTION
While working on moonlight, I had the urge to cleanup `execution-core` while working on it and thought it a good idea to make a separate PR.

Some functions are removed/changed, and some fields made public where they were otherwise private. In particular:

Changed:
- Transaction::new now takes a proof as impl Into<Vec<u8>>
- Transaction::proof now returns &[u8]
- Made Fee::stealth_address public
- Made Fee::sender public

Removed:
- Transaction::payload_hash
- Fee::sender
- Fee::stealth_address
- Payload::new
- Payload::tx_skeleton
- Payload::fee
- Payload::contract_call

