### PR TITLE
Stake contract refactor

### DIFF
--- a/contracts/stake/src/state.rs
+++ b/contracts/stake/src/state.rs
@@ -194,8 +194,8 @@ impl StakeState {
             panic!("There is no reward available to withdraw");
         }
 
-        if value != loaded_stake.reward {
-            panic!("Value withdrawn different from available reward");
+        if value > loaded_stake.reward {
+            panic!("Value withdrawn higher than available reward");
         }
 
         // check signature is correct
@@ -211,7 +211,7 @@ impl StakeState {
                 .expect("Withdrawing reward should succeed");
 
         // update the state accordingly
-        loaded_stake.reward = 0;
+        loaded_stake.reward -= value;
         rusk_abi::emit(
             "withdraw",
             StakeWithReceiverEvent {

--- a/contracts/stake/src/state.rs
+++ b/contracts/stake/src/state.rs
@@ -337,12 +337,7 @@ impl StakeState {
         let to_slash = min(to_slash, stake_amount.value);
 
         if to_slash > 0 {
-            // Move the slash amount from stake to reward and deduct contract
-            // balance
-            stake_amount.value -= to_slash;
-            stake.reward += to_slash;
-
-            Self::deduct_contract_balance(to_slash);
+            stake_amount.lock_amount(to_slash);
 
             rusk_abi::emit(
                 "slash",

--- a/contracts/stake/src/state.rs
+++ b/contracts/stake/src/state.rs
@@ -138,12 +138,13 @@ impl StakeState {
 
         // ensure there is a value staked, and that the withdrawal is exactly
         // the same amount
-        let staked_value = loaded_stake
+        let stake = loaded_stake
             .amount
-            .expect("There must be an amount to unstake")
-            .value;
+            .as_ref()
+            .expect("There must be an amount to unstake");
+        let withdrawal_value = stake.locked + stake.value;
 
-        if value != staked_value {
+        if value != withdrawal_value {
             panic!("Value withdrawn different from staked amount");
         }
 
@@ -166,7 +167,7 @@ impl StakeState {
             "unstake",
             StakeWithReceiverEvent {
                 account,
-                value: staked_value,
+                value: withdrawal_value,
                 receiver: Some(*transfer_withdraw.receiver()),
             },
         );

--- a/contracts/stake/tests/common/assert.rs
+++ b/contracts/stake/tests/common/assert.rs
@@ -8,7 +8,9 @@ use dusk_bytes::Serializable;
 use rkyv::{check_archived_root, Deserialize, Infallible};
 
 use execution_core::{
-    signatures::bls::PublicKey as BlsPublicKey, stake::StakeEvent, Event,
+    signatures::bls::PublicKey as BlsPublicKey,
+    stake::{StakeEvent, StakeWithReceiverEvent},
+    Event,
 };
 
 pub fn assert_event<S>(
@@ -19,20 +21,30 @@ pub fn assert_event<S>(
 ) where
     S: AsRef<str>,
 {
-    let event =
-        events
-            .iter()
-            .find(|e| e.topic == topic.as_ref())
-            .expect(&format!(
-                "event: {} should exist in the event list",
-                topic.as_ref()
-            ));
-    let staking_event_data =
-        check_archived_root::<StakeEvent>(event.data.as_slice())
-            .expect("Stake event data should deserialize correctly");
-    let staking_event_data: StakeEvent = staking_event_data
-        .deserialize(&mut Infallible)
-        .expect("Infallible");
-    assert_eq!(staking_event_data.value, should_amount);
-    assert_eq!(staking_event_data.account.to_bytes(), should_pk.to_bytes());
+    let topic = topic.as_ref();
+    let event = events
+        .iter()
+        .find(|e| e.topic == topic)
+        .expect(&format!("event: {topic} should exist in the event list",));
+
+    if topic == "unstake" || topic == "withdraw" {
+        let staking_event_data = check_archived_root::<StakeWithReceiverEvent>(
+            event.data.as_slice(),
+        )
+        .expect("Stake event data should deserialize correctly");
+        let staking_event_data: StakeWithReceiverEvent = staking_event_data
+            .deserialize(&mut Infallible)
+            .expect("Infallible");
+        assert_eq!(staking_event_data.value, should_amount);
+        assert_eq!(staking_event_data.account.to_bytes(), should_pk.to_bytes());
+    } else {
+        let staking_event_data =
+            check_archived_root::<StakeEvent>(event.data.as_slice())
+                .expect("Stake event data should deserialize correctly");
+        let staking_event_data: StakeEvent = staking_event_data
+            .deserialize(&mut Infallible)
+            .expect("Infallible");
+        assert_eq!(staking_event_data.value, should_amount);
+        assert_eq!(staking_event_data.account.to_bytes(), should_pk.to_bytes());
+    }
 }

--- a/contracts/stake/tests/events.rs
+++ b/contracts/stake/tests/events.rs
@@ -51,6 +51,7 @@ fn reward_slash() -> Result<(), PiecrustError> {
         amount: Some(StakeAmount {
             value: stake_amount,
             eligibility: 0,
+            locked: 0,
         }),
         nonce: 0,
         faults: 0,
@@ -142,6 +143,7 @@ fn stake_hard_slash() -> Result<(), PiecrustError> {
         amount: Some(StakeAmount {
             value: stake_amount,
             eligibility: block_height,
+            locked: 0,
         }),
         nonce: 0,
         faults: 0,

--- a/execution-core/src/stake.rs
+++ b/execution-core/src/stake.rs
@@ -196,11 +196,21 @@ impl Withdraw {
 pub struct StakeEvent {
     /// Account associated to the event.
     pub account: BlsPublicKey,
-    /// Value of the relevant operation, be it `stake`, `unstake`, `withdraw`,
-    /// `reward`, or `slash`.
+    /// Value of the relevant operation, be it `stake`, `reward` or `slash`.
+    ///
+    /// In case of `suspended` the amount refers to the next eligibility
     pub value: u64,
-    /// The receiver of the action, relevant in `withdraw` and `unstake`
-    /// operations.
+}
+
+/// Event emitted after a stake contract operation is performed.
+#[derive(Debug, Clone, Archive, Deserialize, Serialize)]
+#[archive_attr(derive(CheckBytes))]
+pub struct StakeWithReceiverEvent {
+    /// Account associated to the event.
+    pub account: BlsPublicKey,
+    /// Value of the relevant operation, be it `unstake` or `withdraw`.
+    pub value: u64,
+    /// The receiver of the action
     pub receiver: Option<WithdrawReceiver>,
 }
 

--- a/rusk-recovery/src/state.rs
+++ b/rusk-recovery/src/state.rs
@@ -127,6 +127,7 @@ fn generate_stake_state(
         let amount = (staker.amount > 0).then(|| StakeAmount {
             value: staker.amount,
             eligibility: staker.eligibility.unwrap_or_default(),
+            locked: 0,
         });
 
         let stake = StakeData {

--- a/rusk/tests/services/stake.rs
+++ b/rusk/tests/services/stake.rs
@@ -298,12 +298,14 @@ pub async fn slash() -> Result<()> {
         .expect("balance to exists");
     let to_slash = wallet.account_public_key(0).unwrap();
     let stake = wallet.get_stake(0).unwrap();
+    let initial_stake_value = dusk(20.0);
     assert_eq!(stake.reward, dusk(3.0));
     assert_eq!(
         stake.amount,
         Some(StakeAmount {
-            value: dusk(20.0),
-            eligibility: 0
+            value: initial_stake_value,
+            eligibility: 0,
+            locked: 0
         })
     );
 
@@ -334,7 +336,8 @@ pub async fn slash() -> Result<()> {
         prev.amount,
         Some(StakeAmount {
             value: dusk(20.0),
-            eligibility: 0
+            eligibility: 0,
+            locked: 0
         })
     );
 
@@ -342,25 +345,17 @@ pub async fn slash() -> Result<()> {
     let slashed_amount = prev_stake / 10;
 
     let after_slash = wallet.get_stake(0).unwrap();
-    assert_eq!(after_slash.reward, dusk(5.0));
-    assert_eq!(after_slash.reward, prev.reward + slashed_amount);
+    assert_eq!(after_slash.reward, dusk(3.0));
     assert_eq!(
         after_slash.amount,
         Some(StakeAmount {
             value: prev_stake - slashed_amount,
-            eligibility: 4320
-        })
-    );
-    assert_eq!(
-        after_slash.amount,
-        Some(StakeAmount {
-            value: dusk(18.0),
-            eligibility: 4320
+            eligibility: 4320,
+            locked: dusk(2.0)
         })
     );
     let new_balance = rusk.contract_balance(STAKE_CONTRACT).unwrap();
-    assert_eq!(new_balance, contract_balance - slashed_amount);
-    let contract_balance = new_balance;
+    assert_eq!(new_balance, contract_balance);
 
     generator_procedure(
         &rusk,
@@ -375,40 +370,42 @@ pub async fn slash() -> Result<()> {
     let last_changes = rusk.last_provisioners_change(None).unwrap();
     let (_, prev) = last_changes.first().expect("Something changed").clone();
     let prev = prev.expect("to have something");
-    assert_eq!(prev.reward, dusk(5.0));
+    assert_eq!(prev.reward, dusk(3.0));
     assert_eq!(
         prev.amount,
         Some(StakeAmount {
             value: dusk(18.0),
-            eligibility: 4320
+            eligibility: 4320,
+            locked: dusk(2.0)
         })
     );
 
     let prev_stake = prev.amount.unwrap().value;
+    let prev_locked = prev.amount.unwrap().locked;
     // 20% slash
     let slashed_amount = prev_stake / 10 * 2;
 
     let after_slash = wallet.get_stake(0).unwrap();
-    assert_eq!(after_slash.reward, dusk(8.6));
-    assert_eq!(after_slash.reward, prev.reward + slashed_amount);
+    assert_eq!(after_slash.reward, dusk(3.0));
     assert_eq!(
         after_slash.amount,
         Some(StakeAmount {
             value: prev_stake - slashed_amount,
-            eligibility: 6480
+            eligibility: 6480,
+            locked: prev_locked + slashed_amount
         })
     );
     assert_eq!(
         after_slash.amount,
         Some(StakeAmount {
             value: dusk(14.4),
-            eligibility: 6480
+            eligibility: 6480,
+            locked: dusk(20.0) - dusk(14.4)
         })
     );
 
     let new_balance = rusk.contract_balance(STAKE_CONTRACT).unwrap();
-    assert_eq!(new_balance, contract_balance - slashed_amount);
-    let contract_balance = new_balance;
+    assert_eq!(new_balance, contract_balance);
 
     generator_procedure(
         &rusk,
@@ -423,29 +420,33 @@ pub async fn slash() -> Result<()> {
     let last_changes = rusk.last_provisioners_change(None).unwrap();
     let (_, prev) = last_changes.first().expect("Something changed").clone();
     let prev = prev.expect("to have something");
-    assert_eq!(prev.reward, dusk(8.6));
+    assert_eq!(prev.reward, dusk(3.0));
     assert_eq!(
         prev.amount,
         Some(StakeAmount {
             value: dusk(14.4),
-            eligibility: 6480
+            eligibility: 6480,
+            locked: dusk(20.0) - dusk(14.4)
         })
     );
 
     let prev_stake = prev.amount.unwrap().value;
+    let prev_locked = prev.amount.unwrap().locked;
     // 30% slash
     let slashed_amount = prev_stake / 10 * 3;
     let after_slash = wallet.get_stake(0).unwrap();
-    assert_eq!(after_slash.reward, dusk(12.92));
+
+    assert_eq!(after_slash.reward, dusk(3.0));
     assert_eq!(
         after_slash.amount,
         Some(StakeAmount {
             value: dusk(10.08),
-            eligibility: 17280
+            eligibility: 17280,
+            locked: prev_locked + slashed_amount
         })
     );
     let new_balance = rusk.contract_balance(STAKE_CONTRACT).unwrap();
-    assert_eq!(new_balance, contract_balance - slashed_amount);
+    assert_eq!(new_balance, contract_balance);
 
     generator_procedure(
         &rusk,
@@ -461,12 +462,13 @@ pub async fn slash() -> Result<()> {
     let last_changes = rusk.last_provisioners_change(None).unwrap();
     let (_, prev) = last_changes.first().expect("Something changed").clone();
     let prev = prev.expect("to have something");
-    assert_eq!(prev.reward, dusk(8.6));
+    assert_eq!(prev.reward, dusk(3.0));
     assert_eq!(
         prev.amount,
         Some(StakeAmount {
             value: dusk(14.4),
-            eligibility: 6480
+            eligibility: 6480,
+            locked: dusk(20.0) - dusk(14.4)
         })
     );
 


### PR DESCRIPTION
* Change slash to lock amount instead of move funds to reward (Resolves #1945)
* Allow for partial withdrawal of stake rewards
* Change unstake to remove the whole amount (active + locked)
* Change events emitted by the stake contract to include receiver only if needed