### PR TITLE
node: refactor `LongLivedService` trait

### DIFF
--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -26,6 +26,7 @@ pub use header_validation::verify_att;
 use node_data::ledger::{to_str, BlockWithLabel, Label};
 use node_data::message::AsyncQueue;
 use node_data::message::{Payload, Topics};
+use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -61,7 +62,9 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
         db: Arc<RwLock<DB>>,
         vm: Arc<RwLock<VM>>,
     ) -> anyhow::Result<()> {
-        let tip = Self::load_tip(db.clone(), vm.clone()).await?;
+        let tip =
+            Self::load_tip(db.read().await.deref(), vm.read().await.deref())
+                .await?;
 
         let state_hash = tip.inner().header().state_hash;
         let provisioners_list = vm.read().await.get_provisioners(state_hash)?;
@@ -72,8 +75,8 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
             tip,
             provisioners_list,
             db,
-            network.clone(),
-            vm.clone(),
+            network,
+            vm,
         )
         .await?;
 
@@ -246,12 +249,9 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> ChainSrv<N, DB, VM> {
     /// Panics
     ///
     /// If register entry is read but block is not found.
-    async fn load_tip(
-        db: Arc<RwLock<DB>>,
-        vm: Arc<RwLock<VM>>,
-    ) -> Result<BlockWithLabel> {
-        let stored_block = db.read().await.update(|t| {
-            Ok(t.op_read(MD_HASH_KEY)?.and_then(|tip_hash| {
+    async fn load_tip(db: &DB, vm: &VM) -> Result<BlockWithLabel> {
+        let stored_block = db.view(|t| {
+            anyhow::Ok(t.op_read(MD_HASH_KEY)?.and_then(|tip_hash| {
                 t.fetch_block(&tip_hash[..])
                     .expect("block to be found if metadata is set")
             }))
@@ -260,8 +260,6 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> ChainSrv<N, DB, VM> {
         let block = match stored_block {
             Some(blk) => {
                 let (_, label) = db
-                    .read()
-                    .await
                     .view(|t| {
                         t.fetch_block_label_by_height(blk.header().height)
                     })?
@@ -272,9 +270,9 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> ChainSrv<N, DB, VM> {
             None => {
                 // Lack of register record means the loaded database is
                 // either malformed or empty.
-                let state = vm.read().await.get_state_root()?;
+                let state = vm.get_state_root()?;
                 let genesis_blk = genesis::generate_state(state);
-                db.write().await.update(|t| {
+                db.update(|t| {
                     // Persist genesis block
                     t.store_block(
                         genesis_blk.header(),

--- a/node/src/databroker.rs
+++ b/node/src/databroker.rs
@@ -93,15 +93,6 @@ impl DataBrokerSrv {
 impl<N: Network, DB: database::DB, VM: vm::VMExecution>
     LongLivedService<N, DB, VM> for DataBrokerSrv
 {
-    async fn initialize(
-        &mut self,
-        _network: Arc<RwLock<N>>,
-        _db: Arc<RwLock<DB>>,
-        _vm: Arc<RwLock<VM>>,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-
     async fn execute(
         &mut self,
         network: Arc<RwLock<N>>,

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -106,12 +106,15 @@ pub trait Network: Send + Sync + 'static {
 pub trait LongLivedService<N: Network, DB: database::DB, VM: vm::VMExecution>:
     Send + Sync
 {
+    #[allow(unused_variables)]
     async fn initialize(
         &mut self,
         network: Arc<RwLock<N>>,
         database: Arc<RwLock<DB>>,
         vm: Arc<RwLock<VM>>,
-    ) -> anyhow::Result<()>;
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
 
     async fn execute(
         &mut self,

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -133,16 +133,6 @@ pub trait LongLivedService<N: Network, DB: database::DB, VM: vm::VMExecution>:
         Ok(())
     }
 
-    async fn add_filter(
-        &self,
-        topic: u8,
-        filter_fn: BoxedFilter,
-        network: &Arc<RwLock<N>>,
-    ) -> anyhow::Result<()> {
-        network.write().await.add_filter(topic, filter_fn).await?;
-        Ok(())
-    }
-
     /// Returns service name.
     fn name(&self) -> &'static str;
 }

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -48,16 +48,6 @@ impl Default for MempoolSrv {
     }
 }
 
-pub struct TxFilter {}
-impl crate::Filter for TxFilter {
-    fn filter(&mut self, _msg: &Message) -> anyhow::Result<()> {
-        // TODO: Ensure transaction does not exist in the mempool state
-        // TODO: Ensure transaction does not exist in blockchain
-        // TODO: Check  Nullifier
-        Ok(())
-    }
-}
-
 #[async_trait]
 impl<N: Network, DB: database::DB, VM: vm::VMExecution>
     LongLivedService<N, DB, VM> for MempoolSrv
@@ -81,16 +71,6 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
             self,
             TOPICS,
             self.inbound.clone(),
-            &network,
-        )
-        .await?;
-
-        // Add a filter that will discard any transactions invalid to the actual
-        // mempool, blockchain state.
-        LongLivedService::<N, DB, VM>::add_filter(
-            self,
-            Topics::Tx.into(),
-            Box::new(TxFilter {}),
             &network,
         )
         .await?;

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -52,15 +52,6 @@ impl Default for MempoolSrv {
 impl<N: Network, DB: database::DB, VM: vm::VMExecution>
     LongLivedService<N, DB, VM> for MempoolSrv
 {
-    async fn initialize(
-        &mut self,
-        _network: Arc<RwLock<N>>,
-        _db: Arc<RwLock<DB>>,
-        _vm: Arc<RwLock<VM>>,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-
     async fn execute(
         &mut self,
         network: Arc<RwLock<N>>,

--- a/node/src/telemetry.rs
+++ b/node/src/telemetry.rs
@@ -29,15 +29,6 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
         "telemetry"
     }
 
-    async fn initialize(
-        &mut self,
-        _network: Arc<RwLock<N>>,
-        _db: Arc<RwLock<DB>>,
-        _vm: Arc<RwLock<VM>>,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-
     /// Initialize and spawn Prometheus Exporter and Recorder
     async fn execute(
         &mut self,


### PR DESCRIPTION
This is a refactor PR triggered while #2049 

- Remove (unused) TxFilter
- Add default empty `initialize` implementation for `LongLivedService`