### PR TITLE
web-wallet: Added gas settings validation (Unstake / Widthdraw Rewards flows)

### DIFF
--- a/web-wallet/CHANGELOG.md
+++ b/web-wallet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added gas settings validation on Unstake / Widthdraw Rewards flows [#2000]
+
 ### Changed
 
 - Update font-display to swap for custom fonts to improve performance [#2026]
@@ -227,6 +231,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1901]: https://github.com/dusk-network/rusk/issues/1901
 [#1922]: https://github.com/dusk-network/rusk/issues/1922
 [#2026]: https://github.com/dusk-network/rusk/issues/2026
+[#2000]: https://github.com/dusk-network/rusk/issues/2000
 
 <!-- VERSIONS -->
 

--- a/web-wallet/src/lib/components/Stake/Stake.svelte
+++ b/web-wallet/src/lib/components/Stake/Stake.svelte
@@ -263,7 +263,7 @@
         ? { action: resetOperation, disabled: false }
         : undefined}
       nextButton={{
-        disabled: stakeAmount === 0,
+        disabled: flow === "stake" ? stakeAmount === 0 : !isGasValid,
         icon: {
           path:
             flow === "stake" ? mdiDatabaseOutline : mdiDatabaseArrowDownOutline,


### PR DESCRIPTION
Resolves #2000

**Visuals:**
<img width="628" alt="Screenshot 2024-07-25 at 17 39 10" src="https://github.com/user-attachments/assets/9600c927-4c90-44cd-b180-30f6e9224975">
<img width="622" alt="Screenshot 2024-07-25 at 17 39 05" src="https://github.com/user-attachments/assets/c6c62812-54a7-4985-9c71-4c490af76648">
<img width="631" alt="Screenshot 2024-07-25 at 17 38 55" src="https://github.com/user-attachments/assets/8e6da9bc-f058-45dd-98f6-23bbd7a8f11e">
