### PR TITLE
explorer: Avoid restart market data polling in case of 429 error

### DIFF
--- a/explorer/src/lib/stores/marketDataStore.js
+++ b/explorer/src/lib/stores/marketDataStore.js
@@ -1,4 +1,5 @@
 import { derived, get } from "svelte/store";
+import { getPathIn } from "lamb";
 
 import { createPollingDataStore } from "$lib/dusk/svelte-stores";
 import { duskAPI } from "$lib/services";
@@ -24,6 +25,9 @@ const marketDataStore = derived(
     const isDataChanged = $pollingDataStore.data !== current.data;
     const isErrorChanged = $pollingDataStore.error !== current.error;
     const hasNewData = $pollingDataStore.data && isDataChanged;
+    const isRecoverableError =
+      $pollingDataStore.error &&
+      getPathIn($pollingDataStore, "error.cause.status") !== 429;
 
     set({
       data: $pollingDataStore.data ?? current.data,
@@ -36,7 +40,7 @@ const marketDataStore = derived(
           : null,
     });
 
-    if ($pollingDataStore.error && isErrorChanged) {
+    if (isErrorChanged && isRecoverableError) {
       pollingDataStore.start();
     }
   },


### PR DESCRIPTION
Resolves #1926