### PR TITLE
Make chain ID available to contracts

### DIFF
--- a/contracts/host_fn/src/lib.rs
+++ b/contracts/host_fn/src/lib.rs
@@ -64,6 +64,10 @@ impl HostFnTest {
         rusk_abi::verify_bls(msg, pk, sig)
     }
 
+    pub fn chain_id(&self) -> u8 {
+        rusk_abi::chain_id()
+    }
+
     pub fn block_height(&self) -> u64 {
         rusk_abi::block_height()
     }
@@ -106,6 +110,11 @@ unsafe fn verify_bls(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |(msg, pk, sig)| {
         STATE.verify_bls(msg, pk, sig)
     })
+}
+
+#[no_mangle]
+unsafe fn chain_id(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |_: ()| STATE.chain_id())
 }
 
 #[no_mangle]

--- a/contracts/license/tests/license.rs
+++ b/contracts/license/tests/license.rs
@@ -41,6 +41,7 @@ const LICENSE_CONTRACT_ID: ContractId = {
 
 const POINT_LIMIT: u64 = 0x10000000;
 const TEST_OWNER: [u8; 32] = [0; 32];
+const CHAIN_ID: u8 = 0xFA;
 const USER_ATTRIBUTES: u64 = 545072475273;
 
 static LABEL: &[u8] = b"dusk-network";
@@ -66,7 +67,7 @@ fn initialize() -> Session {
         "../../../target/dusk/wasm32-unknown-unknown/release/license_contract.wasm"
     );
 
-    let mut session = rusk_abi::new_genesis_session(&vm);
+    let mut session = rusk_abi::new_genesis_session(&vm, CHAIN_ID);
 
     session
         .deploy(

--- a/contracts/stake/src/state.rs
+++ b/contracts/stake/src/state.rs
@@ -72,6 +72,10 @@ impl StakeState {
         let nonce = stake.nonce();
         let signature = *stake.signature();
 
+        if stake.chain_id() != self.chain_id() {
+            panic!("The stake must target the correct chain");
+        }
+
         let loaded_stake = self.load_or_create_stake_mut(&account);
 
         // ensure the stake is at least the minimum and that there isn't an
@@ -454,6 +458,10 @@ impl StakeState {
         for (stake_data, account) in self.stakes.values() {
             rusk_abi::feed((*account, *stake_data));
         }
+    }
+
+    fn chain_id(&self) -> u8 {
+        rusk_abi::chain_id()
     }
 
     fn deduct_contract_balance(amount: u64) {

--- a/contracts/stake/tests/common/init.rs
+++ b/contracts/stake/tests/common/init.rs
@@ -20,6 +20,7 @@ use rusk_abi::{ContractData, Session, VM};
 use crate::common::utils::update_root;
 
 const OWNER: [u8; 32] = [0; 32];
+pub const CHAIN_ID: u8 = 0xFA;
 const POINT_LIMIT: u64 = 0x100_000_000;
 
 /// Instantiate the virtual machine with the transfer contract deployed, with a
@@ -37,7 +38,7 @@ pub fn instantiate<Rng: RngCore + CryptoRng>(
         "../../../../target/dusk/wasm32-unknown-unknown/release/stake_contract.wasm"
     );
 
-    let mut session = rusk_abi::new_genesis_session(vm);
+    let mut session = rusk_abi::new_genesis_session(vm, CHAIN_ID);
 
     session
         .deploy(
@@ -81,6 +82,6 @@ pub fn instantiate<Rng: RngCore + CryptoRng>(
     // sets the block height for all subsequent operations to 1
     let base = session.commit().expect("Committing should succeed");
 
-    rusk_abi::new_session(vm, base, 1)
+    rusk_abi::new_session(vm, base, CHAIN_ID, 1)
         .expect("Instantiating new session should succeed")
 }

--- a/contracts/stake/tests/common/utils.rs
+++ b/contracts/stake/tests/common/utils.rs
@@ -87,6 +87,12 @@ pub fn opening(
         .map(|r| r.data)
 }
 
+pub fn chain_id(session: &mut Session) -> Result<u8, PiecrustError> {
+    session
+        .call(TRANSFER_CONTRACT, "chain_id", &(), POINT_LIMIT)
+        .map(|r| r.data)
+}
+
 pub fn filter_notes_owned_by<I: IntoIterator<Item = Note>>(
     vk: PhoenixViewKey,
     iter: I,
@@ -179,6 +185,9 @@ pub fn create_transaction<const I: usize>(
         inputs.push((note.clone(), opening));
     }
 
+    let chain_id =
+        chain_id(session).expect("Getting the chain ID should succeed");
+
     PhoenixTransaction::new::<StdRng, LocalProver>(
         rng,
         sender_sk,
@@ -191,6 +200,7 @@ pub fn create_transaction<const I: usize>(
         deposit,
         gas_limit,
         gas_price,
+        chain_id,
         exec.map(Into::into),
     )
     .expect("creating the creation shouldn't fail")

--- a/contracts/stake/tests/stake.rs
+++ b/contracts/stake/tests/stake.rs
@@ -26,7 +26,7 @@ use execution_core::{
 };
 
 use crate::common::assert::assert_event;
-use crate::common::init::instantiate;
+use crate::common::init::{instantiate, CHAIN_ID};
 use crate::common::utils::*;
 
 const GENESIS_VALUE: u64 = dusk(1_000_000.0);
@@ -71,8 +71,11 @@ fn stake_withdraw_unstake() {
     let input_note_pos = 0;
     let deposit = INITIAL_STAKE;
 
+    let chain_id =
+        chain_id(&mut session).expect("Getting the chain ID should succeed");
+
     // Fashion a Stake struct
-    let stake = Stake::new(&stake_sk, deposit, 1);
+    let stake = Stake::new(&stake_sk, deposit, 1, chain_id);
     let stake_bytes = rkyv::to_bytes::<_, 1024>(&stake)
         .expect("Should serialize Stake correctly")
         .to_vec();
@@ -230,7 +233,7 @@ fn stake_withdraw_unstake() {
     // set different block height so that the new notes are easily located and
     // filtered
     let base = session.commit().expect("Committing should succeed");
-    let mut session = rusk_abi::new_session(vm, base, 2)
+    let mut session = rusk_abi::new_session(vm, base, CHAIN_ID, 2)
         .expect("Instantiating new session should succeed");
 
     let receipt =
@@ -344,7 +347,7 @@ fn stake_withdraw_unstake() {
     // filtered
     // sets the block height for all subsequent operations to 1
     let base = session.commit().expect("Committing should succeed");
-    let mut session = rusk_abi::new_session(vm, base, 3)
+    let mut session = rusk_abi::new_session(vm, base, CHAIN_ID, 3)
         .expect("Instantiating new session should succeed");
 
     let receipt =

--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -77,6 +77,11 @@ unsafe fn num_notes(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |_: ()| STATE.num_notes())
 }
 
+#[no_mangle]
+unsafe fn chain_id(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |_: ()| STATE.chain_id())
+}
+
 // "Feeder" queries
 
 #[no_mangle]

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -342,6 +342,10 @@ impl TransferState {
         transitory::put_transaction(tx);
         let phoenix_tx = transitory::unwrap_phoenix_tx();
 
+        if phoenix_tx.chain_id() != self.chain_id() {
+            panic!("The tx must target the correct chain");
+        }
+
         // panic if the root is invalid
         if !self.root_exists(phoenix_tx.root()) {
             panic!("Root not found in the state!");
@@ -397,6 +401,10 @@ impl TransferState {
     ) -> Result<Vec<u8>, ContractError> {
         transitory::put_transaction(tx);
         let moonlight_tx = transitory::unwrap_moonlight_tx();
+
+        if moonlight_tx.chain_id() != self.chain_id() {
+            panic!("The tx must target the correct chain");
+        }
 
         // check the signature is valid and made by `from`
         if !rusk_abi::verify_bls(
@@ -675,6 +683,10 @@ impl TransferState {
     fn push_note_current_height(&mut self, note: Note) -> Note {
         let block_height = rusk_abi::block_height();
         self.push_note(block_height, note)
+    }
+
+    pub fn chain_id(&self) -> u8 {
+        rusk_abi::chain_id()
     }
 }
 

--- a/contracts/transfer/tests/common/utils.rs
+++ b/contracts/transfer/tests/common/utils.rs
@@ -112,6 +112,12 @@ pub fn opening(
         .map(|r| r.data)
 }
 
+pub fn chain_id(session: &mut Session) -> Result<u8, PiecrustError> {
+    session
+        .call(TRANSFER_CONTRACT, "chain_id", &(), GAS_LIMIT)
+        .map(|r| r.data)
+}
+
 /// Executes a transaction.
 /// Returns result containing gas spent.
 pub fn execute(
@@ -214,6 +220,9 @@ pub fn create_phoenix_transaction<const I: usize>(
         inputs.push((note.clone(), opening));
     }
 
+    let chain_id =
+        chain_id(session).expect("Getting the chain ID should succeed");
+
     PhoenixTransaction::new::<StdRng, LocalProver>(
         rng,
         sender_sk,
@@ -226,6 +235,7 @@ pub fn create_phoenix_transaction<const I: usize>(
         deposit,
         gas_limit,
         gas_price,
+        chain_id,
         exec.map(Into::into),
     )
     .expect("creating the creation shouldn't fail")

--- a/execution-core/src/transfer.rs
+++ b/execution-core/src/transfer.rs
@@ -73,6 +73,7 @@ impl Transaction {
         deposit: u64,
         gas_limit: u64,
         gas_price: u64,
+        chain_id: u8,
         exec: Option<impl Into<ContractExec>>,
     ) -> Result<Self, Error> {
         Ok(Self::Phoenix(PhoenixTransaction::new::<R, P>(
@@ -87,6 +88,7 @@ impl Transaction {
             deposit,
             gas_limit,
             gas_price,
+            chain_id,
             exec,
         )?))
     }
@@ -102,11 +104,12 @@ impl Transaction {
         gas_limit: u64,
         gas_price: u64,
         nonce: u64,
+        chain_id: u8,
         exec: Option<impl Into<ContractExec>>,
     ) -> Self {
         Self::Moonlight(MoonlightTransaction::new(
             from_sk, to_account, value, deposit, gas_limit, gas_price, nonce,
-            exec,
+            chain_id, exec,
         ))
     }
 

--- a/execution-core/tests/serialization.rs
+++ b/execution-core/tests/serialization.rs
@@ -25,6 +25,8 @@ use poseidon_merkle::{Item, Tree};
 use rand::rngs::StdRng;
 use rand::{CryptoRng, Rng, RngCore, SeedableRng};
 
+const CHAIN_ID: u8 = 0xFA;
+
 struct TxCircuitVecProver();
 
 // use the serialized TxCircuitVec as proof. This way that serialization is also
@@ -121,6 +123,7 @@ fn new_phoenix_tx<R: RngCore + CryptoRng>(
         deposit,
         gas_limit,
         gas_price,
+        CHAIN_ID,
         exec,
     )
     .expect("transcaction generation should work")
@@ -141,7 +144,8 @@ fn new_moonlight_tx<R: RngCore + CryptoRng>(
     let nonce: u64 = rng.gen();
 
     Transaction::moonlight(
-        &from_sk, to_account, value, deposit, gas_limit, gas_price, nonce, exec,
+        &from_sk, to_account, value, deposit, gas_limit, gas_price, nonce,
+        CHAIN_ID, exec,
     )
 }
 

--- a/node-data/src/ledger/transaction.rs
+++ b/node-data/src/ledger/transaction.rs
@@ -156,6 +156,7 @@ pub mod faker {
             ContractCall::new([21; 32], "some_method", &()).unwrap();
 
         let payload = PhoenixPayload {
+            chain_id: 0xFA,
             tx_skeleton,
             fee,
             exec: Some(ContractExec::Call(contract_call)),

--- a/rusk-abi/src/abi.rs
+++ b/rusk-abi/src/abi.rs
@@ -55,6 +55,11 @@ pub fn verify_bls(msg: Vec<u8>, pk: BlsPublicKey, sig: BlsSignature) -> bool {
     host_query(Query::VERIFY_BLS, (msg, pk, sig))
 }
 
+/// Get the chain ID.
+pub fn chain_id() -> u8 {
+    meta_data(Metadata::CHAIN_ID).unwrap()
+}
+
 /// Get the current block height.
 pub fn block_height() -> u64 {
     meta_data(Metadata::BLOCK_HEIGHT).unwrap()

--- a/rusk-abi/src/host.rs
+++ b/rusk-abi/src/host.rs
@@ -32,20 +32,24 @@ use crate::{Metadata, Query};
 pub fn new_session(
     vm: &VM,
     base: [u8; 32],
+    chain_id: u8,
     block_height: u64,
 ) -> Result<Session, PiecrustError> {
     vm.session(
         SessionData::builder()
             .base(base)
+            .insert(Metadata::CHAIN_ID, chain_id)?
             .insert(Metadata::BLOCK_HEIGHT, block_height)?,
     )
 }
 
 /// Create a new genesis session based on the given `vm`. The vm *must* have
 /// been created using [`new_vm`] or [`new_ephemeral_vm`].
-pub fn new_genesis_session(vm: &VM) -> Session {
+pub fn new_genesis_session(vm: &VM, chain_id: u8) -> Session {
     vm.session(
         SessionData::builder()
+            .insert(Metadata::CHAIN_ID, chain_id)
+            .expect("Inserting chain ID in metadata should succeed")
             .insert(Metadata::BLOCK_HEIGHT, 0)
             .expect("Inserting block height in metadata should succeed"),
     )

--- a/rusk-abi/src/lib.rs
+++ b/rusk-abi/src/lib.rs
@@ -28,7 +28,7 @@ pub use piecrust_uplink::debug as piecrust_debug;
 mod abi;
 #[cfg(feature = "abi")]
 pub use abi::{
-    block_height, hash, owner, owner_raw, poseidon_hash, self_owner,
+    block_height, chain_id, hash, owner, owner_raw, poseidon_hash, self_owner,
     self_owner_raw, verify_bls, verify_proof, verify_schnorr,
 };
 
@@ -65,6 +65,7 @@ enum Metadata {}
 
 #[allow(dead_code)]
 impl Metadata {
+    pub const CHAIN_ID: &'static str = "chain_id";
     pub const BLOCK_HEIGHT: &'static str = "block_height";
 }
 

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -40,6 +40,7 @@ pub const DEFAULT_SNAPSHOT: &str =
     include_str!("../config/testnet_remote.toml");
 
 const GENESIS_BLOCK_HEIGHT: u64 = 0;
+const GENESIS_CHAIN_ID: u8 = 0xFA;
 
 pub static DUSK_KEY: Lazy<PublicKey> = Lazy::new(|| {
     let addr = include_str!("../assets/dusk.address");
@@ -171,7 +172,7 @@ fn generate_empty_state<P: AsRef<Path>>(
     let state_dir = state_dir.as_ref();
 
     let vm = rusk_abi::new_vm(state_dir)?;
-    let mut session = rusk_abi::new_genesis_session(&vm);
+    let mut session = rusk_abi::new_genesis_session(&vm, GENESIS_CHAIN_ID);
 
     let transfer_code = include_bytes!(
         "../../target/dusk/wasm64-unknown-unknown/release/transfer_contract.wasm"
@@ -259,8 +260,12 @@ where
         None => generate_empty_state(state_dir, snapshot),
     }?;
 
-    let mut session =
-        rusk_abi::new_session(&vm, old_commit_id, GENESIS_BLOCK_HEIGHT)?;
+    let mut session = rusk_abi::new_session(
+        &vm,
+        old_commit_id,
+        GENESIS_CHAIN_ID,
+        GENESIS_BLOCK_HEIGHT,
+    )?;
 
     generate_transfer_state(&mut session, snapshot)?;
     generate_stake_state(&mut session, snapshot)?;

--- a/rusk/src/bin/config/kadcast.rs
+++ b/rusk/src/bin/config/kadcast.rs
@@ -33,4 +33,8 @@ impl KadcastConfig {
             self.0.kadcast_id = Some(network_id)
         };
     }
+
+    pub fn chain_id(&self) -> u8 {
+        self.0.kadcast_id.unwrap_or_default()
+    }
 }

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -64,6 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let rusk = Rusk::new(
             state_dir,
+            config.kadcast.chain_id(),
             config.chain.generation_timeout(),
             config.chain.gas_per_deploy_byte(),
             config.chain.block_gas_limit(),

--- a/rusk/src/lib/node.rs
+++ b/rusk/src/lib/node.rs
@@ -42,6 +42,7 @@ pub struct Rusk {
     pub(crate) tip: Arc<RwLock<RuskTip>>,
     pub(crate) vm: Arc<VM>,
     dir: PathBuf,
+    pub(crate) chain_id: u8,
     pub(crate) generation_timeout: Option<Duration>,
     pub(crate) gas_per_deploy_byte: Option<u64>,
     pub(crate) feeder_gas_limit: u64,

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -53,6 +53,7 @@ const DEFAULT_GAS_PER_DEPLOY_BYTE: u64 = 100;
 impl Rusk {
     pub fn new<P: AsRef<Path>>(
         dir: P,
+        chain_id: u8,
         generation_timeout: Option<Duration>,
         gas_per_deploy_byte: Option<u64>,
         block_gas_limit: u64,
@@ -87,6 +88,7 @@ impl Rusk {
             tip,
             vm,
             dir: dir.into(),
+            chain_id,
             generation_timeout,
             gas_per_deploy_byte,
             feeder_gas_limit,
@@ -347,6 +349,11 @@ impl Rusk {
         self.query(TRANSFER_CONTRACT, "account", pk)
     }
 
+    /// Returns an account's information.
+    pub fn chain_id(&self) -> Result<u8> {
+        self.query(TRANSFER_CONTRACT, "chain_id", &())
+    }
+
     /// Fetches the previous state data for stake changes in the contract.
     ///
     /// Communicates with the stake contract to obtain information about the
@@ -396,7 +403,12 @@ impl Rusk {
             tip.current
         });
 
-        let session = rusk_abi::new_session(&self.vm, commit, block_height)?;
+        let session = rusk_abi::new_session(
+            &self.vm,
+            commit,
+            self.chain_id,
+            block_height,
+        )?;
 
         Ok(session)
     }

--- a/rusk/tests/common/state.rs
+++ b/rusk/tests/common/state.rs
@@ -29,6 +29,8 @@ use tracing::info;
 
 use crate::common::keys::STAKE_SK;
 
+const CHAIN_ID: u8 = 0xFA;
+
 // Creates a Rusk initial state in the given directory
 pub fn new_state<P: AsRef<Path>>(
     dir: P,
@@ -42,8 +44,9 @@ pub fn new_state<P: AsRef<Path>>(
 
     let (sender, _) = broadcast::channel(10);
 
-    let rusk = Rusk::new(dir, None, None, block_gas_limit, u64::MAX, sender)
-        .expect("Instantiating rusk should succeed");
+    let rusk =
+        Rusk::new(dir, CHAIN_ID, None, None, block_gas_limit, u64::MAX, sender)
+            .expect("Instantiating rusk should succeed");
 
     assert_eq!(
         commit_id,

--- a/rusk/tests/common/wallet.rs
+++ b/rusk/tests/common/wallet.rs
@@ -121,6 +121,11 @@ impl wallet::StateClient for TestStateClient {
         let account = self.rusk.account(pk)?;
         Ok(account)
     }
+
+    fn fetch_chain_id(&self) -> Result<u8, Self::Error> {
+        let chain_id = self.rusk.chain_id()?;
+        Ok(chain_id)
+    }
 }
 
 #[derive(Default, Debug, Clone)]

--- a/rusk/tests/rusk-state.rs
+++ b/rusk/tests/rusk-state.rs
@@ -35,6 +35,7 @@ use tracing::info;
 use crate::common::state::new_state;
 
 const BLOCK_HEIGHT: u64 = 1;
+const CHAIN_ID: u8 = 0xFA;
 const BLOCK_GAS_LIMIT: u64 = 100_000_000_000;
 const INITIAL_BALANCE: u64 = 10_000_000_000;
 
@@ -83,7 +84,7 @@ where
     rusk.with_tip(|mut tip, vm| {
         let current_commit = tip.current;
         let mut session =
-            rusk_abi::new_session(vm, current_commit, BLOCK_HEIGHT)
+            rusk_abi::new_session(vm, current_commit, CHAIN_ID, BLOCK_HEIGHT)
                 .expect("current commit should exist");
 
         session

--- a/rusk/tests/services/contract_deployment.rs
+++ b/rusk/tests/services/contract_deployment.rs
@@ -44,6 +44,7 @@ const ALICE_CONTRACT_ID: ContractId = {
 };
 
 const OWNER: [u8; 32] = [1; 32];
+const CHAIN_ID: u8 = 0xFA;
 
 const BOB_ECHO_VALUE: u64 = 775;
 const BOB_INIT_VALUE: u8 = 5;
@@ -95,8 +96,9 @@ fn initial_state<P: AsRef<Path>>(dir: P, deploy_bob: bool) -> Result<Rusk> {
 
     let (sender, _) = broadcast::channel(10);
 
-    let rusk = Rusk::new(dir, None, None, BLOCK_GAS_LIMIT, u64::MAX, sender)
-        .expect("Instantiating rusk should succeed");
+    let rusk =
+        Rusk::new(dir, CHAIN_ID, None, None, BLOCK_GAS_LIMIT, u64::MAX, sender)
+            .expect("Instantiating rusk should succeed");
     Ok(rusk)
 }
 
@@ -215,7 +217,7 @@ impl Fixture {
         let commit = self.rusk.state_root();
         let vm = rusk_abi::new_vm(self.path.as_path())
             .expect("VM creation should succeed");
-        let mut session = rusk_abi::new_session(&vm, commit, 0)
+        let mut session = rusk_abi::new_session(&vm, commit, CHAIN_ID, 0)
             .expect("Session creation should succeed");
         let result = session.call::<_, u64>(
             self.contract_id,
@@ -233,7 +235,7 @@ impl Fixture {
         let commit = self.rusk.state_root();
         let vm = rusk_abi::new_vm(self.path.as_path())
             .expect("VM creation should succeed");
-        let mut session = rusk_abi::new_session(&vm, commit, 0)
+        let mut session = rusk_abi::new_session(&vm, commit, CHAIN_ID, 0)
             .expect("Session creation should succeed");
         let result = session.call::<_, u64>(
             self.contract_id,

--- a/test-wallet/src/imp.rs
+++ b/test-wallet/src/imp.rs
@@ -370,6 +370,9 @@ where
         let transfer_value = 0;
         let obfuscated_transaction = false;
 
+        let chain_id =
+            self.state.fetch_chain_id().map_err(Error::from_state_err)?;
+
         let tx = phoenix_transaction::<Rng, LocalProver>(
             rng,
             &sender_sk,
@@ -382,6 +385,7 @@ where
             deposit,
             gas_limit,
             gas_price,
+            chain_id,
             Some(exec),
         )?;
 
@@ -416,6 +420,9 @@ where
 
         let exec: Option<ContractExec> = None;
 
+        let chain_id =
+            self.state.fetch_chain_id().map_err(Error::from_state_err)?;
+
         let tx = phoenix_transaction::<Rng, LocalProver>(
             rng,
             &sender_sk,
@@ -428,6 +435,7 @@ where
             deposit,
             gas_limit,
             gas_price,
+            chain_id,
             exec,
         )?;
 
@@ -465,6 +473,9 @@ where
             .map_err(Error::from_state_err)?
             .nonce;
 
+        let chain_id =
+            self.state.fetch_chain_id().map_err(Error::from_state_err)?;
+
         let tx = phoenix_stake::<Rng, LocalProver>(
             rng,
             &phoenix_sender_sk,
@@ -473,6 +484,7 @@ where
             root,
             gas_limit,
             gas_price,
+            chain_id,
             stake_value,
             current_nonce,
         )?;
@@ -517,6 +529,9 @@ where
             })?
             .value;
 
+        let chain_id =
+            self.state.fetch_chain_id().map_err(Error::from_state_err)?;
+
         let tx = phoenix_unstake::<Rng, LocalProver>(
             rng,
             &phoenix_sender_sk,
@@ -526,6 +541,7 @@ where
             staked_amount,
             gas_limit,
             gas_price,
+            chain_id,
         )?;
 
         stake_sk.zeroize();
@@ -562,6 +578,9 @@ where
             .map_err(Error::from_state_err)?
             .reward;
 
+        let chain_id =
+            self.state.fetch_chain_id().map_err(Error::from_state_err)?;
+
         let tx = phoenix_stake_reward::<Rng, LocalProver>(
             rng,
             &phoenix_sender_sk,
@@ -571,6 +590,7 @@ where
             stake_reward,
             gas_limit,
             gas_price,
+            chain_id,
         )?;
 
         stake_sk.zeroize();
@@ -631,9 +651,12 @@ where
         }
         let nonce = account.nonce + 1;
 
+        let chain_id =
+            self.state.fetch_chain_id().map_err(Error::from_state_err)?;
+
         let tx = MoonlightTransaction::new(
             &from_sk, to_account, value, deposit, gas_limit, gas_price, nonce,
-            exec,
+            chain_id, exec,
         );
 
         seed.zeroize();

--- a/test-wallet/src/lib.rs
+++ b/test-wallet/src/lib.rs
@@ -143,4 +143,7 @@ pub trait StateClient {
         &self,
         pk: &BlsPublicKey,
     ) -> Result<AccountData, Self::Error>;
+
+    /// Queries for the chain ID.
+    fn fetch_chain_id(&self) -> Result<u8, Self::Error>;
 }

--- a/wallet-core/src/transaction.rs
+++ b/wallet-core/src/transaction.rs
@@ -61,6 +61,7 @@ pub fn phoenix<R: RngCore + CryptoRng, P: Prove>(
     deposit: u64,
     gas_limit: u64,
     gas_price: u64,
+    chain_id: u8,
     exec: Option<impl Into<ContractExec>>,
 ) -> Result<Transaction, Error> {
     Ok(PhoenixTransaction::new::<R, P>(
@@ -75,6 +76,7 @@ pub fn phoenix<R: RngCore + CryptoRng, P: Prove>(
         deposit,
         gas_limit,
         gas_price,
+        chain_id,
         exec,
     )?
     .into())
@@ -99,6 +101,7 @@ pub fn phoenix_stake<R: RngCore + CryptoRng, P: Prove>(
     root: BlsScalar,
     gas_limit: u64,
     gas_price: u64,
+    chain_id: u8,
     stake_value: u64,
     current_nonce: u64,
 ) -> Result<Transaction, Error> {
@@ -109,7 +112,7 @@ pub fn phoenix_stake<R: RngCore + CryptoRng, P: Prove>(
     let obfuscated_transaction = false;
     let deposit = stake_value;
 
-    let stake = Stake::new(stake_sk, stake_value, current_nonce + 1);
+    let stake = Stake::new(stake_sk, stake_value, current_nonce + 1, chain_id);
 
     let contract_call = ContractCall::new(STAKE_CONTRACT, "stake", &stake)?;
 
@@ -125,6 +128,7 @@ pub fn phoenix_stake<R: RngCore + CryptoRng, P: Prove>(
         deposit,
         gas_limit,
         gas_price,
+        chain_id,
         Some(contract_call),
     )
 }
@@ -150,6 +154,7 @@ pub fn phoenix_stake_reward<R: RngCore + CryptoRng, P: Prove>(
     reward_amount: u64,
     gas_limit: u64,
     gas_price: u64,
+    chain_id: u8,
 ) -> Result<Transaction, Error> {
     let receiver_pk = PhoenixPublicKey::from(phoenix_sender_sk);
     let change_pk = receiver_pk;
@@ -190,6 +195,7 @@ pub fn phoenix_stake_reward<R: RngCore + CryptoRng, P: Prove>(
         deposit,
         gas_limit,
         gas_price,
+        chain_id,
         Some(contract_call),
     )
 }
@@ -214,6 +220,7 @@ pub fn phoenix_unstake<R: RngCore + CryptoRng, P: Prove>(
     unstake_value: u64,
     gas_limit: u64,
     gas_price: u64,
+    chain_id: u8,
 ) -> Result<Transaction, Error> {
     let receiver_pk = PhoenixPublicKey::from(phoenix_sender_sk);
     let change_pk = receiver_pk;
@@ -254,6 +261,7 @@ pub fn phoenix_unstake<R: RngCore + CryptoRng, P: Prove>(
         deposit,
         gas_limit,
         gas_price,
+        chain_id,
         Some(contract_call),
     )
 }


### PR DESCRIPTION
At the moment, contracts have no way to check which chain they're operating in. As a consequence, cross-chain replay attacks are made possible. In this PR we expose the chain ID to contracts and make use of it in our own transactions and calls where appropriate.

The changes effectively make it impossible to replay transactions on different chains, as well as allow contract developers to do the same with their own call data structures.