### PR TITLE
Exclude next generator from both ratification and validation com…

### DIFF
--- a/consensus/src/aggregator.rs
+++ b/consensus/src/aggregator.rs
@@ -264,7 +264,7 @@ mod tests {
         }
 
         // Execute sortition with specific config
-        let cfg = Config::raw(Seed::from([4u8; 48]), round, 1, 10, None);
+        let cfg = Config::raw(Seed::from([4u8; 48]), round, 1, 10, vec![]);
         let c = Committee::new(&p, &cfg);
 
         let target_quorum = 7;

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -28,4 +28,4 @@ pub const EMERGENCY_MODE_ITERATION_THRESHOLD: u8 = CONSENSUS_MAX_ITER - 50;
 pub const MIN_STEP_TIMEOUT: Duration = Duration::from_secs(7);
 pub const MAX_STEP_TIMEOUT: Duration = Duration::from_secs(40);
 pub const TIMEOUT_INCREASE: Duration = Duration::from_secs(2);
-pub const MINIMUM_BLOCK_TIME: u64 = 2;
+pub const MINIMUM_BLOCK_TIME: u64 = 10;

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -28,4 +28,4 @@ pub const EMERGENCY_MODE_ITERATION_THRESHOLD: u8 = CONSENSUS_MAX_ITER - 50;
 pub const MIN_STEP_TIMEOUT: Duration = Duration::from_secs(7);
 pub const MAX_STEP_TIMEOUT: Duration = Duration::from_secs(40);
 pub const TIMEOUT_INCREASE: Duration = Duration::from_secs(2);
-pub const MINIMUM_BLOCK_TIME: u64 = 10;
+pub const MINIMUM_BLOCK_TIME: u64 = 2;

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -105,8 +105,8 @@ impl<'a, DB: Database, T: Operations + 'static> ExecutionCtx<'a, DB, T> {
         committee.is_member(&self.round_update.pubkey_bls)
     }
 
-    pub(crate) fn save_committee(&mut self, committee: Committee) {
-        self.iter_ctx.committees.insert(self.step(), committee);
+    pub(crate) fn save_committee(&mut self, step: u16, committee: Committee) {
+        self.iter_ctx.committees.insert(step, committee);
     }
 
     pub(crate) fn get_current_committee(&self) -> Option<&Committee> {
@@ -435,7 +435,7 @@ impl<'a, DB: Database, T: Operations + 'static> ExecutionCtx<'a, DB, T> {
 
     pub fn get_sortition_config(
         &self,
-        exclusion: Option<PublicKeyBytes>,
+        exclusion: Vec<PublicKeyBytes>,
     ) -> sortition::Config {
         sortition::Config::new(
             self.round_update.seed(),

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -276,6 +276,9 @@ impl<'a, DB: Database, T: Operations + 'static> ExecutionCtx<'a, DB, T> {
         let committee = self
             .get_current_committee()
             .expect("committee to be created before run");
+
+        let generator = self.get_curr_generator();
+
         // Check if message is valid in the context of current step
         let valid = phase.lock().await.is_valid(
             &msg,
@@ -335,7 +338,7 @@ impl<'a, DB: Database, T: Operations + 'static> ExecutionCtx<'a, DB, T> {
         let collected = phase
             .lock()
             .await
-            .collect(msg, &self.round_update, committee)
+            .collect(msg, &self.round_update, committee, generator)
             .await;
 
         match collected {
@@ -380,6 +383,9 @@ impl<'a, DB: Database, T: Operations + 'static> ExecutionCtx<'a, DB, T> {
         let committee = self
             .get_current_committee()
             .expect("committee to be created before run");
+
+        let generator = self.get_curr_generator();
+
         if let Some(messages) = self
             .future_msgs
             .lock()
@@ -421,7 +427,7 @@ impl<'a, DB: Database, T: Operations + 'static> ExecutionCtx<'a, DB, T> {
                     if let Ok(HandleMsgOutput::Ready(msg)) = phase
                         .lock()
                         .await
-                        .collect(msg, &self.round_update, committee)
+                        .collect(msg, &self.round_update, committee, generator)
                         .await
                     {
                         return Some(msg);
@@ -462,5 +468,9 @@ impl<'a, DB: Database, T: Operations + 'static> ExecutionCtx<'a, DB, T> {
                 elapsed,
             )
             .await;
+    }
+
+    pub(crate) fn get_curr_generator(&self) -> Option<PublicKeyBytes> {
+        self.iter_ctx.get_generator(self.iteration)
     }
 }

--- a/consensus/src/iteration_ctx.rs
+++ b/consensus/src/iteration_ctx.rs
@@ -149,23 +149,29 @@ impl<D: Database> IterationCtx<D> {
         msg: Message,
     ) -> Option<Message> {
         let committee = self.committees.get_committee(msg.get_step())?;
+        let generator = self.get_generator(msg.header.iteration);
+
         match msg.topic() {
             node_data::message::Topics::Candidate => {
                 let mut handler = self.proposal_handler.lock().await;
-                _ = handler.collect_from_past(msg, ru, committee).await;
+                _ = handler
+                    .collect_from_past(msg, ru, committee, generator)
+                    .await;
             }
             node_data::message::Topics::Validation => {
                 let mut handler = self.validation_handler.lock().await;
-                if let Ok(HandleMsgOutput::Ready(m)) =
-                    handler.collect_from_past(msg, ru, committee).await
+                if let Ok(HandleMsgOutput::Ready(m)) = handler
+                    .collect_from_past(msg, ru, committee, generator)
+                    .await
                 {
                     return Some(m);
                 }
             }
             node_data::message::Topics::Ratification => {
                 let mut handler = self.ratification_handler.lock().await;
-                if let Ok(HandleMsgOutput::Ready(m)) =
-                    handler.collect_from_past(msg, ru, committee).await
+                if let Ok(HandleMsgOutput::Ready(m)) = handler
+                    .collect_from_past(msg, ru, committee, generator)
+                    .await
                 {
                     return Some(m);
                 }

--- a/consensus/src/msg_handler.rs
+++ b/consensus/src/msg_handler.rs
@@ -94,6 +94,7 @@ pub trait MsgHandler {
         msg: Message,
         ru: &RoundUpdate,
         committee: &Committee,
+        generator: Option<PublicKeyBytes>,
     ) -> Result<HandleMsgOutput, ConsensusError>;
 
     /// handle_timeout allows each Phase to handle a timeout event.

--- a/consensus/src/msg_handler.rs
+++ b/consensus/src/msg_handler.rs
@@ -8,6 +8,7 @@ use crate::commons::{ConsensusError, RoundUpdate};
 use crate::iteration_ctx::RoundCommittees;
 use crate::user::committee::Committee;
 use async_trait::async_trait;
+use node_data::bls::PublicKeyBytes;
 use node_data::message::{Message, Status};
 use node_data::StepName;
 use tracing::{debug, trace};
@@ -83,6 +84,7 @@ pub trait MsgHandler {
         msg: Message,
         ru: &RoundUpdate,
         committee: &Committee,
+        generator: Option<PublicKeyBytes>,
     ) -> Result<HandleMsgOutput, ConsensusError>;
 
     /// collect allows each Phase to process a verified message from a former

--- a/consensus/src/phase.rs
+++ b/consensus/src/phase.rs
@@ -5,6 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::commons::{ConsensusError, Database};
+use crate::config::CONSENSUS_MAX_ITER;
 use crate::execution_ctx::ExecutionCtx;
 use crate::operations::Operations;
 use crate::user::committee::Committee;
@@ -62,13 +63,27 @@ impl<T: Operations + 'static, D: Database + 'static> Phase<T, D> {
         debug!(event = "execute_step", ?timeout);
 
         let exclusion = match step_name {
-            StepName::Proposal => None,
+            StepName::Proposal => vec![],
             _ => {
+                let mut exclusion_list = vec![];
                 let generator = ctx
                     .iter_ctx
                     .get_generator(ctx.iteration)
                     .expect("Proposal committee to be already generated");
-                Some(generator)
+
+                exclusion_list.push(generator);
+
+                if ctx.iteration < CONSENSUS_MAX_ITER {
+                    let next_generator =
+                        ctx.iter_ctx.get_generator(ctx.iteration + 1).expect(
+                            "Next Proposal committee to be already generated",
+                        );
+
+                    // TODO: Check for single-provisioner network setup
+                    exclusion_list.push(next_generator);
+                }
+
+                exclusion_list
             }
         };
 
@@ -82,12 +97,25 @@ impl<T: Operations + 'static, D: Database + 'static> Phase<T, D> {
             &ctx.get_sortition_config(exclusion),
         );
 
+        if let StepName::Proposal = step_name {
+            if ctx.iteration < CONSENSUS_MAX_ITER {
+                let mut cfg_next_iteration = ctx.get_sortition_config(vec![]);
+                cfg_next_iteration.step =
+                    StepName::Proposal.to_step(ctx.iteration + 1);
+
+                ctx.save_committee(
+                    cfg_next_iteration.step,
+                    Committee::new(ctx.provisioners, &cfg_next_iteration),
+                );
+            }
+        }
+
         debug!(
             event = "committee_generated",
             members = format!("{}", &step_committee)
         );
 
-        ctx.save_committee(step_committee);
+        ctx.save_committee(ctx.step(), step_committee);
 
         // Execute step
         await_phase!(self, run(ctx))

--- a/consensus/src/phase.rs
+++ b/consensus/src/phase.rs
@@ -79,7 +79,6 @@ impl<T: Operations + 'static, D: Database + 'static> Phase<T, D> {
                             "Next Proposal committee to be already generated",
                         );
 
-                    // TODO: Check for single-provisioner network setup
                     exclusion_list.push(next_generator);
                 }
 

--- a/consensus/src/proposal/handler.rs
+++ b/consensus/src/proposal/handler.rs
@@ -44,6 +44,7 @@ impl<D: Database> MsgHandler for ProposalHandler<D> {
         msg: Message,
         _ru: &RoundUpdate,
         _committee: &Committee,
+        _generator: Option<PublicKeyBytes>,
     ) -> Result<HandleMsgOutput, ConsensusError> {
         // store candidate block
         let p = Self::unwrap_msg(&msg)?;

--- a/consensus/src/proposal/handler.rs
+++ b/consensus/src/proposal/handler.rs
@@ -61,6 +61,7 @@ impl<D: Database> MsgHandler for ProposalHandler<D> {
         _msg: Message,
         _ru: &RoundUpdate,
         _committee: &Committee,
+        _generator: Option<PublicKeyBytes>,
     ) -> Result<HandleMsgOutput, ConsensusError> {
         Ok(HandleMsgOutput::Pending)
     }

--- a/consensus/src/proposal/step.rs
+++ b/consensus/src/proposal/step.rs
@@ -57,6 +57,7 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
         let committee = ctx
             .get_current_committee()
             .expect("committee to be created before run");
+
         if ctx.am_member(committee) {
             let iteration =
                 cmp::min(config::RELAX_ITERATION_THRESHOLD, ctx.iteration);
@@ -84,7 +85,7 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
                     .handler
                     .lock()
                     .await
-                    .collect(msg, &ctx.round_update, committee)
+                    .collect(msg, &ctx.round_update, committee, None)
                     .await
                 {
                     Ok(HandleMsgOutput::Ready(msg)) => return Ok(msg),

--- a/consensus/src/quorum/verifiers.rs
+++ b/consensus/src/quorum/verifiers.rs
@@ -15,6 +15,7 @@ use crate::user::cluster::Cluster;
 use crate::user::committee::{Committee, CommitteeSet};
 use crate::user::sortition;
 
+use crate::config::CONSENSUS_MAX_ITER;
 use dusk_bytes::Serializable as BytesSerializable;
 use execution_core::{StakeAggPublicKey, StakeSignature};
 use tokio::sync::RwLock;
@@ -87,13 +88,15 @@ pub async fn verify_step_votes(
 
     exclusion_list.push(generator);
 
-    let next_generator = committees_set
-        .read()
-        .await
-        .provisioners()
-        .get_generator(iteration + 1, seed, round);
+    if iteration < CONSENSUS_MAX_ITER {
+        let next_generator = committees_set
+            .read()
+            .await
+            .provisioners()
+            .get_generator(iteration + 1, seed, round);
 
-    exclusion_list.push(next_generator);
+        exclusion_list.push(next_generator);
+    }
 
     let cfg =
         sortition::Config::new(seed, round, iteration, step, exclusion_list);

--- a/consensus/src/quorum/verifiers.rs
+++ b/consensus/src/quorum/verifiers.rs
@@ -78,14 +78,25 @@ pub async fn verify_step_votes(
     let round = header.round;
     let iteration = header.iteration;
 
+    let mut exclusion_list = vec![];
     let generator = committees_set
         .read()
         .await
         .provisioners()
         .get_generator(iteration, seed, round);
 
+    exclusion_list.push(generator);
+
+    let next_generator = committees_set
+        .read()
+        .await
+        .provisioners()
+        .get_generator(iteration + 1, seed, round);
+
+    exclusion_list.push(next_generator);
+
     let cfg =
-        sortition::Config::new(seed, round, iteration, step, Some(generator));
+        sortition::Config::new(seed, round, iteration, step, exclusion_list);
 
     if committees_set.read().await.get(&cfg).is_none() {
         let _ = committees_set.write().await.get_or_create(&cfg);

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -8,6 +8,7 @@ use crate::commons::{ConsensusError, RoundUpdate};
 use crate::msg_handler::{HandleMsgOutput, MsgHandler};
 use crate::step_votes_reg::SafeAttestationInfoRegistry;
 use async_trait::async_trait;
+use node_data::bls::PublicKeyBytes;
 use node_data::ledger::Attestation;
 use node_data::{ledger, StepName};
 use tracing::{error, warn};
@@ -68,6 +69,7 @@ impl MsgHandler for RatificationHandler {
         msg: Message,
         ru: &RoundUpdate,
         committee: &Committee,
+        generator: Option<PublicKeyBytes>,
     ) -> Result<HandleMsgOutput, ConsensusError> {
         let p = Self::unwrap_msg(msg)?;
         let iteration = p.header().iteration;
@@ -101,7 +103,7 @@ impl MsgHandler for RatificationHandler {
             sv,
             StepName::Ratification,
             quorum_reached,
-            &committee.excluded()[0], // TODO
+            &generator.expect("There must be a valid generator"),
         );
 
         if quorum_reached {

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -101,7 +101,7 @@ impl MsgHandler for RatificationHandler {
             sv,
             StepName::Ratification,
             quorum_reached,
-            committee.excluded().expect("Generator to be excluded"),
+            &committee.excluded()[0], // TODO
         );
 
         if quorum_reached {
@@ -144,7 +144,7 @@ impl MsgHandler for RatificationHandler {
                         sv,
                         StepName::Ratification,
                         quorum_reached,
-                        committee.excluded().expect("Generator to be excluded"),
+                        &committee.excluded()[0], // TODO
                     )
                 {
                     return Ok(HandleMsgOutput::Ready(quorum_msg));

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -125,6 +125,7 @@ impl MsgHandler for RatificationHandler {
         msg: Message,
         _ru: &RoundUpdate,
         committee: &Committee,
+        generator: Option<PublicKeyBytes>,
     ) -> Result<HandleMsgOutput, ConsensusError> {
         let p = Self::unwrap_msg(msg)?;
 
@@ -146,7 +147,7 @@ impl MsgHandler for RatificationHandler {
                         sv,
                         StepName::Ratification,
                         quorum_reached,
-                        &committee.excluded()[0], // TODO
+                        &generator.expect("There must be a valid generator"),
                     )
                 {
                     return Ok(HandleMsgOutput::Ready(quorum_msg));

--- a/consensus/src/ratification/step.rs
+++ b/consensus/src/ratification/step.rs
@@ -122,6 +122,8 @@ impl<DB: Database> RatificationStep<DB> {
             .get_current_committee()
             .expect("committee to be created before run");
 
+        let generator = ctx.get_curr_generator();
+
         if ctx.am_member(committee) {
             let mut handler = self.handler.lock().await;
             let vote = handler.validation_result().vote();
@@ -137,7 +139,7 @@ impl<DB: Database> RatificationStep<DB> {
 
             // Collect my own vote
             let res = handler
-                .collect(vote_msg, &ctx.round_update, committee)
+                .collect(vote_msg, &ctx.round_update, committee, generator)
                 .await?;
             if let HandleMsgOutput::Ready(m) = res {
                 return Ok(m);

--- a/consensus/src/user/committee.rs
+++ b/consensus/src/user/committee.rs
@@ -19,7 +19,7 @@ pub struct Committee {
     members: BTreeMap<PublicKey, usize>,
     super_majority: usize,
     majority: usize,
-    excluded: Option<PublicKeyBytes>,
+    excluded: Vec<PublicKeyBytes>,
 }
 
 impl Committee {
@@ -50,7 +50,7 @@ impl Committee {
             members: BTreeMap::new(),
             super_majority,
             majority,
-            excluded: cfg.exclusion().copied(),
+            excluded: cfg.exclusion().clone(),
         };
 
         for member_key in extracted {
@@ -60,8 +60,8 @@ impl Committee {
         committee
     }
 
-    pub fn excluded(&self) -> Option<&PublicKeyBytes> {
-        self.excluded.as_ref()
+    pub fn excluded(&self) -> &Vec<PublicKeyBytes> {
+        &self.excluded
     }
 
     /// Returns true if `pubkey_bls` is a member of the generated committee.

--- a/consensus/src/user/provisioners.rs
+++ b/consensus/src/user/provisioners.rs
@@ -216,7 +216,7 @@ impl Provisioners {
             round,
             iteration,
             StepName::Proposal,
-            None,
+            vec![],
         );
         let committee_keys = Committee::new(self, &cfg);
 
@@ -238,17 +238,18 @@ impl<'a> CommitteeGenerator<'a> {
     fn from_provisioners(
         provisioners: &'a Provisioners,
         round: u64,
-        exclusion: Option<&PublicKeyBytes>,
+        exclusion: &Vec<PublicKeyBytes>,
     ) -> Self {
         let eligibles = provisioners
             .eligibles(round)
             .map(|(p, stake)| (p, stake.clone()));
 
-        let members = match exclusion {
-            None => BTreeMap::from_iter(eligibles),
-            Some(excluded) => {
-                let eligibles =
-                    eligibles.filter(|(p, _)| p.bytes() != excluded);
+        let members = match exclusion.len() {
+            0 => BTreeMap::from_iter(eligibles),
+            _ => {
+                let eligibles = eligibles.filter(|(p, _)| {
+                    !exclusion.iter().any(|excluded| excluded == p.bytes())
+                });
                 BTreeMap::from_iter(eligibles)
             }
         };

--- a/consensus/src/user/sortition.rs
+++ b/consensus/src/user/sortition.rs
@@ -110,7 +110,7 @@ mod tests {
             round: u64,
             step: u16,
             committee_credits: usize,
-            exclusion: Option<PublicKeyBytes>,
+            exclusion: Vec<PublicKeyBytes>,
         ) -> Config {
             Self {
                 seed,
@@ -132,7 +132,7 @@ mod tests {
 
         assert_eq!(
             create_sortition_hash(
-                &Config::raw(Seed::from([3; 48]), 10, 3, 0, None),
+                &Config::raw(Seed::from([3; 48]), 10, 3, 0, vec![]),
                 1
             )[..],
             hash[..],
@@ -148,7 +148,7 @@ mod tests {
 
         for (seed, total_weight, expected_score) in dataset {
             let hash = create_sortition_hash(
-                &Config::raw(Seed::from(seed), 10, 3, 0, None),
+                &Config::raw(Seed::from(seed), 10, 3, 0, vec![]),
                 1,
             );
 
@@ -166,7 +166,7 @@ mod tests {
         let committee_credits = 64;
 
         // Execute sortition with specific config
-        let cfg = Config::raw(Seed::default(), 1, 1, 64, None);
+        let cfg = Config::raw(Seed::default(), 1, 1, 64, vec![]);
 
         let committee = Committee::new(&p, &cfg);
 
@@ -190,7 +190,7 @@ mod tests {
             7777,
             8,
             committee_credits,
-            None,
+            vec![],
         );
 
         let committee = Committee::new(&p, &cfg);
@@ -212,7 +212,7 @@ mod tests {
         let relative_step = 2;
         let step = iteration as u16 * 3 + relative_step;
 
-        let cfg = Config::raw(seed, round, step, committee_credits, None);
+        let cfg = Config::raw(seed, round, step, committee_credits, vec![]);
         let generator = p.get_generator(iteration, seed, round);
         let committee = Committee::new(&p, &cfg);
 
@@ -228,7 +228,7 @@ mod tests {
 
         // Run the same extraction, with the generator excluded
         let cfg =
-            Config::raw(seed, round, step, committee_credits, Some(generator));
+            Config::raw(seed, round, step, committee_credits, vec![generator]);
         let committee = Committee::new(&p, &cfg);
 
         assert!(
@@ -249,7 +249,7 @@ mod tests {
     fn test_quorum() {
         let p = generate_provisioners(5);
 
-        let cfg = Config::raw(Seed::default(), 7777, 8, 64, None);
+        let cfg = Config::raw(Seed::default(), 7777, 8, 64, vec![]);
 
         let c = Committee::new(&p, &cfg);
         assert_eq!(c.super_majority_quorum(), 43);
@@ -259,7 +259,7 @@ mod tests {
     fn test_intersect() {
         let p = generate_provisioners(10);
 
-        let cfg = Config::raw(Seed::default(), 1, 3, 200, None);
+        let cfg = Config::raw(Seed::default(), 1, 3, 200, vec![]);
         // println!("{:#?}", p);
 
         let c = Committee::new(&p, &cfg);

--- a/consensus/src/user/sortition.rs
+++ b/consensus/src/user/sortition.rs
@@ -20,9 +20,9 @@ use crate::config::{
 pub struct Config {
     seed: Seed,
     round: u64,
-    step: u16,
+    pub step: u16,
     committee_credits: usize,
-    exclusion: Option<PublicKeyBytes>,
+    exclusion: Vec<PublicKeyBytes>,
 }
 
 impl Config {
@@ -31,7 +31,7 @@ impl Config {
         round: u64,
         iteration: u8,
         step: StepName,
-        exclusion: Option<PublicKeyBytes>,
+        exclusion: Vec<PublicKeyBytes>,
     ) -> Config {
         let committee_credits = match step {
             StepName::Proposal => PROPOSAL_COMMITTEE_CREDITS,
@@ -60,8 +60,8 @@ impl Config {
         self.round
     }
 
-    pub fn exclusion(&self) -> Option<&PublicKeyBytes> {
-        self.exclusion.as_ref()
+    pub fn exclusion(&self) -> &Vec<PublicKeyBytes> {
+        &self.exclusion
     }
 }
 

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -130,7 +130,7 @@ impl MsgHandler for ValidationHandler {
             sv,
             StepName::Validation,
             quorum_reached,
-            committee.excluded().expect("Generator to be excluded"),
+            &committee.excluded()[0], // TODO:
         );
 
         if quorum_reached {
@@ -182,7 +182,7 @@ impl MsgHandler for ValidationHandler {
                         sv,
                         StepName::Validation,
                         quorum_reached,
-                        committee.excluded().expect("Generator to be excluded"),
+                        &committee.excluded()[0], // TODO:
                     )
                 {
                     return Ok(HandleMsgOutput::Ready(quorum_msg));

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -159,6 +159,7 @@ impl MsgHandler for ValidationHandler {
         msg: Message,
         _ru: &RoundUpdate,
         committee: &Committee,
+        generator: Option<PublicKeyBytes>,
     ) -> Result<HandleMsgOutput, ConsensusError> {
         let p = Self::unwrap_msg(msg)?;
 
@@ -184,7 +185,7 @@ impl MsgHandler for ValidationHandler {
                         sv,
                         StepName::Validation,
                         quorum_reached,
-                        &committee.excluded()[0], // TODO:
+                        &generator.expect("There must be a valid generator"),
                     )
                 {
                     return Ok(HandleMsgOutput::Ready(quorum_msg));

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -9,6 +9,7 @@ use crate::commons::{ConsensusError, RoundUpdate};
 use crate::msg_handler::{HandleMsgOutput, MsgHandler};
 use crate::step_votes_reg::SafeAttestationInfoRegistry;
 use async_trait::async_trait;
+use node_data::bls::PublicKeyBytes;
 use node_data::ledger::{Block, StepVotes};
 use node_data::StepName;
 use tracing::{info, warn};
@@ -94,6 +95,7 @@ impl MsgHandler for ValidationHandler {
         msg: Message,
         _ru: &RoundUpdate,
         committee: &Committee,
+        generator: Option<PublicKeyBytes>,
     ) -> Result<HandleMsgOutput, ConsensusError> {
         let p = Self::unwrap_msg(msg)?;
 
@@ -130,7 +132,7 @@ impl MsgHandler for ValidationHandler {
             sv,
             StepName::Validation,
             quorum_reached,
-            &committee.excluded()[0], // TODO:
+            &generator.expect("There must be a valid generator"),
         );
 
         if quorum_reached {

--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -103,8 +103,6 @@ impl Serializable for Message {
             Payload::Quorum(p) => p.write(w),
             Payload::Block(p) => p.write(w),
             Payload::Transaction(p) => p.write(w),
-            Payload::GetCandidate(p) => p.write(w),
-            Payload::CandidateResp(p) => p.write(w),
             Payload::GetMempool(p) => p.write(w),
             Payload::GetInv(p) => p.write(w),
             Payload::GetBlocks(p) => p.write(w),
@@ -134,12 +132,6 @@ impl Serializable for Message {
             Topics::Block => Message::new_block(ledger::Block::read(r)?),
             Topics::Tx => {
                 Message::new_transaction(ledger::Transaction::read(r)?)
-            }
-            Topics::GetCandidateResp => Message::new_get_candidate_resp(
-                payload::GetCandidateResp::read(r)?,
-            ),
-            Topics::GetCandidate => {
-                Message::new_get_candidate(payload::GetCandidate::read(r)?)
             }
             Topics::GetResource => {
                 Message::new_get_resource(payload::GetResource::read(r)?)
@@ -209,24 +201,6 @@ impl Message {
         Self {
             topic: Topics::Block,
             payload: Payload::Block(Box::new(payload)),
-            ..Default::default()
-        }
-    }
-
-    /// Creates topics.GetCandidate message
-    pub fn new_get_candidate(p: payload::GetCandidate) -> Message {
-        Self {
-            topic: Topics::GetCandidate,
-            payload: Payload::GetCandidate(p),
-            ..Default::default()
-        }
-    }
-
-    /// Creates topics.GetCandidateResp message
-    pub fn new_get_candidate_resp(p: payload::GetCandidateResp) -> Message {
-        Self {
-            topic: Topics::GetCandidateResp,
-            payload: Payload::CandidateResp(Box::new(p)),
             ..Default::default()
         }
     }
@@ -371,12 +345,10 @@ pub enum Payload {
 
     Block(Box<ledger::Block>),
     Transaction(Box<ledger::Transaction>),
-    GetCandidate(payload::GetCandidate),
     GetMempool(payload::GetMempool),
     GetInv(payload::Inv),
     GetBlocks(payload::GetBlocks),
     GetResource(payload::GetResource),
-    CandidateResp(Box<payload::GetCandidateResp>),
 
     // Internal messages payload
     /// Result message passed from Validation step to Ratification step
@@ -1087,14 +1059,12 @@ pub enum Topics {
     GetBlocks = 9,
     GetMempool = 13, // NB: This is aliased as Mempool in the golang impl
     GetInv = 14,     // NB: This is aliased as Inv in the golang impl
-    GetCandidate = 46,
 
     // Fire-and-forget messaging
     Tx = 10,
     Block = 11,
 
     // Consensus main loop topics
-    GetCandidateResp = 15,
     Candidate = 16,
     Validation = 17,
     Ratification = 18,
@@ -1126,8 +1096,6 @@ impl From<u8> for Topics {
         map_topic!(v, Topics::Block);
         map_topic!(v, Topics::GetMempool);
         map_topic!(v, Topics::GetInv);
-        map_topic!(v, Topics::GetCandidateResp);
-        map_topic!(v, Topics::GetCandidate);
         map_topic!(v, Topics::Candidate);
         map_topic!(v, Topics::Validation);
         map_topic!(v, Topics::Ratification);

--- a/node/benches/accept.rs
+++ b/node/benches/accept.rs
@@ -44,7 +44,7 @@ fn create_step_votes(
     let generator = provisioners.get_generator(iteration, seed, round);
 
     let sortition_config =
-        SortitionConfig::new(seed, round, iteration, step, Some(generator));
+        SortitionConfig::new(seed, round, iteration, step, vec![generator]);
 
     let committee = Committee::new(provisioners, &sortition_config);
 


### PR DESCRIPTION
- fixes #1834
- Removal of GetCandidate (deprecated) message flow
- Pass Block generator to consensus message handlers instead of using "exclusion_list"

Test Result:
```
Round: 3, Iter: 0, Generator: pFPEcfxidLvwmFKR, Excludion_list: [pFPEcfxidLvwmFKR, rvXLHF8DBNwzZ63u]

"committee_generated","members":" [0]=pk:pFPEcfxidLvwmFKR w:1,","exclusion_list":"[]","target":"dusk_consensus::phase","spans":[{"iter":0,"name":"Proposal","pk":"pFPEcfxidLvwmFKR","round":3,"name":"main"}]}
"committee_generated","members":" [0]=pk:rdHa4H5p1rVtQyqD w:39, [1]=pk:244Sywxj7PuMHpcP w:25,","exclusion_list":"[pFPEcfxidLvwmFKR, rvXLHF8DBNwzZ63u]","target":"dusk_consensus::phase","spans":[{"iter":0,"name":"Validation","pk":"pFPEcfxidLvwmFKR","round":3,"name":"main"}]}
"committee_generated","members":" [0]=pk:rdHa4H5p1rVtQyqD w:29, [1]=pk:244Sywxj7PuMHpcP w:35,","exclusion_list":"[pFPEcfxidLvwmFKR, rvXLHF8DBNwzZ63u]","target":"dusk_consensus::phase","spans":[{"iter":0,"name":"Ratification","pk":"pFPEcfxidLvwmFKR","round":3,"name":"main"}]}

Round: 3, Iter: 1, Generator: rvXLHF8DBNwzZ63u
"committee_generated","members":" [0]=pk:rvXLHF8DBNwzZ63u w:1,","exclusion_list":"[]","target":"dusk_consensus::phase","spans":[{"iter":1,"name":"Proposal","pk":"pFPEcfxidLvwmFKR","round":3,"name":"main"}]}
```