### PR TITLE
web-wallet: Resetting the wallet store should also abort the sync

### DIFF
--- a/web-wallet/src/lib/navigation/__tests__/logout.spec.js
+++ b/web-wallet/src/lib/navigation/__tests__/logout.spec.js
@@ -11,7 +11,6 @@ describe("logout", () => {
 
   afterEach(() => {
     gotoSpy.mockClear();
-    vi.mocked(walletStore.abortSync).mockClear();
     vi.mocked(walletStore.reset).mockClear();
   });
 
@@ -23,7 +22,6 @@ describe("logout", () => {
   it("should reset the wallet store and redirect the user to the homepage, if the logout is not forced", async () => {
     await navigation.logout(false);
 
-    expect(walletStore.abortSync).toHaveBeenCalledTimes(1);
     expect(walletStore.reset).toHaveBeenCalledTimes(1);
     expect(gotoSpy).toHaveBeenCalledTimes(1);
     expect(gotoSpy).toHaveBeenCalledWith("/");
@@ -32,7 +30,6 @@ describe("logout", () => {
   it("should redirect to `/forced-logout` if the logout is forced", async () => {
     await navigation.logout(true);
 
-    expect(walletStore.abortSync).toHaveBeenCalledTimes(1);
     expect(walletStore.reset).toHaveBeenCalledTimes(1);
     expect(gotoSpy).toHaveBeenCalledTimes(1);
     expect(gotoSpy).toHaveBeenCalledWith("/forced-logout");

--- a/web-wallet/src/lib/navigation/logout.js
+++ b/web-wallet/src/lib/navigation/logout.js
@@ -11,7 +11,6 @@ import { walletStore } from "$lib/stores";
  * @returns {ReturnType<goto>}
  */
 const logout = (isForced) => {
-  walletStore.abortSync();
   walletStore.reset();
 
   return goto(`/${isForced ? "forced-logout" : ""}`);


### PR DESCRIPTION
- The store update after the sync now checks if the sync is aborted
- Streamlined wallet store tests

Resolves #2156