### PR TITLE
Remove unused definitions

### DIFF
--- a/consensus/src/commons.rs
+++ b/consensus/src/commons.rs
@@ -139,7 +139,6 @@ impl From<BlsSigError> for ConsensusError {
 #[async_trait::async_trait]
 pub trait Database: Send + Sync {
     fn store_candidate_block(&mut self, b: Block);
-    fn delete_candidate_blocks(&mut self);
 }
 
 #[derive(Clone)]

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -161,7 +161,7 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
                 Phase::Proposal(proposal::step::ProposalStep::new(
                     executor.clone(),
                     db.clone(),
-                    proposal_handler.clone(),
+                    proposal_handler,
                 )),
                 Phase::Validation(validation::step::ValidationStep::new(
                     executor.clone(),
@@ -179,7 +179,6 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
             let mut iter_ctx = IterationCtx::new(
                 ru.round,
                 iter,
-                proposal_handler,
                 validation_handler,
                 ratification_handler,
                 ru.base_timeouts.clone(),

--- a/consensus/src/phase.rs
+++ b/consensus/src/phase.rs
@@ -29,7 +29,7 @@ macro_rules! await_phase {
 pub enum Phase<T: Operations, D: Database> {
     Proposal(proposal::step::ProposalStep<T, D>),
     Validation(validation::step::ValidationStep<T>),
-    Ratification(ratification::step::RatificationStep<D>),
+    Ratification(ratification::step::RatificationStep),
 }
 
 impl<T: Operations + 'static, D: Database + 'static> Phase<T, D> {
@@ -54,7 +54,7 @@ impl<T: Operations + 'static, D: Database + 'static> Phase<T, D> {
 
     pub async fn run(
         &mut self,
-        mut ctx: ExecutionCtx<'_, D, T>,
+        mut ctx: ExecutionCtx<'_, T>,
     ) -> Result<Message, ConsensusError> {
         ctx.set_start_time();
 

--- a/consensus/src/proposal/step.rs
+++ b/consensus/src/proposal/step.rs
@@ -53,7 +53,7 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
 
     pub async fn run(
         &mut self,
-        mut ctx: ExecutionCtx<'_, D, T>,
+        mut ctx: ExecutionCtx<'_, T>,
     ) -> Result<Message, ConsensusError> {
         let committee = ctx
             .get_current_committee()

--- a/consensus/src/queue.rs
+++ b/consensus/src/queue.rs
@@ -58,11 +58,6 @@ impl<T: Debug + Clone> MsgRegistry<T> {
         self.0.remove(&round);
     }
 
-    /// Removes all messages that belong to a round greater than the specified.
-    pub fn remove_msgs_greater_than(&mut self, round: u64) {
-        self.0.split_off(&round);
-    }
-
     /// Removes all messages that do not belong to the range (closed interval)
     /// of keys
     pub fn remove_msgs_out_of_range(&mut self, start_round: u64, offset: u64) {
@@ -119,30 +114,6 @@ mod tests {
         reg.remove_msgs_by_round(4444);
         assert_eq!(reg.msg_count(), 0);
         assert!(reg.drain_msg_by_round_step(round, 2).is_none());
-    }
-
-    #[test]
-    fn test_remove() {
-        #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-        struct Item(i32);
-
-        let round = 100;
-
-        let mut reg = MsgRegistry::<Item>::default();
-        reg.put_msg(round + 1, 1, Item(1));
-        reg.put_msg(round + 2, 1, Item(1));
-        reg.put_msg(round + 3, 1, Item(1));
-        reg.put_msg(round, 1, Item(1));
-
-        reg.remove_msgs_greater_than(round + 2);
-
-        assert!(reg.drain_msg_by_round_step(round, 1).is_some());
-        assert!(reg.drain_msg_by_round_step(round + 1, 1).is_some());
-
-        assert!(reg.drain_msg_by_round_step(round + 2, 1).is_none());
-        assert!(reg.drain_msg_by_round_step(round + 3, 1).is_none());
-
-        assert_eq!(reg.msg_count(), 0);
     }
 
     #[test]

--- a/consensus/src/ratification/step.rs
+++ b/consensus/src/ratification/step.rs
@@ -4,10 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::commons::{ConsensusError, Database, RoundUpdate};
+use crate::commons::{ConsensusError, RoundUpdate};
 use crate::execution_ctx::ExecutionCtx;
 use crate::operations::Operations;
-use std::marker::PhantomData;
 
 use crate::msg_handler::{HandleMsgOutput, MsgHandler};
 use crate::ratification::handler;
@@ -19,12 +18,11 @@ use tokio::sync::Mutex;
 
 use tracing::{info, Instrument};
 
-pub struct RatificationStep<DB> {
+pub struct RatificationStep {
     handler: Arc<Mutex<handler::RatificationHandler>>,
-    marker: PhantomData<DB>,
 }
 
-impl<DB: Database> RatificationStep<DB> {
+impl RatificationStep {
     pub async fn try_vote(
         ru: &RoundUpdate,
         iteration: u8,
@@ -70,14 +68,11 @@ pub fn build_ratification_payload(
     ratification
 }
 
-impl<DB: Database> RatificationStep<DB> {
+impl RatificationStep {
     pub(crate) fn new(
         handler: Arc<Mutex<handler::RatificationHandler>>,
     ) -> Self {
-        Self {
-            handler,
-            marker: PhantomData,
-        }
+        Self { handler }
     }
 
     pub async fn reinitialize(
@@ -112,7 +107,7 @@ impl<DB: Database> RatificationStep<DB> {
 
     pub async fn run<T: Operations + 'static>(
         &mut self,
-        mut ctx: ExecutionCtx<'_, DB, T>,
+        mut ctx: ExecutionCtx<'_, T>,
     ) -> Result<Message, ConsensusError> {
         let committee = ctx
             .get_current_committee()

--- a/consensus/src/validation/step.rs
+++ b/consensus/src/validation/step.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::commons::{ConsensusError, Database, RoundUpdate};
+use crate::commons::{ConsensusError, RoundUpdate};
 use crate::config;
 use crate::execution_ctx::ExecutionCtx;
 use crate::operations::{Operations, Voter};
@@ -227,9 +227,9 @@ impl<T: Operations + 'static> ValidationStep<T> {
         )
     }
 
-    pub async fn run<DB: Database>(
+    pub async fn run(
         &mut self,
-        mut ctx: ExecutionCtx<'_, DB, T>,
+        mut ctx: ExecutionCtx<'_, T>,
     ) -> Result<Message, ConsensusError> {
         let committee = ctx
             .get_current_committee()

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -211,19 +211,6 @@ impl<DB: database::DB> dusk_consensus::commons::Database for CandidateDB<DB> {
             }
         }
     }
-
-    fn delete_candidate_blocks(&mut self) {
-        match self.db.try_read() {
-            Ok(db) => {
-                if let Err(e) = db.update(|t| t.clear_candidates()) {
-                    warn!("Unable to cleare candidates: {e}");
-                };
-            }
-            Err(e) => {
-                warn!("Cannot acquire lock to clear_candidate: {e}");
-            }
-        }
-    }
 }
 
 /// Implements Executor trait to mock Contract Storage calls.


### PR DESCRIPTION
Fix #2188 

- Remove `remove_msgs_greater_than`
- Remove `delete_candidate_blocks`

 - `CONSENSUS_DELAY_MS` was already removed
 - `add` is currently used

- `collect_from_past` is not removed (because part of a trait), but it's not invoked anymore