### PR TITLE
Re-define Majority and Supermajority

### DIFF
--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -60,6 +60,17 @@ pub fn ratification_extra() -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_majorities() {
+        assert_eq!(majority(4), 3);
+        assert_eq!(majority(11), 6);
+        assert_eq!(majority(99), 50);
+        assert_eq!(supermajority(3), 2);
+        assert_eq!(supermajority(9), 6);
+        assert_eq!(supermajority(51), 34);
+    }
+
     #[test]
     fn test_quorums() {
         assert_eq!(majority(VALIDATION_COMMITTEE_CREDITS), 33);

--- a/consensus/src/user/committee.rs
+++ b/consensus/src/user/committee.rs
@@ -8,7 +8,7 @@ use crate::user::provisioners::Provisioners;
 use crate::user::sortition;
 
 use super::cluster::Cluster;
-use crate::config;
+use crate::config::{majority, supermajority};
 use node_data::bls::{PublicKey, PublicKeyBytes};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
@@ -36,13 +36,10 @@ impl Committee {
     pub fn new(provisioners: &Provisioners, cfg: &sortition::Config) -> Self {
         // Generate committee using deterministic sortition.
         let extracted = provisioners.create_committee(cfg);
-        let committee_credits = cfg.committee_credits() as f64;
+        let committee_credits = cfg.committee_credits();
 
-        let super_majority = (committee_credits
-            * config::SUPERMAJORITY_THRESHOLD)
-            .ceil() as usize;
-        let majority =
-            (committee_credits * config::MAJORITY_THRESHOLD) as usize + 1;
+        let majority = majority(committee_credits);
+        let super_majority = supermajority(committee_credits);
 
         // Turn the raw vector into a hashmap where we map a pubkey to its
         // occurrences.

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -16,9 +16,9 @@ use tracing::{debug, info, warn};
 
 use dusk_bytes::{DeserializableSlice, Serializable};
 use dusk_consensus::config::{
-    ratification_committee_quorum, ratification_extra,
-    validation_committee_quorum, validation_extra,
-    RATIFICATION_COMMITTEE_CREDITS, VALIDATION_COMMITTEE_CREDITS,
+    ratification_extra, ratification_quorum, validation_extra,
+    validation_quorum, RATIFICATION_COMMITTEE_CREDITS,
+    VALIDATION_COMMITTEE_CREDITS,
 };
 use dusk_consensus::operations::{CallParams, VerificationOutput, Voter};
 use execution_core::{
@@ -773,7 +773,7 @@ fn calc_generator_extra_reward(
     let reward_per_quota = generator_extra_reward
         / (validation_extra() + ratification_extra()) as u64;
 
-    let sum = ratification_committee_quorum() + validation_committee_quorum();
+    let sum = ratification_quorum() + validation_quorum();
     credits.saturating_sub(sum as u64) * reward_per_quota
 }
 


### PR DESCRIPTION
Fix #2100

- Eliminate `MAJORITY_THRESHOLD` and `SUPERMAJORITY_THRESHOLD` constants
- Define `majority` and `supermajority` functions, which returns `floor(x/2)+1` and `ceil(x/2*3)` respectively

The new definitions eliminate the risk of wrong quorum values for some edge cases.