### PR TITLE
node: Check Certificate is Success Attestation

### DIFF
--- a/node/src/chain/header_validation.rs
+++ b/node/src/chain/header_validation.rs
@@ -168,11 +168,9 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
         }
 
         let prev_block_seed = self.db.read().await.view(|v| {
-            let prior_tip =
-                Ledger::fetch_block_by_height(&v, self.prev_header.height - 1)?
-                    .ok_or_else(|| anyhow::anyhow!("could not fetch block"))?;
-
-            Ok::<_, anyhow::Error>(prior_tip.header().seed)
+            v.fetch_block_header(&self.prev_header.prev_block_hash)?
+                .ok_or_else(|| anyhow::anyhow!("Header not found"))
+                .map(|h| h.seed)
         })?;
 
         let (_, _, voters) = verify_block_att(


### PR DESCRIPTION
Additionally, improve `verify_prev_block_cert` performance:
- Fetch the header instead of fetching the full block
- Use the header hash instead of the block height

Resolves #1905