### PR TITLE
consensus: handle Faults proof (aka hard slash)

### DIFF
--- a/consensus/src/proposal/handler.rs
+++ b/consensus/src/proposal/handler.rs
@@ -90,10 +90,17 @@ impl<D: Database> ProposalHandler<D> {
             return Err(ConsensusError::InvalidBlockHash);
         }
 
-        let tx_hashes: Vec<[u8; 32]> =
+        let tx_hashes: Vec<_> =
             p.candidate.txs().iter().map(|t| t.hash()).collect();
         let tx_root = merkle_root(&tx_hashes[..]);
         if tx_root != p.candidate.header().txroot {
+            return Err(ConsensusError::InvalidBlock);
+        }
+
+        let fault_hashes: Vec<_> =
+            p.candidate.faults().iter().map(|t| t.hash()).collect();
+        let fault_root = merkle_root(&fault_hashes[..]);
+        if fault_root != p.candidate.header().faultroot {
             return Err(ConsensusError::InvalidBlock);
         }
 

--- a/node-data/Cargo.toml
+++ b/node-data/Cargo.toml
@@ -24,6 +24,7 @@ chrono = "0.4"
 bs58 = { version = "0.4" }
 tracing = "0.1"
 anyhow = "1"
+thiserror = "1"
 
 
 [dev-dependencies]

--- a/node-data/src/bls.rs
+++ b/node-data/src/bls.rs
@@ -68,6 +68,10 @@ impl PublicKey {
         &self.inner
     }
 
+    pub fn into_inner(self) -> BlsPublicKey {
+        self.inner
+    }
+
     /// Truncated base58 representation of inner data
     pub fn to_bs58(&self) -> String {
         self.bytes().to_bs58()

--- a/node-data/src/encoding.rs
+++ b/node-data/src/encoding.rs
@@ -482,7 +482,7 @@ mod tests {
     }
 
     #[test]
-    fn test_encoding_faul() {
+    fn test_encoding_fault() {
         assert_serializable::<Fault>();
     }
 }

--- a/node-data/src/ledger.rs
+++ b/node-data/src/ledger.rs
@@ -14,7 +14,7 @@ mod transaction;
 pub use transaction::{SpentTransaction, Transaction};
 
 mod faults;
-pub use faults::Fault;
+pub use faults::{Fault, InvalidFault, Slash, SlashType};
 
 mod attestation;
 pub use attestation::{
@@ -24,7 +24,6 @@ pub use attestation::{
 use crate::bls::PublicKeyBytes;
 use crate::Serializable;
 
-use dusk_bytes::DeserializableSlice;
 use rusk_abi::hash::Hasher;
 use sha3::Digest;
 use std::io::{self, Read, Write};

--- a/node-data/src/ledger/attestation.rs
+++ b/node-data/src/ledger/attestation.rs
@@ -6,9 +6,7 @@
 
 use super::*;
 
-use execution_core::BlsPublicKey;
-
-use crate::message::payload::{RatificationResult, Vote};
+use crate::message::payload::RatificationResult;
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 #[cfg_attr(any(feature = "faker", test), derive(Dummy))]
@@ -94,27 +92,6 @@ impl IterationsInfo {
         Self {
             att_list: attestations,
         }
-    }
-
-    pub fn to_missed_generators(&self) -> Result<Vec<BlsPublicKey>, io::Error> {
-        self.to_missed_generators_bytes()
-        .map(|pk| BlsPublicKey::from_slice(pk.inner()).map_err(|e|{
-            tracing::error!("Unable to generate missing generators from failed_iterations: {e:?}");
-            io::Error::new(io::ErrorKind::InvalidData, "Error in deserialize")
-        }))
-        .collect()
-    }
-
-    pub fn to_missed_generators_bytes(
-        &self,
-    ) -> impl Iterator<Item = &PublicKeyBytes> {
-        self.att_list
-            .iter()
-            .flatten()
-            .filter(|(c, _)| {
-                c.result == RatificationResult::Fail(Vote::NoCandidate)
-            })
-            .map(|(_, pk)| pk)
     }
 }
 

--- a/rusk/benches/block_ingestion.rs
+++ b/rusk/benches/block_ingestion.rs
@@ -106,7 +106,7 @@ pub fn accept_benchmark(c: &mut Criterion) {
                             generator,
                             txs,
                             None,
-                            &[],
+                            vec![],
                             None,
                         )
                         .expect("Accepting transactions should succeed");

--- a/rusk/tests/common/state.rs
+++ b/rusk/tests/common/state.rs
@@ -18,7 +18,9 @@ use execution_core::{
 };
 use node_data::{
     bls::PublicKeyBytes,
-    ledger::{Attestation, Block, Header, IterationsInfo, SpentTransaction},
+    ledger::{
+        Attestation, Block, Header, IterationsInfo, Slash, SpentTransaction,
+    },
     message::payload::Vote,
 };
 
@@ -100,11 +102,16 @@ pub fn generator_procedure(
         )));
     }
 
+    let faults = vec![];
+
+    let to_slash =
+        Slash::from_iterations_and_faults(&failed_iterations, &faults)?;
+
     let call_params = CallParams {
         round,
         block_gas_limit,
         generator_pubkey,
-        missed_generators,
+        to_slash,
         voters_pubkey: None,
     };
 


### PR DESCRIPTION
This is a followup of #1923 

- [ ] ~~Collect faults to process during proposal step~~ tracked by #1969
- [x] Hard slash during proposal if any faults (change EST/VST/AST)
- [x] Check fault proofs while verifying block
   - [x] Check if fault has been already slashed
   - [x] Verify proof signatures 
- [x] Discard obsoleted proofs

See also #1651 