### PR TITLE
Add doc cmd to Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,18 @@ clippy: ## Run clippy
 	$(MAKE) -C ./node $@
 	$(MAKE) -C ./rusk/ $@
 
+doc: ## Run doc gen
+	$(MAKE) -j -C ./circuits $@
+	$(MAKE) -C ./consensus $@
+	$(MAKE) -j1 -C ./contracts $@
+	$(MAKE) -C ./node $@
+	$(MAKE) -C ./node-data $@
+	$(MAKE) -C ./rusk/ $@
+	$(MAKE) -C ./rusk-abi $@
+	$(MAKE) -C ./rusk-profile $@
+	$(MAKE) -C ./rusk-prover/ $@
+	$(MAKE) -C ./rusk-recovery $@
+
 run: keys state web-wallet ## Run the server
 	$(MAKE) -C ./rusk/ $@
 

--- a/circuits/Makefile
+++ b/circuits/Makefile
@@ -12,6 +12,8 @@ test: ## Run all the tests for the circuits
 
 clippy: $(SUBDIRS) ## Run clippy
 
+doc: $(SUBDIRS) ## Run doc gen
+
 $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 

--- a/circuits/license/Makefile
+++ b/circuits/license/Makefile
@@ -12,4 +12,7 @@ test: ## Run the transfer circuits tests
 clippy: ## Run clippy
 	@cargo clippy --all-features --release -- -D warnings
 
+doc: ## Run doc gen
+	@cargo doc --release
+
 .PHONY: all test help

--- a/consensus/Makefile
+++ b/consensus/Makefile
@@ -18,6 +18,9 @@ test: ## Run tests
 clippy: ## Run clippy
 	@cargo clippy --all-features --release -- -D warnings
 
+doc: ## Run doc gen
+	@cargo doc --release
+
 clean:
 	@cargo clean
 

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -13,6 +13,8 @@ wasm: $(SUBDIRS) ## Generate the WASM for all the contracts
 
 clippy: $(SUBDIRS) ## Run clippy
 
+doc: $(SUBDIRS) ## Run doc gen
+
 $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 

--- a/contracts/alice/Makefile
+++ b/contracts/alice/Makefile
@@ -11,8 +11,11 @@ wasm: ## Generate the optimized WASM for the contract given
     		-Z build-std=core,alloc,panic_abort \
     		-Z build-std-features=panic_immediate_abort \
     		--target wasm32-unknown-unknown
-clippy: 
 
 test:
+
+clippy: 
+
+doc:
 
 .PHONY: all test wasm

--- a/contracts/bob/Makefile
+++ b/contracts/bob/Makefile
@@ -16,4 +16,6 @@ test:
 
 clippy: 
 
+doc:
+
 .PHONY: all test wasm

--- a/contracts/host_fn/Makefile
+++ b/contracts/host_fn/Makefile
@@ -16,4 +16,6 @@ test:
 
 clippy: 
 
+doc:
+
 .PHONY: all test wasm

--- a/contracts/license/Makefile
+++ b/contracts/license/Makefile
@@ -28,4 +28,7 @@ clippy: ## Run clippy
 	@cargo clippy --all-features --release -- -D warnings
 	@cargo clippy -Z build-std=core,alloc --release --target wasm32-unknown-unknown -- -D warnings
 
+doc: ## Run doc gen
+	@cargo doc --release
+
 .PHONY: all check test wasm help

--- a/contracts/stake/Makefile
+++ b/contracts/stake/Makefile
@@ -28,4 +28,7 @@ clippy: ## Run clippy
 	@cargo clippy --all-features --release -- -D warnings
 	@cargo clippy -Z build-std=core,alloc --release --target wasm32-unknown-unknown -- -D warnings
 
+doc: ## Run doc gen
+	@cargo doc --release
+
 .PHONY: all check test wasm help

--- a/contracts/transfer/Makefile
+++ b/contracts/transfer/Makefile
@@ -28,4 +28,7 @@ clippy: ## Run clippy
 	@cargo clippy --all-features --release -- -D warnings
 	@cargo clippy -Z build-std=core,alloc --release --target wasm32-unknown-unknown -- -D warnings
 
+doc: ## Run doc gen
+	@cargo doc --release
+
 .PHONY: all check test wasm help

--- a/node-data/Makefile
+++ b/node-data/Makefile
@@ -10,4 +10,7 @@ clean:
 clippy: ## Run clippy
 	@cargo clippy --all-features --release -- -D warnings
 
+doc: ## Run doc gen
+	@cargo doc --release
+
 .PHONY: test help clean

--- a/node/Makefile
+++ b/node/Makefile
@@ -17,4 +17,7 @@ clippy: ## Run clippy
 	@cargo clippy --all-features --release -- -D warnings
 	@cargo check --benches
 
+doc: ## Run doc gen
+	@cargo doc --release
+
 .PHONY: test help binary clean

--- a/rusk-abi/Makefile
+++ b/rusk-abi/Makefile
@@ -11,4 +11,7 @@ clippy: ## Run clippy
 	@cargo clippy --release -- -D warnings
 	@cargo clippy --no-default-features --features=host --release -- -D warnings
 
+doc: ## Run doc gen
+	@cargo doc --release
+
 .PHONY: all help test

--- a/rusk-profile/Makefile
+++ b/rusk-profile/Makefile
@@ -12,6 +12,9 @@ test: $(SUBDIRS)
 clippy: ## Run clippy
 	@cargo clippy --release -- -D warnings
 
+doc: ## Run doc gen
+	@cargo doc --release
+
 $(SUBDIRS):
 	$(MAKE) -C $@
 

--- a/rusk-prover/Makefile
+++ b/rusk-prover/Makefile
@@ -12,4 +12,7 @@ clippy: ## Run clippy
 	@cargo clippy --release -- -D warnings
 	@cargo clippy --release --no-default-features -- -D warnings
 
+doc: ## Run doc gen
+	@cargo doc --release
+
 .PHONY: all help test clippy

--- a/rusk-recovery/Makefile
+++ b/rusk-recovery/Makefile
@@ -14,4 +14,7 @@ clippy: ## Run clippy
 	@cargo clippy --release --no-default-features --features state -- -D warnings
 	@cargo clippy --release --no-default-features --features keys -- -D warnings
 
+doc: ## Run doc gen
+	@cargo doc --release
+
 .PHONY: test clippy help

--- a/rusk/Makefile
+++ b/rusk/Makefile
@@ -39,6 +39,9 @@ clippy: ## Run clippy
 		-- -D warnings
 	@cargo check --benches --features testwallet
 
+doc: ## Run doc gen
+	@cargo doc --release
+
 build: ## Build rusk binary
 	@cargo build --release
 


### PR DESCRIPTION
Resolves #2008

This makes it possible to call `make doc` in the root dir to run the doc command.

At some point, however, we should find out what the problem is with cargo not working in the base directory. It may be related to a dependency problem with having std & no_std at the same time.