### PR TITLE
Rename GetInv to Inv

### DIFF
--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -106,7 +106,7 @@ impl Serializable for Message {
             Payload::Block(p) => p.write(w),
             Payload::Transaction(p) => p.write(w),
             Payload::GetMempool(p) => p.write(w),
-            Payload::GetInv(p) => p.write(w),
+            Payload::Inv(p) => p.write(w),
             Payload::GetBlocks(p) => p.write(w),
             Payload::GetResource(p) => p.write(w),
             Payload::Ratification(p) => p.write(w),
@@ -144,7 +144,7 @@ impl Serializable for Message {
             Topics::GetMempool => {
                 Message::new_get_mempool(payload::GetMempool::read(r)?)
             }
-            Topics::GetInv => Message::new_inv(payload::Inv::read(r)?),
+            Topics::Inv => Message::new_inv(payload::Inv::read(r)?),
             Topics::Unknown => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -210,8 +210,8 @@ impl Message {
     /// Creates topics.Inv (inventory) message
     pub fn new_inv(p: payload::Inv) -> Message {
         Self {
-            topic: Topics::GetInv,
-            payload: Payload::GetInv(p),
+            topic: Topics::Inv,
+            payload: Payload::Inv(p),
             ..Default::default()
         }
     }
@@ -348,7 +348,7 @@ pub enum Payload {
     Block(Box<ledger::Block>),
     Transaction(Box<ledger::Transaction>),
     GetMempool(payload::GetMempool),
-    GetInv(payload::Inv),
+    Inv(payload::Inv),
     GetBlocks(payload::GetBlocks),
     GetResource(payload::GetResource),
 
@@ -1064,7 +1064,7 @@ pub enum Topics {
     GetResource = 8,
     GetBlocks = 9,
     GetMempool = 13, // NB: This is aliased as Mempool in the golang impl
-    GetInv = 14,     // NB: This is aliased as Inv in the golang impl
+    Inv = 14,
 
     // Fire-and-forget messaging
     Tx = 10,
@@ -1099,7 +1099,7 @@ impl From<u8> for Topics {
         map_topic!(v, Topics::Tx);
         map_topic!(v, Topics::Block);
         map_topic!(v, Topics::GetMempool);
-        map_topic!(v, Topics::GetInv);
+        map_topic!(v, Topics::Inv);
         map_topic!(v, Topics::Candidate);
         map_topic!(v, Topics::Validation);
         map_topic!(v, Topics::Ratification);

--- a/node/src/databroker.rs
+++ b/node/src/databroker.rs
@@ -26,7 +26,7 @@ use tracing::{debug, info, warn};
 const TOPICS: &[u8] = &[
     Topics::GetBlocks as u8,
     Topics::GetMempool as u8,
-    Topics::GetInv as u8,
+    Topics::Inv as u8,
     Topics::GetResource as u8,
 ];
 
@@ -203,8 +203,8 @@ impl DataBrokerSrv {
                 let msg = Self::handle_get_mempool(db).await?;
                 Ok(Response::new_from_msg(msg, recv_peer))
             }
-            // Handle GetInv requests
-            Payload::GetInv(m) => {
+            // Handle Inv messages
+            Payload::Inv(m) => {
                 let msg =
                     Self::handle_inv(db, m, conf.max_inv_entries, this_peer)
                         .await?;


### PR DESCRIPTION
As per title, GetInv should be Inv, as it is used to send inventory messages in response to GetBlocks and GetMempool, and not to "request an Inv".