### PR TITLE
Add benchmarks to CI

### DIFF
--- a/.github/workflows/rusk_ci.yml
+++ b/.github/workflows/rusk_ci.yml
@@ -75,3 +75,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
       - run: cargo fmt --all -- --check
+  benchmark:
+    needs: changes
+    if: needs.changes.outputs.run-ci == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/master'
+    name: Run Benchmarks
+    runs-on: core
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dsherret/rust-toolchain-file@v1      
+      - run: make bench
+      - name: Upload Benchmark Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: rusk-benchmark-results
+          path: ./target/criterion
+          retention-days: 14

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ doc: ## Run doc gen
 	$(MAKE) -C ./rusk-recovery $@
 	$(MAKE) -C ./wallet-core/ $@
 
+bench: keys wasm  ## Bench Rusk
+	$(MAKE) -C ./rusk bench
+
 run: keys state web-wallet ## Run the server
 	$(MAKE) -C ./rusk/ $@
 
@@ -79,4 +82,4 @@ COMPILER_VERSION=v0.2.0
 setup-compiler: ## Setup the Dusk Contract Compiler
 	@./scripts/setup-compiler.sh $(COMPILER_VERSION)
 
-.PHONY: all abi keys state wasm allcircuits contracts test run help rusk web-wallet setup-compiler
+.PHONY: all abi keys state wasm allcircuits contracts test bench run help rusk web-wallet setup-compiler

--- a/rusk/Makefile
+++ b/rusk/Makefile
@@ -48,6 +48,9 @@ build: ## Build rusk binary
 build-bench: ## Build the benchmarks
 	@cargo bench --features testwallet --no-run
 
+bench: ## Run the benchmarks
+	@cargo bench --features testwallet
+
 run:
 	@cargo r --release --bin rusk
 
@@ -66,4 +69,4 @@ recovery-state: ## Build network state
 		-- recovery-state \
 		--init $(INITFILE)
 
-.PHONY: test help clippy build build-bench recovery-keys recovery-state rusk
+.PHONY: test help clippy build build-bench bench recovery-keys recovery-state rusk


### PR DESCRIPTION
Resolves #1954 

This is both a good and a bad idea. The good part is that we can frequently check incremental improvements and regressions. I currently set the criterion report retention to 3 days, but that might be too short.

The bad idea about this implementation is that it clogs up CI for ~20 minutes. And the results can be affected by other runs. We can opt to limit the number of tests (1 tx, 5 tx, 10 tx, 50 tx, 100 tx), make it run only as a triggerable action or only run it on merge commits.