### PR TITLE
Refactor Attestation verification

### DIFF
--- a/consensus/src/commons.rs
+++ b/consensus/src/commons.rs
@@ -20,7 +20,7 @@ use node_data::message::{AsyncQueue, Message, Payload};
 use node_data::StepName;
 use tracing::error;
 
-use crate::operations::VoterWithCredits;
+use crate::operations::Voter;
 
 pub type TimeoutSet = HashMap<StepName, Duration>;
 
@@ -36,7 +36,7 @@ pub struct RoundUpdate {
     seed: Seed,
     hash: [u8; 32],
     att: Attestation,
-    att_voters: Vec<VoterWithCredits>,
+    att_voters: Vec<Voter>,
     timestamp: u64,
 
     pub base_timeouts: TimeoutSet,
@@ -48,7 +48,7 @@ impl RoundUpdate {
         secret_key: BlsSecretKey,
         tip_header: &Header,
         base_timeouts: TimeoutSet,
-        att_voters: Vec<VoterWithCredits>,
+        att_voters: Vec<Voter>,
     ) -> Self {
         let round = tip_header.height + 1;
         RoundUpdate {
@@ -80,7 +80,7 @@ impl RoundUpdate {
         self.timestamp
     }
 
-    pub fn att_voters(&self) -> &Vec<VoterWithCredits> {
+    pub fn att_voters(&self) -> &Vec<Voter> {
         &self.att_voters
     }
 }

--- a/consensus/src/operations.rs
+++ b/consensus/src/operations.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::io;
 use std::time::Duration;
 
-use execution_core::BlsPublicKey;
+use node_data::bls::PublicKey;
 use node_data::ledger::{
     Block, Fault, Header, InvalidFault, Slash, SpentTransaction, Transaction,
 };
@@ -17,7 +17,7 @@ use thiserror::Error;
 
 pub type StateRoot = [u8; 32];
 pub type EventHash = [u8; 32];
-pub type Voter = (BlsPublicKey, usize);
+pub type Voter = (PublicKey, usize);
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/consensus/src/operations.rs
+++ b/consensus/src/operations.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 
 pub type StateRoot = [u8; 32];
 pub type EventHash = [u8; 32];
-pub type VoterWithCredits = (BlsPublicKey, usize);
+pub type Voter = (BlsPublicKey, usize);
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -53,7 +53,7 @@ pub struct CallParams {
     pub block_gas_limit: u64,
     pub generator_pubkey: node_data::bls::PublicKey,
     pub to_slash: Vec<Slash>,
-    pub voters_pubkey: Option<Vec<VoterWithCredits>>,
+    pub voters_pubkey: Option<Vec<Voter>>,
 }
 
 #[derive(Default)]
@@ -86,7 +86,7 @@ pub trait Operations: Send + Sync {
         &self,
         candidate_header: &Header,
         disable_winning_att_check: bool,
-    ) -> Result<(u8, Vec<VoterWithCredits>, Vec<VoterWithCredits>), Error>;
+    ) -> Result<(u8, Vec<Voter>, Vec<Voter>), Error>;
 
     async fn verify_faults(
         &self,
@@ -97,7 +97,7 @@ pub trait Operations: Send + Sync {
     async fn verify_state_transition(
         &self,
         blk: &Block,
-        voters: &[VoterWithCredits],
+        voters: &[Voter],
     ) -> Result<VerificationOutput, Error>;
 
     async fn execute_state_transition(

--- a/consensus/src/proposal/block_generator.rs
+++ b/consensus/src/proposal/block_generator.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::commons::{get_current_timestamp, RoundUpdate};
-use crate::operations::{CallParams, Operations, VoterWithCredits};
+use crate::operations::{CallParams, Operations, Voter};
 use node_data::ledger::{
     to_str, Attestation, Block, Fault, IterationsInfo, Seed, Slash,
 };
@@ -90,7 +90,7 @@ impl<T: Operations> Generator<T> {
         iteration: u8,
         failed_iterations: IterationsInfo,
         faults: &[Fault],
-        voters: &[VoterWithCredits],
+        voters: &[Voter],
     ) -> Result<Block, crate::operations::Error> {
         let to_slash =
             Slash::from_iterations_and_faults(&failed_iterations, faults)?;

--- a/consensus/src/quorum/verifiers.rs
+++ b/consensus/src/quorum/verifiers.rs
@@ -145,10 +145,8 @@ impl Cluster<PublicKey> {
         }
     }
 
-    pub fn to_voters(&self) -> Vec<Voter> {
-        self.iter()
-            .map(|(public_key, &weight)| (public_key.clone(), weight))
-            .collect()
+    pub fn to_voters(self) -> Vec<Voter> {
+        self.into_vec()
     }
 }
 

--- a/consensus/src/quorum/verifiers.rs
+++ b/consensus/src/quorum/verifiers.rs
@@ -6,7 +6,7 @@
 
 use node_data::bls::PublicKey;
 use node_data::ledger::{Seed, StepVotes};
-use node_data::message::payload::{self, Quorum, Vote};
+use node_data::message::payload::{self, Vote};
 use node_data::message::{ConsensusHeader, StepMessage};
 use node_data::{Serializable, StepName};
 
@@ -19,54 +19,6 @@ use crate::config::CONSENSUS_MAX_ITER;
 use dusk_bytes::Serializable as BytesSerializable;
 use execution_core::{BlsAggPublicKey, BlsSignature};
 use tokio::sync::RwLock;
-use tracing::error;
-
-/// Performs all three-steps verification of a quorum msg.
-pub async fn verify_quorum(
-    quorum: &Quorum,
-    committees_set: &RwLock<CommitteeSet<'_>>,
-    seed: Seed,
-) -> Result<(), StepSigError> {
-    // Verify validation
-    verify_step_votes(
-        &quorum.header,
-        quorum.vote(),
-        &quorum.att.validation,
-        committees_set,
-        seed,
-        StepName::Validation,
-    )
-    .await
-    .map_err(|e| {
-        error!(
-            desc = "invalid validation",
-            sv = ?quorum.att.validation,
-            hdr = ?quorum.header,
-        );
-        e
-    })?;
-
-    // Verify ratification
-    verify_step_votes(
-        &quorum.header,
-        quorum.vote(),
-        &quorum.att.ratification,
-        committees_set,
-        seed,
-        StepName::Ratification,
-    )
-    .await
-    .map_err(|e| {
-        error!(
-            desc = "invalid ratification",
-            sv = ?quorum.att.ratification,
-            hdr = ?quorum.header,
-        );
-        e
-    })?;
-
-    Ok(())
-}
 
 pub async fn verify_step_votes(
     header: &ConsensusHeader,

--- a/consensus/src/user/cluster.rs
+++ b/consensus/src/user/cluster.rs
@@ -43,6 +43,10 @@ where
         self.0.iter()
     }
 
+    pub fn into_vec(self) -> Vec<(T, usize)> {
+        self.0.into_iter().collect()
+    }
+
     pub fn contains_key(&self, key: &T) -> bool {
         self.0.contains_key(key)
     }

--- a/consensus/src/validation/step.rs
+++ b/consensus/src/validation/step.rs
@@ -7,7 +7,7 @@
 use crate::commons::{ConsensusError, Database, RoundUpdate};
 use crate::config;
 use crate::execution_ctx::ExecutionCtx;
-use crate::operations::{Operations, VoterWithCredits};
+use crate::operations::{Operations, Voter};
 use crate::validation::handler;
 use anyhow::anyhow;
 use node_data::ledger::{to_str, Block};
@@ -140,7 +140,7 @@ impl<T: Operations + 'static> ValidationStep<T> {
 
     async fn call_vst(
         candidate: &Block,
-        voters: &[VoterWithCredits],
+        voters: &[Voter],
         executor: &Arc<T>,
     ) -> anyhow::Result<()> {
         match executor.verify_state_transition(candidate, voters).await {

--- a/node-data/src/ledger/header.rs
+++ b/node-data/src/ledger/header.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use crate::message::ConsensusHeader;
+
 use super::*;
 
 pub type Seed = Signature;
@@ -58,6 +60,15 @@ impl std::fmt::Debug for Header {
 }
 
 impl Header {
+    /// Return the corresponding ConsensusHeader
+    pub fn to_consensus_header(&self) -> ConsensusHeader {
+        ConsensusHeader {
+            prev_block_hash: self.prev_block_hash,
+            round: self.height,
+            iteration: self.iteration,
+        }
+    }
+
     /// Marshal hashable fields.
     pub(crate) fn marshal_hashable<W: Write>(
         &self,

--- a/node/benches/accept.rs
+++ b/node/benches/accept.rs
@@ -156,12 +156,13 @@ pub fn verify_att(c: &mut Criterion) {
                     format!("{} prov", input.provisioners),
                 ),
                 move |b| {
-                    let consensus_header = ConsensusHeader {
-                        prev_block_hash: [0u8; 32],
-                        round: tip_header.height + 1,
-                        iteration: 0,
-                    };
                     b.to_async(FuturesExecutor).iter(|| async {
+                        let consensus_header = ConsensusHeader {
+                            prev_block_hash: [0u8; 32],
+                            round: tip_header.height + 1,
+                            iteration: 0,
+                        };
+
                         chain::verify_att(
                             &att,
                             consensus_header,

--- a/node/benches/accept.rs
+++ b/node/benches/accept.rs
@@ -26,6 +26,7 @@ use node_data::ledger::{Attestation, StepVotes};
 use node_data::message::payload::{
     QuorumType, RatificationResult, ValidationResult, Vote,
 };
+use node_data::message::ConsensusHeader;
 use node_data::{ledger, StepName};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -155,12 +156,15 @@ pub fn verify_att(c: &mut Criterion) {
                     format!("{} prov", input.provisioners),
                 ),
                 move |b| {
+                    let consensus_header = ConsensusHeader {
+                        prev_block_hash: [0u8; 32],
+                        round: tip_header.height + 1,
+                        iteration: 0,
+                    };
                     b.to_async(FuturesExecutor).iter(|| async {
                         chain::verify_att(
                             &att,
-                            [0u8; 32],
-                            tip_header.height + 1,
-                            iteration,
+                            consensus_header,
                             tip_header.seed,
                             &provisioners,
                         )

--- a/node/benches/accept.rs
+++ b/node/benches/accept.rs
@@ -168,6 +168,9 @@ pub fn verify_att(c: &mut Criterion) {
                             consensus_header,
                             tip_header.seed,
                             &provisioners,
+                            RatificationResult::Success(Vote::Valid(
+                                block_hash,
+                            )),
                         )
                         .await
                         .expect("block to be verified")

--- a/node/benches/accept.rs
+++ b/node/benches/accept.rs
@@ -105,8 +105,8 @@ where
     r
 }
 
-pub fn verify_block_att(c: &mut Criterion) {
-    with_group("verify_block_att", c, |group| {
+pub fn verify_att(c: &mut Criterion) {
+    with_group("verify_att", c, |group| {
         for input in INPUTS {
             group.measurement_time(Duration::from_secs(input.measurement_time));
             let mut keys = vec![];
@@ -151,18 +151,18 @@ pub fn verify_block_att(c: &mut Criterion) {
 
             group.bench_function(
                 BenchmarkId::new(
-                    "verify_block_att",
+                    "verify_att",
                     format!("{} prov", input.provisioners),
                 ),
                 move |b| {
                     b.to_async(FuturesExecutor).iter(|| async {
-                        chain::verify_block_att(
+                        chain::verify_att(
+                            &att,
                             [0u8; 32],
+                            tip_header.height + 1,
+                            iteration,
                             tip_header.seed,
                             &provisioners,
-                            tip_header.height + 1,
-                            &att,
-                            iteration,
                         )
                         .await
                         .expect("block to be verified")
@@ -200,5 +200,5 @@ const INPUTS: &[Input] = &[
         measurement_time: 15,
     },
 ];
-criterion_group!(benches, verify_block_att);
+criterion_group!(benches, verify_att);
 criterion_main!(benches);

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -22,7 +22,7 @@ use crate::{LongLivedService, Message};
 use anyhow::Result;
 use async_trait::async_trait;
 use dusk_consensus::commons::ConsensusError;
-pub use header_validation::verify_block_att;
+pub use header_validation::verify_att;
 use node_data::ledger::{to_str, BlockWithLabel, Label};
 use node_data::message::AsyncQueue;
 use node_data::message::{Payload, Topics};

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -201,7 +201,6 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
         let prev_seed = self.get_prev_block_seed().await.expect("valid seed");
         Validator::<DB>::get_voters(tip.header(), provisioners_list, prev_seed)
             .await
-            .expect("valid voters")
     }
 
     // Re-route message to consensus task

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -17,7 +17,7 @@ use node_data::ledger::{
 use node_data::message::AsyncQueue;
 use node_data::message::Payload;
 
-use dusk_consensus::operations::VoterWithCredits;
+use dusk_consensus::operations::Voter;
 use execution_core::stake::Withdraw;
 use metrics::{counter, gauge, histogram};
 use node_data::message::payload::Vote;
@@ -193,7 +193,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
         &self,
         provisioners_list: &Provisioners,
         tip: &Block,
-    ) -> Vec<VoterWithCredits> {
+    ) -> Vec<Voter> {
         if tip.header().height == 0 {
             return vec![];
         };
@@ -1026,7 +1026,7 @@ pub(crate) async fn verify_block_header<DB: database::DB>(
     prev_header: &ledger::Header,
     provisioners: &ContextProvisioners,
     header: &ledger::Header,
-) -> anyhow::Result<(u8, Vec<VoterWithCredits>, Vec<VoterWithCredits>)> {
+) -> anyhow::Result<(u8, Vec<Voter>, Vec<Voter>)> {
     let validator = Validator::new(db, prev_header, provisioners);
     validator.execute_checks(header, false).await
 }

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -10,8 +10,7 @@ use async_trait::async_trait;
 use dusk_consensus::commons::{ConsensusError, RoundUpdate, TimeoutSet};
 use dusk_consensus::consensus::Consensus;
 use dusk_consensus::operations::{
-    self, CallParams, Error, Operations, Output, VerificationOutput,
-    VoterWithCredits,
+    self, CallParams, Error, Operations, Output, VerificationOutput, Voter,
 };
 use dusk_consensus::queue::MsgRegistry;
 use dusk_consensus::user::provisioners::ContextProvisioners;
@@ -87,7 +86,7 @@ impl Task {
         db: &Arc<RwLock<D>>,
         vm: &Arc<RwLock<VM>>,
         base_timeout: TimeoutSet,
-        voters: Vec<VoterWithCredits>,
+        voters: Vec<Voter>,
     ) {
         let current = provisioners_list.to_current();
         let consensus_task = Consensus::new(
@@ -248,7 +247,7 @@ impl<DB: database::DB, VM: vm::VMExecution> Operations for Executor<DB, VM> {
         &self,
         candidate_header: &Header,
         disable_winning_att_check: bool,
-    ) -> Result<(u8, Vec<VoterWithCredits>, Vec<VoterWithCredits>), Error> {
+    ) -> Result<(u8, Vec<Voter>, Vec<Voter>), Error> {
         let validator = Validator::new(
             self.db.clone(),
             &self.tip_header,
@@ -277,7 +276,7 @@ impl<DB: database::DB, VM: vm::VMExecution> Operations for Executor<DB, VM> {
     async fn verify_state_transition(
         &self,
         blk: &Block,
-        voters: &[VoterWithCredits],
+        voters: &[Voter],
     ) -> Result<VerificationOutput, dusk_consensus::operations::Error> {
         info!("verifying state");
 

--- a/node/src/chain/header_validation.rs
+++ b/node/src/chain/header_validation.rs
@@ -173,12 +173,6 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
             return Ok(vec![]);
         }
 
-        let prev_block_seed = self.db.read().await.view(|v| {
-            v.fetch_block_header(&self.prev_header.prev_block_hash)?
-                .ok_or_else(|| anyhow::anyhow!("Header not found"))
-                .map(|h| h.seed)
-        })?;
-
         let cert_result = candidate_block.prev_block_cert.result;
         let prev_block_hash = candidate_block.prev_block_hash;
 
@@ -189,6 +183,12 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
                 "Invalid result for previous block hash: {cert_result:?}"
             ),
         }
+
+        let prev_block_seed = self.db.read().await.view(|v| {
+            v.fetch_block_header(&self.prev_header.prev_block_hash)?
+                .ok_or_else(|| anyhow::anyhow!("Header not found"))
+                .map(|h| h.seed)
+        })?;
 
         let (_, _, voters) = verify_att(
             &candidate_block.prev_block_cert,

--- a/node/src/chain/header_validation.rs
+++ b/node/src/chain/header_validation.rs
@@ -9,7 +9,7 @@ use crate::database::Ledger;
 use anyhow::anyhow;
 use dusk_bytes::Serializable;
 use dusk_consensus::config::MINIMUM_BLOCK_TIME;
-use dusk_consensus::operations::VoterWithCredits;
+use dusk_consensus::operations::Voter;
 use dusk_consensus::quorum::verifiers;
 use dusk_consensus::quorum::verifiers::QuorumResult;
 use dusk_consensus::user::committee::{Committee, CommitteeSet};
@@ -63,7 +63,7 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
         &self,
         candidate_block: &ledger::Header,
         disable_winner_att_check: bool,
-    ) -> anyhow::Result<(u8, Vec<VoterWithCredits>, Vec<VoterWithCredits>)>
+    ) -> anyhow::Result<(u8, Vec<Voter>, Vec<Voter>)>
     {
         self.verify_basic_fields(candidate_block).await?;
         let prev_block_voters =
@@ -168,7 +168,7 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
     pub async fn verify_prev_block_cert(
         &self,
         candidate_block: &'a ledger::Header,
-    ) -> anyhow::Result<Vec<VoterWithCredits>> {
+    ) -> anyhow::Result<Vec<Voter>> {
         if self.prev_header.height == 0 {
             return Ok(vec![]);
         }
@@ -252,7 +252,7 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
     pub async fn verify_success_att(
         &self,
         candidate_block: &'a ledger::Header,
-    ) -> anyhow::Result<Vec<VoterWithCredits>> {
+    ) -> anyhow::Result<Vec<Voter>> {
         let (_, _, voters) = verify_att(
             &candidate_block.att,
             candidate_block.get_consensus_header(),
@@ -272,7 +272,7 @@ impl<'a, DB: database::DB> Validator<'a, DB> {
         blk: &'a ledger::Header,
         provisioners: &Provisioners,
         prev_block_seed: Seed,
-    ) -> anyhow::Result<Vec<VoterWithCredits>> {
+    ) -> anyhow::Result<Vec<Voter>> {
         let (_, _, voters) = verify_att(
             &blk.att,
             blk.to_consensus_header(),
@@ -332,7 +332,7 @@ pub async fn verify_att(
     consensus_header: ConsensusHeader,
     curr_seed: Signature,
     curr_eligible_provisioners: &Provisioners,
-) -> anyhow::Result<(QuorumResult, QuorumResult, Vec<VoterWithCredits>)> {
+) -> anyhow::Result<(QuorumResult, QuorumResult, Vec<Voter>)> {
     let committee = RwLock::new(CommitteeSet::new(curr_eligible_provisioners));
 
     let mut result = (QuorumResult::default(), QuorumResult::default());
@@ -402,7 +402,7 @@ pub async fn verify_att(
 }
 
 /// Merges two committees into a vector
-fn merge_committees(a: &Committee, b: &Committee) -> Vec<VoterWithCredits> {
+fn merge_committees(a: &Committee, b: &Committee) -> Vec<Voter> {
     let mut members = a.members().clone();
     for (key, value) in b.members() {
         // Keeps track of the number of occurrences for each member.

--- a/node/src/vm.rs
+++ b/node/src/vm.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_consensus::operations::VoterWithCredits;
+use dusk_consensus::operations::Voter;
 use dusk_consensus::{
     operations::{CallParams, VerificationOutput},
     user::{provisioners::Provisioners, stake::Stake},
@@ -29,13 +29,13 @@ pub trait VMExecution: Send + Sync + 'static {
     fn verify_state_transition(
         &self,
         blk: &Block,
-        voters: Option<&[VoterWithCredits]>,
+        voters: Option<&[Voter]>,
     ) -> anyhow::Result<VerificationOutput>;
 
     fn accept(
         &self,
         blk: &Block,
-        voters: Option<&[VoterWithCredits]>,
+        voters: Option<&[Voter]>,
     ) -> anyhow::Result<(Vec<SpentTransaction>, VerificationOutput)>;
 
     fn finalize_state(

--- a/rusk/src/lib/chain/rusk.rs
+++ b/rusk/src/lib/chain/rusk.rs
@@ -20,9 +20,7 @@ use dusk_consensus::config::{
     validation_committee_quorum, validation_extra,
     RATIFICATION_COMMITTEE_CREDITS, VALIDATION_COMMITTEE_CREDITS,
 };
-use dusk_consensus::operations::{
-    CallParams, VerificationOutput, VoterWithCredits,
-};
+use dusk_consensus::operations::{CallParams, VerificationOutput, Voter};
 use execution_core::bytecode::Bytecode;
 use execution_core::transfer::ContractDeploy;
 use execution_core::{
@@ -219,7 +217,7 @@ impl Rusk {
         generator: &BlsPublicKey,
         txs: &[Transaction],
         slashing: Vec<Slash>,
-        voters: Option<&[VoterWithCredits]>,
+        voters: Option<&[Voter]>,
     ) -> Result<(Vec<SpentTransaction>, VerificationOutput)> {
         let session = self.session(block_height, None)?;
 
@@ -250,7 +248,7 @@ impl Rusk {
         txs: Vec<Transaction>,
         consistency_check: Option<VerificationOutput>,
         slashing: Vec<Slash>,
-        voters: Option<&[VoterWithCredits]>,
+        voters: Option<&[Voter]>,
     ) -> Result<(Vec<SpentTransaction>, VerificationOutput)> {
         let session = self.session(block_height, None)?;
 
@@ -439,7 +437,7 @@ fn accept(
     generator: &BlsPublicKey,
     txs: &[Transaction],
     slashing: Vec<Slash>,
-    voters: Option<&[VoterWithCredits]>,
+    voters: Option<&[Voter]>,
     gas_per_deploy_byte: Option<u64>,
 ) -> Result<(
     Vec<SpentTransaction>,

--- a/rusk/src/lib/chain/rusk.rs
+++ b/rusk/src/lib/chain/rusk.rs
@@ -682,8 +682,6 @@ fn reward_slash_and_update_root(
         return Err(InvalidCreditsCount(block_height, 0));
     }
 
-    let credit_reward = voters_reward / 64 * 2;
-
     let r = session.call::<_, ()>(
         STAKE_CONTRACT,
         "reward",
@@ -718,6 +716,10 @@ fn reward_slash_and_update_root(
         extra_reward = generator_curr_extra_reward,
         credits,
     );
+
+    let credit_reward = voters_reward
+        / (VALIDATION_COMMITTEE_CREDITS + RATIFICATION_COMMITTEE_CREDITS)
+            as u64;
 
     for (to_voter, credits) in voters.unwrap_or_default() {
         let voter = to_voter.inner();

--- a/rusk/src/lib/chain/rusk.rs
+++ b/rusk/src/lib/chain/rusk.rs
@@ -663,7 +663,7 @@ fn reward_slash_and_update_root(
     dusk_spent: Dusk,
     generator: &BlsPublicKey,
     slashing: Vec<Slash>,
-    voters: Option<&[(BlsPublicKey, usize)]>,
+    voters: Option<&[Voter]>,
 ) -> Result<Vec<Event>> {
     let (
         dusk_value,
@@ -713,25 +713,26 @@ fn reward_slash_and_update_root(
 
     debug!(
         event = "generator rewarded",
-        voter = to_bs58(generator),
+        generator = to_bs58(generator),
         total_reward = generator_reward,
         extra_reward = generator_curr_extra_reward,
         credits,
     );
 
     for (to_voter, credits) in voters.unwrap_or_default() {
+        let voter = to_voter.inner();
         let voter_reward = *credits as u64 * credit_reward;
         let r = session.call::<_, ()>(
             STAKE_CONTRACT,
             "reward",
-            &(*to_voter, voter_reward),
+            &(*voter, voter_reward),
             u64::MAX,
         )?;
         events.extend(r.events);
 
         debug!(
             event = "validator of prev block rewarded",
-            voter = to_bs58(to_voter),
+            voter = to_bs58(voter),
             credits = *credits,
             reward = voter_reward
         )

--- a/rusk/src/lib/chain/vm.rs
+++ b/rusk/src/lib/chain/vm.rs
@@ -9,9 +9,7 @@ mod query;
 use tracing::info;
 
 use dusk_bytes::DeserializableSlice;
-use dusk_consensus::operations::{
-    CallParams, VerificationOutput, VoterWithCredits,
-};
+use dusk_consensus::operations::{CallParams, VerificationOutput, Voter};
 use dusk_consensus::user::provisioners::Provisioners;
 use dusk_consensus::user::stake::Stake;
 use execution_core::{
@@ -46,7 +44,7 @@ impl VMExecution for Rusk {
     fn verify_state_transition(
         &self,
         blk: &Block,
-        voters: Option<&[VoterWithCredits]>,
+        voters: Option<&[Voter]>,
     ) -> anyhow::Result<VerificationOutput> {
         info!("Received verify_state_transition request");
         let generator = blk.header().generator_bls_pubkey;
@@ -72,7 +70,7 @@ impl VMExecution for Rusk {
     fn accept(
         &self,
         blk: &Block,
-        voters: Option<&[VoterWithCredits]>,
+        voters: Option<&[Voter]>,
     ) -> anyhow::Result<(Vec<SpentTransaction>, VerificationOutput)> {
         info!("Received accept request");
         let generator = blk.header().generator_bls_pubkey;


### PR DESCRIPTION
Rename:
   - `verify_block_att` to `verify_att`
   - `VoterWithCredit` to `Voter`

Add:
   - `to_consensus_header` method for `Header`
   - `to_voters` method for `Cluster<PublicKey>`
   - `get_step_voters`
   - `get_step_committee`
   - `merge_voters`

Remove: 
   - `verify_quorum`
   - `verify_success_att`
   - `merge_committees`

Refactor:
   - `get_voters` is modified to only return voters, without re-verifying the attestation
   - `verify_att` is modified to get a `consensus_header` parameter
   - `verify_att` is modified to checks the expected result
   - `Voter` is modified to be `(PublicKey, usize)` to ease its handling
      - `reward_slash_and_update_root` is updated as a consequence

Bugfixes:
   - fix `verify_att` to correctly return the set of voters, instead of the whole committees