### PR TITLE
Allow converting between Phoenix and Moonlight Dusk

### DIFF
--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -41,6 +41,11 @@ unsafe fn withdraw(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |arg| STATE.withdraw(arg))
 }
 
+#[no_mangle]
+unsafe fn convert(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |arg| STATE.convert(arg))
+}
+
 // Queries
 
 #[no_mangle]


### PR DESCRIPTION
We add the `convert` function to the contract, leveraging the deposit and withdrawal capabilities to atomically swap Dusk between the Phoenix and Moonlight models.

The function is meant to be called directly - meaning as the first and only call - and takes a `Withdraw` as an argument, such that the user can prove ownership of either the account or address being deposited to.

Resolves: #1994