### PR TITLE
Fix "freed while in use"

### DIFF
--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -116,7 +116,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
             tokio::select! {
                 biased;
                 // Receives results from the upper layer
-                recv = &mut result_chan.recv() => {
+                recv = result_chan.recv() => {
                     match recv? {
                         Err(ConsensusError::Canceled(round)) => {
                             info!(event = "consensus canceled", round);
@@ -186,7 +186,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
                     }
                 },
                 // Re-routes messages originated from Consensus (upper) layer to the network layer.
-                recv = &mut outbound_chan.recv() => {
+                recv = outbound_chan.recv() => {
                     let msg = recv?;
 
                     // Handle quorum messages from Consensus layer.

--- a/rusk-prover/Cargo.toml
+++ b/rusk-prover/Cargo.toml
@@ -24,7 +24,7 @@ phoenix-circuits = { version = "0.2.1-rc", optional = true }
 
 [dev-dependencies]
 hex = "0.4"
-tokio = { version = "1.17.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 rand = "0.8"
 
 [features]

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -13,7 +13,7 @@ name = "rusk"
 path = "src/bin/main.rs"
 
 [dependencies]
-tokio = { version = "1.15", features = ["rt-multi-thread", "fs", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "fs", "macros"] }
 futures-util = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", features = [


### PR DESCRIPTION
The `tokio::select!` macro seems to have broken its syntax, even if not reflected in the `tokio` version. This PR fixes our syntax to comply with `tokio`.

We also ensure only one version of `tokio` is included at a time, avoiding longer compilation times.