### PR TITLE
execution-core: re-export and type alias poseidon merkle types

### DIFF
--- a/contracts/stake/Cargo.toml
+++ b/contracts/stake/Cargo.toml
@@ -23,7 +23,6 @@ rusk-prover = { version = "0.3", path = "../../rusk-prover/" }
 rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
 hex = "0.4"
 rand = "0.8"
-poseidon-merkle = { version = "0.7", features = ["rkyv-impl"] }
 ff = { version = "0.13", default-features = false }
 criterion = "0.5"
 

--- a/contracts/transfer/Cargo.toml
+++ b/contracts/transfer/Cargo.toml
@@ -9,7 +9,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 execution-core = { version = "0.1.0", path = "../../execution-core" }
 dusk-bytes = "0.1"
-poseidon-merkle = { version = "0.7", features = ["rkyv-impl"] }
 rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
 ringbuffer = "0.15"
 

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -13,7 +13,6 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::vec::Vec;
 
 use dusk_bytes::Serializable;
-use poseidon_merkle::Opening as PoseidonOpening;
 use ringbuffer::{ConstGenericRingBuffer, RingBuffer};
 
 use execution_core::{
@@ -22,8 +21,8 @@ use execution_core::{
     transfer::{
         moonlight::{AccountData, Transaction as MoonlightTransaction},
         phoenix::{
-            Note, Sender, Transaction as PhoenixTransaction, TreeLeaf,
-            NOTES_TREE_DEPTH,
+            Note, NoteLeaf, NoteOpening, Sender,
+            Transaction as PhoenixTransaction,
         },
         withdraw::{
             Withdraw, WithdrawReceiver, WithdrawReplayToken, WithdrawSignature,
@@ -539,7 +538,7 @@ impl TransferState {
     /// Note: the method `update_root` needs to be called after the last note is
     /// pushed.
     pub fn push_note(&mut self, block_height: u64, note: Note) -> Note {
-        let tree_leaf = TreeLeaf { block_height, note };
+        let tree_leaf = NoteLeaf { block_height, note };
         let pos = self.tree.push(tree_leaf.clone());
         rusk_abi::emit("TREE_LEAF", (pos, tree_leaf));
         self.get_note(pos)
@@ -595,10 +594,7 @@ impl TransferState {
     }
 
     /// Get the opening
-    pub fn opening(
-        &self,
-        pos: u64,
-    ) -> Option<PoseidonOpening<(), NOTES_TREE_DEPTH>> {
+    pub fn opening(&self, pos: u64) -> Option<NoteOpening> {
         self.tree.opening(pos)
     }
 

--- a/execution-core/tests/serialization.rs
+++ b/execution-core/tests/serialization.rs
@@ -13,15 +13,15 @@ use execution_core::{
             ContractBytecode, ContractCall, ContractDeploy, ContractExec,
         },
         phoenix::{
-            Note, Prove, PublicKey as PhoenixPublicKey,
-            SecretKey as PhoenixSecretKey, TxCircuitVec, NOTES_TREE_DEPTH,
+            Note, NoteTreeItem, NotesTree, Prove,
+            PublicKey as PhoenixPublicKey, SecretKey as PhoenixSecretKey,
+            TxCircuitVec,
         },
         Transaction,
     },
     BlsScalar, Error, JubJubScalar,
 };
 use ff::Field;
-use poseidon_merkle::{Item, Tree};
 use rand::rngs::StdRng;
 use rand::{CryptoRng, Rng, RngCore, SeedableRng};
 
@@ -86,9 +86,9 @@ fn new_phoenix_tx<R: RngCore + CryptoRng>(
     input_2.set_pos(2);
     let notes = vec![input_0, input_1, input_2];
 
-    let mut notes_tree = Tree::<(), NOTES_TREE_DEPTH>::new();
+    let mut notes_tree = NotesTree::new();
     for note in notes.iter() {
-        let item = Item {
+        let item = NoteTreeItem {
             hash: note.hash(),
             data: (),
         };

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -41,7 +41,6 @@ dirs = "4"
 blake3 = "1"
 blake2b_simd = { version = "1", default-features = false }
 
-poseidon-merkle = { version = "0.7", features = ["rkyv-impl", "size_32"] }
 sha3 = "0.10"
 dusk-bytes = "0.1"
 kadcast = "0.7.0-rc"

--- a/rusk/src/lib/test_utils.rs
+++ b/rusk/src/lib/test_utils.rs
@@ -20,13 +20,12 @@ use execution_core::{
     signatures::bls::PublicKey as BlsPublicKey,
     stake::{StakeData, STAKE_CONTRACT},
     transfer::{
-        phoenix::{Note, TreeLeaf, ViewKey, NOTES_TREE_DEPTH},
+        phoenix::{Note, NoteLeaf, NoteOpening, ViewKey},
         TRANSFER_CONTRACT,
     },
     BlsScalar, ContractId,
 };
 use parking_lot::RwLockWriteGuard;
-use poseidon_merkle::Opening as PoseidonOpening;
 use rusk_abi::VM;
 
 pub type StoredNote = (Note, u64);
@@ -62,10 +61,7 @@ impl Rusk {
     }
 
     /// Returns the opening of the transfer tree at the given position.
-    pub fn tree_opening(
-        &self,
-        pos: u64,
-    ) -> Result<Option<PoseidonOpening<(), NOTES_TREE_DEPTH>>> {
+    pub fn tree_opening(&self, pos: u64) -> Result<Option<NoteOpening>> {
         self.query(TRANSFER_CONTRACT, "opening", &pos)
     }
 
@@ -111,7 +107,7 @@ impl Rusk {
         // expected output
         let stream =
             tokio_stream::iter(receiver.into_iter().filter_map(move |bytes| {
-                let leaf = rkyv::from_bytes::<TreeLeaf>(&bytes)
+                let leaf = rkyv::from_bytes::<NoteLeaf>(&bytes)
                     .expect("The contract should always return valid leaves");
                 match &vk {
                     Some(vk) => vk

--- a/rusk/tests/common/wallet.rs
+++ b/rusk/tests/common/wallet.rs
@@ -16,12 +16,11 @@ use execution_core::{
     stake::StakeData,
     transfer::{
         moonlight::AccountData,
-        phoenix::{Note, ViewKey, NOTES_TREE_DEPTH},
+        phoenix::{Note, NoteOpening, ViewKey},
     },
     BlsScalar,
 };
 use futures::StreamExt;
-use poseidon_merkle::Opening as PoseidonOpening;
 use rusk::{Error, Result, Rusk};
 use test_wallet::{self as wallet, Store};
 use tracing::info;
@@ -100,10 +99,7 @@ impl wallet::StateClient for TestStateClient {
     }
 
     /// Queries the node to find the opening for a specific note.
-    fn fetch_opening(
-        &self,
-        note: &Note,
-    ) -> Result<PoseidonOpening<(), NOTES_TREE_DEPTH>, Self::Error> {
+    fn fetch_opening(&self, note: &Note) -> Result<NoteOpening, Self::Error> {
         self.rusk
             .tree_opening(*note.pos())?
             .ok_or(Error::OpeningPositionNotFound(*note.pos()))

--- a/rusk/tests/rusk-state.rs
+++ b/rusk/tests/rusk-state.rs
@@ -15,8 +15,8 @@ use std::sync::{mpsc, Arc};
 use execution_core::{
     transfer::{
         phoenix::{
-            Note, PublicKey as PhoenixPublicKey, SecretKey as PhoenixSecretKey,
-            TreeLeaf,
+            Note, NoteLeaf, PublicKey as PhoenixPublicKey,
+            SecretKey as PhoenixSecretKey,
         },
         TRANSFER_CONTRACT,
     },
@@ -47,7 +47,7 @@ fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
     new_state(dir, &snapshot, BLOCK_GAS_LIMIT)
 }
 
-fn leaves_from_height(rusk: &Rusk, height: u64) -> Result<Vec<TreeLeaf>> {
+fn leaves_from_height(rusk: &Rusk, height: u64) -> Result<Vec<NoteLeaf>> {
     let (sender, receiver) = mpsc::channel();
     rusk.leaves_from_height(height, sender)?;
     Ok(receiver

--- a/test-wallet/Cargo.toml
+++ b/test-wallet/Cargo.toml
@@ -8,7 +8,6 @@ license = "MPL-2.0"
 [dependencies]
 rand_core = "^0.6"
 dusk-bytes = "^0.1"
-poseidon-merkle = { version = "0.7", features = ["rkyv-impl"] }
 rkyv = { version = "0.7", default-features = false }
 ff = { version = "0.13", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["derive"] }

--- a/test-wallet/src/imp.rs
+++ b/test-wallet/src/imp.rs
@@ -12,7 +12,6 @@ use alloc::string::FromUtf8Error;
 use alloc::vec::Vec;
 
 use dusk_bytes::Error as BytesError;
-use poseidon_merkle::Opening;
 use rand_core::{CryptoRng, Error as RngError, RngCore};
 use rkyv::ser::serializers::{
     AllocScratchError, CompositeSerializerError, SharedSerializeMapError,
@@ -27,8 +26,8 @@ use execution_core::{
         contract_exec::ContractExec,
         moonlight::{AccountData, Transaction as MoonlightTransaction},
         phoenix::{
-            Note, PublicKey as PhoenixPublicKey, SecretKey as PhoenixSecretKey,
-            ViewKey as PhoenixViewKey, NOTES_TREE_DEPTH,
+            Note, NoteOpening, PublicKey as PhoenixPublicKey,
+            SecretKey as PhoenixSecretKey, ViewKey as PhoenixViewKey,
         },
         Transaction,
     },
@@ -301,10 +300,7 @@ where
         &self,
         sender_sk: &PhoenixSecretKey,
         transaction_cost: u64,
-    ) -> Result<
-        Vec<(Note, Opening<(), NOTES_TREE_DEPTH>, BlsScalar)>,
-        Error<S, SC>,
-    > {
+    ) -> Result<Vec<(Note, NoteOpening, BlsScalar)>, Error<S, SC>> {
         let notes_and_nullifiers =
             self.input_notes_nullifiers(sender_sk, transaction_cost)?;
 
@@ -328,7 +324,7 @@ where
         &self,
         sender_sk: &PhoenixSecretKey,
         transaction_cost: u64,
-    ) -> Result<Vec<(Note, Opening<(), NOTES_TREE_DEPTH>)>, Error<S, SC>> {
+    ) -> Result<Vec<(Note, NoteOpening)>, Error<S, SC>> {
         let notes_and_nullifiers =
             self.input_notes_nullifiers(sender_sk, transaction_cost)?;
 

--- a/test-wallet/src/lib.rs
+++ b/test-wallet/src/lib.rs
@@ -15,7 +15,6 @@ extern crate alloc;
 mod imp;
 
 use alloc::vec::Vec;
-use poseidon_merkle::Opening as PoseidonOpening;
 use zeroize::Zeroize;
 
 use execution_core::{
@@ -24,16 +23,15 @@ use execution_core::{
     transfer::{
         moonlight::AccountData,
         phoenix::{
-            Note, PublicKey as PhoenixPublicKey, SecretKey as PhoenixSecretKey,
-            ViewKey as PhoenixViewKey, NOTES_TREE_DEPTH,
+            Note, NoteOpening, PublicKey as PhoenixPublicKey,
+            SecretKey as PhoenixSecretKey, ViewKey as PhoenixViewKey,
         },
     },
     BlsScalar,
 };
 
-pub use wallet_core::{
-    keys::{derive_bls_sk, derive_phoenix_pk, derive_phoenix_sk},
-    EnrichedNote,
+pub use wallet_core::keys::{
+    derive_bls_sk, derive_phoenix_pk, derive_phoenix_sk,
 };
 
 pub use imp::*;
@@ -114,7 +112,7 @@ pub trait StateClient {
     fn fetch_notes(
         &self,
         vk: &PhoenixViewKey,
-    ) -> Result<Vec<EnrichedNote>, Self::Error>;
+    ) -> Result<Vec<(Note, u64)>, Self::Error>;
 
     /// Fetch the current root of the state.
     fn fetch_root(&self) -> Result<BlsScalar, Self::Error>;
@@ -127,10 +125,7 @@ pub trait StateClient {
     ) -> Result<Vec<BlsScalar>, Self::Error>;
 
     /// Queries the node to find the opening for a specific note.
-    fn fetch_opening(
-        &self,
-        note: &Note,
-    ) -> Result<PoseidonOpening<(), NOTES_TREE_DEPTH>, Self::Error>;
+    fn fetch_opening(&self, note: &Note) -> Result<NoteOpening, Self::Error>;
 
     /// Queries the node for the stake of a key. If the key has no stake, a
     /// `Default` stake info should be returned.

--- a/wallet-core/src/transaction.rs
+++ b/wallet-core/src/transaction.rs
@@ -11,7 +11,6 @@ use alloc::vec::Vec;
 use rand::{CryptoRng, RngCore};
 
 use ff::Field;
-use poseidon_merkle::Opening;
 use zeroize::Zeroize;
 
 use execution_core::{
@@ -20,9 +19,8 @@ use execution_core::{
     transfer::{
         contract_exec::{ContractCall, ContractExec},
         phoenix::{
-            Note, Prove, PublicKey as PhoenixPublicKey,
+            Note, NoteOpening, Prove, PublicKey as PhoenixPublicKey,
             SecretKey as PhoenixSecretKey, Transaction as PhoenixTransaction,
-            NOTES_TREE_DEPTH,
         },
         withdraw::{Withdraw, WithdrawReceiver, WithdrawReplayToken},
         Transaction,
@@ -54,7 +52,7 @@ pub fn phoenix<R: RngCore + CryptoRng, P: Prove>(
     sender_sk: &PhoenixSecretKey,
     change_pk: &PhoenixPublicKey,
     receiver_pk: &PhoenixPublicKey,
-    inputs: Vec<(Note, Opening<(), NOTES_TREE_DEPTH>)>,
+    inputs: Vec<(Note, NoteOpening)>,
     root: BlsScalar,
     transfer_value: u64,
     obfuscated_transaction: bool,
@@ -97,7 +95,7 @@ pub fn phoenix_stake<R: RngCore + CryptoRng, P: Prove>(
     rng: &mut R,
     phoenix_sender_sk: &PhoenixSecretKey,
     stake_sk: &BlsSecretKey,
-    inputs: Vec<(Note, Opening<(), NOTES_TREE_DEPTH>)>,
+    inputs: Vec<(Note, NoteOpening)>,
     root: BlsScalar,
     gas_limit: u64,
     gas_price: u64,
@@ -149,7 +147,7 @@ pub fn phoenix_stake_reward<R: RngCore + CryptoRng, P: Prove>(
     rng: &mut R,
     phoenix_sender_sk: &PhoenixSecretKey,
     stake_sk: &BlsSecretKey,
-    inputs: Vec<(Note, Opening<(), NOTES_TREE_DEPTH>, BlsScalar)>,
+    inputs: Vec<(Note, NoteOpening, BlsScalar)>,
     root: BlsScalar,
     reward_amount: u64,
     gas_limit: u64,
@@ -215,7 +213,7 @@ pub fn phoenix_unstake<R: RngCore + CryptoRng, P: Prove>(
     rng: &mut R,
     phoenix_sender_sk: &PhoenixSecretKey,
     stake_sk: &BlsSecretKey,
-    inputs: Vec<(Note, Opening<(), NOTES_TREE_DEPTH>, BlsScalar)>,
+    inputs: Vec<(Note, NoteOpening, BlsScalar)>,
     root: BlsScalar,
     unstake_value: u64,
     gas_limit: u64,


### PR DESCRIPTION
By reexporting we can wrap another dusk-dependency (`poseidon-merkle`) downstream and the type alias highly increase the readability of the code.

Additionally the `NoteLeaf` can replace the `EnrichedNote` in `wallet-core` (see #2241)