### PR TITLE
Update to `piecrust@0.23`

### DIFF
--- a/contracts/alice/src/lib.rs
+++ b/contracts/alice/src/lib.rs
@@ -17,11 +17,6 @@ mod wasm {
     use super::*;
     use state::Alice;
 
-    use rusk_abi::ContractId;
-
-    #[no_mangle]
-    static SELF_ID: ContractId = ContractId::uninitialized();
-
     static mut STATE: Alice = state::Alice;
 
     #[no_mangle]

--- a/contracts/host_fn/src/lib.rs
+++ b/contracts/host_fn/src/lib.rs
@@ -16,10 +16,6 @@ use execution_core::{
     BlsPublicKey, BlsScalar, BlsSignature, PublicKey, SchnorrPublicKey,
     SchnorrSignature,
 };
-use rusk_abi::ContractId;
-
-#[no_mangle]
-static SELF_ID: ContractId = ContractId::uninitialized();
 
 static mut STATE: HostFnTest = HostFnTest;
 

--- a/contracts/license/src/lib.rs
+++ b/contracts/license/src/lib.rs
@@ -38,11 +38,7 @@ pub const fn verifier_data_license_circuit() -> &'static [u8] {
 mod wasm {
     use super::*;
 
-    use rusk_abi::ContractId;
     use state::LicenseContractState;
-
-    #[no_mangle]
-    static SELF_ID: ContractId = ContractId::uninitialized();
 
     static mut STATE: LicenseContractState = LicenseContractState::new();
 

--- a/contracts/stake/src/lib.rs
+++ b/contracts/stake/src/lib.rs
@@ -18,11 +18,6 @@ use state::StakeState;
 /// The minimum amount of Dusk one can stake.
 pub const MINIMUM_STAKE: Dusk = dusk(1_000.0);
 
-use rusk_abi::ContractId;
-
-#[no_mangle]
-static SELF_ID: ContractId = ContractId::uninitialized();
-
 static mut STATE: StakeState = StakeState::new();
 
 // Transactions
@@ -135,8 +130,9 @@ unsafe fn set_burnt_amount(arg_len: u32) -> u32 {
 /// # Panics
 /// When the `caller` is not [`rusk_abi::TRANSFER_CONTRACT`].
 fn assert_transfer_caller() {
-    if rusk_abi::caller() != rusk_abi::TRANSFER_CONTRACT {
-        panic!("Can only be called from the transfer contract");
+    const PANIC_MSG: &str = "Can only be called from the transfer contract";
+    if rusk_abi::caller().expect(PANIC_MSG) != rusk_abi::TRANSFER_CONTRACT {
+        panic!("{PANIC_MSG}");
     }
 }
 
@@ -146,7 +142,7 @@ fn assert_transfer_caller() {
 /// # Panics
 /// When the `caller` is not "uninitialized".
 fn assert_external_caller() {
-    if !rusk_abi::caller().is_uninitialized() {
+    if rusk_abi::caller().is_some() {
         panic!("Can only be called from the outside the VM");
     }
 }

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -17,8 +17,8 @@ dusk-bytes = "0.1"
 bytecheck = { version = "0.6", default-features = false }
 dusk-plonk = { version = "0.19", default-features = false, features = ["rkyv-impl", "alloc"] }
 
-piecrust-uplink = { version = "0.15" }
-piecrust = { version = "0.22", optional = true }
+piecrust-uplink = { version = "0.16" }
+piecrust = { version = "0.23", optional = true }
 
 execution-core = { version = "0.1.0", path = "../execution-core" }
 


### PR DESCRIPTION
We update the version of `piecrust` to `0.23` and of `piecrust-uplink` to `0.16`. This allows us to leverage the clearer `caller` API.

We also take the liberty to clean up the errant `SELF_ID` export from the contracts' code since it is no longer required.