### PR TITLE
consensus: Start from saved iteration on restart

### DIFF
--- a/consensus/src/commons.rs
+++ b/consensus/src/commons.rs
@@ -139,6 +139,8 @@ impl From<BlsSigError> for ConsensusError {
 #[async_trait::async_trait]
 pub trait Database: Send + Sync {
     fn store_candidate_block(&mut self, b: Block);
+    async fn get_last_iter(&self) -> (Hash, u8);
+    async fn store_last_iter(&mut self, data: (Hash, u8));
 }
 
 #[derive(Clone)]

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -13,7 +13,6 @@ use crate::queue::MsgRegistry;
 use crate::step_votes_reg::SafeAttestationInfoRegistry;
 use crate::user::committee::Committee;
 use crate::user::provisioners::Provisioners;
-use crate::user::sortition;
 
 use node_data::bls::PublicKeyBytes;
 use node_data::ledger::Block;
@@ -104,10 +103,6 @@ impl<'a, T: Operations + 'static> ExecutionCtx<'a, T> {
     /// Returns true if `my pubkey` is a member of [`committee`].
     pub(crate) fn am_member(&self, committee: &Committee) -> bool {
         committee.is_member(&self.round_update.pubkey_bls)
-    }
-
-    pub(crate) fn save_committee(&mut self, step: u8, committee: Committee) {
-        self.iter_ctx.committees.insert(step, committee);
     }
 
     pub(crate) fn get_current_committee(&self) -> Option<&Committee> {
@@ -454,19 +449,6 @@ impl<'a, T: Operations + 'static> ExecutionCtx<'a, T> {
         }
 
         None
-    }
-
-    pub fn get_sortition_config(
-        &self,
-        exclusion: Vec<PublicKeyBytes>,
-    ) -> sortition::Config {
-        sortition::Config::new(
-            self.round_update.seed(),
-            self.round_update.round,
-            self.iteration,
-            self.step_name(),
-            exclusion,
-        )
     }
 
     /// Reports step elapsed time to the client

--- a/consensus/src/phase.rs
+++ b/consensus/src/phase.rs
@@ -5,10 +5,8 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::commons::{ConsensusError, Database};
-use crate::config::CONSENSUS_MAX_ITER;
 use crate::execution_ctx::ExecutionCtx;
 use crate::operations::Operations;
-use crate::user::committee::Committee;
 use crate::{proposal, ratification, validation};
 use node_data::message::Message;
 use node_data::StepName;
@@ -58,63 +56,8 @@ impl<T: Operations + 'static, D: Database + 'static> Phase<T, D> {
     ) -> Result<Message, ConsensusError> {
         ctx.set_start_time();
 
-        let step_name = ctx.step_name();
         let timeout = ctx.iter_ctx.get_timeout(ctx.step_name());
         debug!(event = "execute_step", ?timeout);
-
-        let exclusion = match step_name {
-            StepName::Proposal => vec![],
-            _ => {
-                let mut exclusion_list = vec![];
-                let generator = ctx
-                    .iter_ctx
-                    .get_generator(ctx.iteration)
-                    .expect("Proposal committee to be already generated");
-
-                exclusion_list.push(generator);
-
-                if ctx.iteration < CONSENSUS_MAX_ITER {
-                    let next_generator =
-                        ctx.iter_ctx.get_generator(ctx.iteration + 1).expect(
-                            "Next Proposal committee to be already generated",
-                        );
-
-                    exclusion_list.push(next_generator);
-                }
-
-                exclusion_list
-            }
-        };
-
-        // Perform deterministic_sortition to generate committee of size=N.
-        // The extracted members are the provisioners eligible to vote on this
-        // particular round and step. In the context of Proposal phase,
-        // the extracted member is the one eligible to generate the candidate
-        // block.
-        let step_committee = Committee::new(
-            ctx.provisioners,
-            &ctx.get_sortition_config(exclusion),
-        );
-
-        if let StepName::Proposal = step_name {
-            if ctx.iteration < CONSENSUS_MAX_ITER {
-                let mut cfg_next_iteration = ctx.get_sortition_config(vec![]);
-                cfg_next_iteration.step =
-                    StepName::Proposal.to_step(ctx.iteration + 1);
-
-                ctx.save_committee(
-                    cfg_next_iteration.step,
-                    Committee::new(ctx.provisioners, &cfg_next_iteration),
-                );
-            }
-        }
-
-        debug!(
-            event = "committee_generated",
-            members = format!("{}", &step_committee)
-        );
-
-        ctx.save_committee(ctx.step(), step_committee);
 
         // Execute step
         await_phase!(self, run(ctx))

--- a/node/src/database/rocksdb.rs
+++ b/node/src/database/rocksdb.rs
@@ -53,6 +53,7 @@ pub const MD_STATE_ROOT_KEY: &[u8] = b"state_hash_key";
 pub const MD_AVG_VALIDATION: &[u8] = b"avg_validation_time";
 pub const MD_AVG_RATIFICATION: &[u8] = b"avg_ratification_time";
 pub const MD_AVG_PROPOSAL: &[u8] = b"avg_proposal_time";
+pub const MD_LAST_ITER: &[u8] = b"consensus_last_iter";
 
 #[derive(Clone)]
 pub struct Backend {


### PR DESCRIPTION
Implements #1908 

- move the committee generation code from phase `run` function to the new `generate_committee` in IterationCtx
- move get_sortition_config to IterationCtx
- remove save_committee
- if starting from `saved_iteration != 0`, generate all committees from iteration 0 to saved_iteration before running the step loop. This is needed in order to ensure we don't panic due to a missing committee when processing a message from a past iteration[^1].
- extract next generator on Validation/Ratification step instead of Proposal
- fix 'iteration < CONSENSUS_MAX_ITER' bug: last iteration is actually CONSENSUS_MAX_ITER-1, so when iteration = CONSENSUS_MAX_ITER-1 we should NOT extract the next generator

[^1]: This is a naive approach just to be on the safe side and not waste too much time. A future refactor should actually allow creating a committee on the fly, as needed (if we receive a message from the past and we don't have the committee, than generate it). 
