### PR TITLE
Add BLS signature cache

### DIFF
--- a/rusk-abi/CHANGELOG.md
+++ b/rusk-abi/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Memoize the `verify_bls` function
 - Memoize the `verify_proof` function [#1228]
 - New ABIs: `owner_raw`, `self_owner_raw` [#1710]
 

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -25,7 +25,7 @@ execution-core = { version = "0.1.0", path = "../execution-core" }
 # These are patches since these crates don't seem to like semver.
 rkyv = { version = "=0.7.39", default-features = false, features = ["size_32"] }
 
-lru = "0.12"
+lru = { version = "0.12", optional = true }
 
 [dev-dependencies]
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
@@ -44,8 +44,8 @@ dlmalloc = ["piecrust-uplink/dlmalloc"]
 
 # These are the features available for when one wishes to use `rusk-abi` as a
 # host.
-host = ["piecrust"]
-host_debug = ["piecrust/debug"]
+host = ["piecrust", "lru"]
+host_debug = ["piecrust/debug", "lru"]
 
 [[test]]
 name = "test-rusk-abi"

--- a/rusk-abi/src/host/cache.rs
+++ b/rusk-abi/src/host/cache.rs
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::env;
+use std::num::NonZeroUsize;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use lru::LruCache;
+
+macro_rules! define_cache {
+    ($get_func:ident, $put_func:ident, $cache_func:ident, $type:ty, $size:literal, $var:literal) => {
+        /// Gets an entry out of the cache. Returns `None` if there is no
+        /// element in the cache. `Some` signifies that there is a
+        /// cache element.
+        pub fn $get_func(hash: [u8; blake2b_simd::OUTBYTES]) -> Option<bool> {
+            // SAFETY: the closure never panics
+            unsafe { $cache_func(|mut cache| cache.get(&hash).copied()) }
+        }
+
+        /// Put an entry into the cache.
+        pub fn $put_func(hash: [u8; blake2b_simd::OUTBYTES], is_valid: bool) {
+            // SAFETY: The closure never panics
+            unsafe {
+                $cache_func(|mut cache| {
+                    cache.put(hash, is_valid);
+                });
+            }
+        }
+
+        /// A simple LRU cache.
+        ///
+        /// # Safety
+        /// `f` should *never* panic, otherwise we poison the Mutex.
+        unsafe fn $cache_func<T, F>(f: F) -> T
+        where
+            F: FnOnce(
+                MutexGuard<LruCache<[u8; blake2b_simd::OUTBYTES], $type>>,
+            ) -> T,
+        {
+            const DEFAULT_SIZE: usize = $size;
+
+            static CACHE: OnceLock<
+                Mutex<LruCache<[u8; blake2b_simd::OUTBYTES], $type>>,
+            > = OnceLock::new();
+
+            CACHE
+                .get_or_init(|| {
+                    let mut cache_size = None;
+
+                    if let Ok(s) = env::var($var) {
+                        cache_size = s.parse().ok();
+                    }
+
+                    let mut cache_size = cache_size.unwrap_or(DEFAULT_SIZE);
+                    if cache_size == 0 {
+                        cache_size = DEFAULT_SIZE;
+                    }
+
+                    Mutex::new(LruCache::new(
+                        NonZeroUsize::new(cache_size).unwrap(),
+                    ))
+                })
+                .lock()
+                .map(f)
+                .unwrap()
+        }
+    };
+}
+
+define_cache!(
+    get_plonk_verification,
+    put_plonk_verification,
+    with_plonk_cache,
+    bool,
+    512,
+    "RUSK_ABI_PLONK_CACHE_SIZE"
+);
+define_cache!(
+    get_bls_verification,
+    put_bls_verification,
+    with_bls_cache,
+    bool,
+    512,
+    "RUSK_ABI_BLS_CACHE_SIZE"
+);


### PR DESCRIPTION
Cache definition placed in a different file, and abstracted away with a macro, allowing one to generate different cache types according to in-code parameters.

This macro is then leveraged to generate both Plonk proof and BLS signature caches, which are then subsequently used in our code.

To slightly improve the implementation of both, the hash used as a cache key is now computed using the argument buffer contents, as opposed to the deserialized parameters. This allows for a cleaner and more performant implementation.

See-also: #1984