### PR TITLE
Use incremental nonces

### DIFF
--- a/contracts/stake/src/state.rs
+++ b/contracts/stake/src/state.rs
@@ -84,9 +84,14 @@ impl StakeState {
             panic!("Can't stake twice for the same key");
         }
 
+        // NOTE: exhausting the nonce is nearly impossible, since it
+        //       requires performing more than 18 quintillion stake operations.
+        //       Since this number is so large, we also skip overflow checks.
+        let incremented_nonce = loaded_stake.nonce + 1;
+
         // check signature and nonce used are correct
-        if nonce <= loaded_stake.nonce {
-            panic!("Replayed nonce");
+        if nonce != incremented_nonce {
+            panic!("Invalid nonce");
         }
 
         let digest = stake.signature_message().to_vec();

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -382,8 +382,14 @@ impl TransferState {
                 if total_value > account.balance {
                     panic!("Account doesn't have enough funds");
                 }
-                if payload.nonce <= account.nonce {
-                    panic!("Replayed nonce");
+
+                // NOTE: exhausting the nonce is nearly impossible, since it
+                //       requires performing more than 18 quintillion
+                //       transactions. Since this number is so large, we also
+                //       skip overflow checks.
+                let incremented_nonce = account.nonce + 1;
+                if payload.nonce != incremented_nonce {
+                    panic!("Invalid nonce");
                 }
 
                 account.balance -= total_value;

--- a/execution-core/src/stake.rs
+++ b/execution-core/src/stake.rs
@@ -73,13 +73,12 @@ impl Stake {
         self.value
     }
 
-    /// Nonce used for replay protection. Nonces are strictly increasing,
-    /// meaning that once a transaction has been settled, only a higher
-    /// nonce can be used.
+    /// Nonce used for replay protection. Nonces are strictly increasing and
+    /// incremental, meaning that for a transaction to be valid, only the
+    /// current nonce + 1 can be used.
     ///
     /// The current nonce is queryable via the stake contract in the form of
-    /// [`StakeData`] and best practice is to use `nonce + 1` for a single
-    /// transaction.
+    /// [`StakeData`].
     #[must_use]
     pub fn nonce(&self) -> u64 {
         self.nonce
@@ -206,12 +205,12 @@ pub struct StakeData {
     pub amount: Option<StakeAmount>,
     /// The reward for participating in consensus.
     pub reward: u64,
-    /// Nonce used for replay protection. Nonces are strictly increasing,
-    /// meaning that once a transaction has been settled, only a higher
-    /// nonce can be used.
+    /// Nonce used for replay protection. Nonces are strictly increasing and
+    /// incremental, meaning that for a transaction to be valid, only the
+    /// current nonce + 1 can be used.
     ///
-    /// The current nonce is queryable via the stake contract and best
-    /// practice is to use `nonce + 1` for a single transaction.
+    /// The current nonce is queryable via the stake contract in the form of
+    /// [`StakeData`].
     pub nonce: u64,
     /// Faults
     pub faults: u8,

--- a/execution-core/src/transfer/transaction/moonlight.rs
+++ b/execution-core/src/transfer/transaction/moonlight.rs
@@ -179,12 +179,11 @@ pub struct Payload {
     pub gas_limit: u64,
     /// Price for each unit of gas.
     pub gas_price: u64,
-    /// Nonce used for replay protection. Nonces are strictly increasing,
-    /// meaning that once a transaction has been settled, only a higher
-    /// nonce can be used.
+    /// Nonce used for replay protection. Nonces are strictly increasing and
+    /// incremental, meaning that for a transaction to be valid, only the
+    /// current nonce + 1 can be used.
     ///
-    /// The current nonce is queryable via the transfer contract and best
-    /// practice is to use `nonce + 1` for a single transaction.
+    /// The current nonce is queryable via the transfer contract.
     pub nonce: u64,
     /// Data to do a contract call or deployment.
     pub exec: Option<ContractExec>,


### PR DESCRIPTION
Incremental nonces are meant to increase by 1 on every operation performed. As opposed to "strictly increasing" where any nonce larger than the one present in the state is valid, with incremental nonces only the one present in the state +1 is valid.

We change the genesis contracts - both the transfer contract with Moonlight, and the stake contract with the `stake` operation -  to make use of incremental nonces. This avoids situations where clients could exhaust the bit space in a single transaction, either knowingly or inadvertently locking an account from ever being used again.

Resolves: #2007

