### PR TITLE
explorer: Delay fetching market data if the current data is not stale

### DIFF
--- a/explorer/src/lib/stores/marketDataStore.js
+++ b/explorer/src/lib/stores/marketDataStore.js
@@ -63,7 +63,14 @@ function isDataStale() {
   );
 }
 
-pollingDataStore.start();
+if (!initialState.lastUpdate || isDataStale()) {
+  pollingDataStore.start();
+} else {
+  setTimeout(
+    pollingDataStore.start,
+    +initialState.lastUpdate + fetchInterval - Date.now()
+  );
+}
 
 /** @type {MarketDataStore} */
 export default {


### PR DESCRIPTION
Resolves #1955