### PR TITLE
Issue 2230 owner only calls

### DIFF
--- a/contracts/bob/Cargo.toml
+++ b/contracts/bob/Cargo.toml
@@ -9,3 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 rusk-abi = { version = "0.13.0-rc", path = "../../rusk-abi", features = ["debug"] }
+execution-core = { version = "0.1.0", path = "../../execution-core" }
+rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
+bytecheck = { version = "0.6", default-features = false }
+dusk-bytes = "0.1"

--- a/contracts/bob/src/lib.rs
+++ b/contracts/bob/src/lib.rs
@@ -26,6 +26,16 @@ mod wasm {
     }
 
     #[no_mangle]
+    unsafe fn reset(arg_len: u32) -> u32 {
+        rusk_abi::wrap_call(arg_len, |n| STATE.reset(n))
+    }
+
+    #[no_mangle]
+    unsafe fn owner_reset(arg_len: u32) -> u32 {
+        rusk_abi::wrap_call(arg_len, |(sig, msg)| STATE.owner_reset(sig, msg))
+    }
+
+    #[no_mangle]
     unsafe fn ping(arg_len: u32) -> u32 {
         rusk_abi::wrap_call(arg_len, |()| STATE.ping())
     }
@@ -38,5 +48,10 @@ mod wasm {
     #[no_mangle]
     unsafe fn value(arg_len: u32) -> u32 {
         rusk_abi::wrap_call(arg_len, |()| STATE.value())
+    }
+
+    #[no_mangle]
+    unsafe fn nonce(arg_len: u32) -> u32 {
+        rusk_abi::wrap_call(arg_len, |()| STATE.nonce())
     }
 }

--- a/contracts/bob/src/state.rs
+++ b/contracts/bob/src/state.rs
@@ -4,15 +4,35 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+extern crate alloc;
+use alloc::string::String;
+use bytecheck::CheckBytes;
+use dusk_bytes::Serializable;
+use execution_core::{
+    signatures::bls::{PublicKey as BlsPublicKey, Signature as BlsSignature},
+    ContractId,
+};
+use rkyv::{Archive, Deserialize, Serialize};
+
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
+#[archive_attr(derive(CheckBytes))]
+pub struct OwnerMessage {
+    contract_id: ContractId,
+    args: u8,
+    fname: String,
+    nonce: u64,
+}
+
 /// Bob contract.
 #[derive(Debug, Clone)]
 pub struct Bob {
     value: u8,
+    nonce: u64,
 }
 
 impl Bob {
     pub const fn new() -> Self {
-        Self { value: 0 }
+        Self { value: 0, nonce: 0 }
     }
 
     #[allow(dead_code)]
@@ -24,6 +44,38 @@ impl Bob {
 impl Bob {
     pub fn init(&mut self, n: u8) {
         self.value = n;
+        self.nonce = 0;
+    }
+
+    pub fn reset(&mut self, n: u8) {
+        self.value = n;
+    }
+
+    pub fn owner_reset(&mut self, sig: BlsSignature, msg: OwnerMessage) {
+        let mut granted = false;
+        let message_bytes = rkyv::to_bytes::<_, 4096>(&msg)
+            .expect("Message should serialize correctly")
+            .to_vec();
+
+        let owner_bytes = rusk_abi::self_owner_raw();
+        if let Ok(owner) = BlsPublicKey::from_bytes(&owner_bytes) {
+            if self.nonce == msg.nonce
+                && msg.fname == "owner_reset"
+                && msg.contract_id == rusk_abi::self_id()
+                && rusk_abi::verify_bls(message_bytes, owner, sig)
+            {
+                self.owner_only_function(msg.args);
+                self.nonce += 1;
+                granted = true;
+            }
+        }
+        if !granted {
+            panic!("method restricted only to the owner")
+        }
+    }
+
+    fn owner_only_function(&mut self, args: u8) {
+        self.value = args;
     }
 
     pub fn ping(&mut self) {}
@@ -34,5 +86,9 @@ impl Bob {
 
     pub fn value(&mut self) -> u8 {
         self.value
+    }
+
+    pub fn nonce(&mut self) -> u64 {
+        self.nonce
     }
 }

--- a/contracts/host_fn/src/lib.rs
+++ b/contracts/host_fn/src/lib.rs
@@ -19,7 +19,6 @@ use execution_core::{
             PublicKey as SchnorrPublicKey, Signature as SchnorrSignature,
         },
     },
-    transfer::phoenix::PublicKey as PhoenixPublicKey,
     BlsScalar,
 };
 
@@ -72,11 +71,11 @@ impl HostFnTest {
         rusk_abi::block_height()
     }
 
-    pub fn owner(&self) -> PhoenixPublicKey {
+    pub fn owner(&self) -> BlsPublicKey {
         rusk_abi::self_owner()
     }
 
-    pub fn owner_raw(&self) -> [u8; PhoenixPublicKey::SIZE] {
+    pub fn owner_raw(&self) -> [u8; BlsPublicKey::SIZE] {
         rusk_abi::self_owner_raw()
     }
 }

--- a/rusk-abi/CHANGELOG.md
+++ b/rusk-abi/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `piecrust-uplink` to `0.15`
 - Change dependencies declarations enforce bytecheck [#1371]
 - Update dusk dependencies [#1609]
+- Made owner methods compatible with BLS key [#2230]
 
 ## [0.11.0] - 2023-10-12
 
@@ -200,6 +201,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add LICENSE
 - Add README.md
 
+[#2230]: https://github.com/dusk-network/rusk/issues/2230
 [#1710]: https://github.com/dusk-network/rusk/issues/1710
 [#1630]: https://github.com/dusk-network/rusk/issues/1630
 [#1609]: https://github.com/dusk-network/rusk/issues/1609

--- a/rusk-abi/src/abi.rs
+++ b/rusk-abi/src/abi.rs
@@ -14,7 +14,6 @@ use execution_core::{
             PublicKey as SchnorrPublicKey, Signature as SchnorrSignature,
         },
     },
-    transfer::phoenix::PublicKey as PhoenixPublicKey,
     BlsScalar, ContractId,
 };
 use piecrust_uplink::{host_query, meta_data};
@@ -68,27 +67,26 @@ pub fn block_height() -> u64 {
 /// Query owner of a given contract.
 /// Returns none if contract is not found.
 /// Panics if owner is not a valid public key (should never happen).
-pub fn owner(contract: ContractId) -> Option<PhoenixPublicKey> {
+pub fn owner(contract: ContractId) -> Option<BlsPublicKey> {
     owner_raw(contract).map(|buf| {
-        PhoenixPublicKey::from_bytes(&buf)
+        BlsPublicKey::from_bytes(&buf)
             .expect("Owner should deserialize correctly")
     })
 }
 
 /// Query self owner of a given contract.
 /// Panics if owner is not a valid public key (should never happen).
-pub fn self_owner() -> PhoenixPublicKey {
+pub fn self_owner() -> BlsPublicKey {
     let buf = self_owner_raw();
-    PhoenixPublicKey::from_bytes(&buf)
-        .expect("Owner should deserialize correctly")
+    BlsPublicKey::from_bytes(&buf).expect("Owner should deserialize correctly")
 }
 
 /// Query raw "to_bytes" serialization of the owner of a given contract.
-pub fn owner_raw(contract: ContractId) -> Option<[u8; PhoenixPublicKey::SIZE]> {
+pub fn owner_raw(contract: ContractId) -> Option<[u8; BlsPublicKey::SIZE]> {
     piecrust_uplink::owner(contract)
 }
 
 /// Query raw "to_bytes" serialization of the self owner.
-pub fn self_owner_raw() -> [u8; PhoenixPublicKey::SIZE] {
+pub fn self_owner_raw() -> [u8; BlsPublicKey::SIZE] {
     piecrust_uplink::self_owner()
 }

--- a/rusk-abi/tests/lib.rs
+++ b/rusk-abi/tests/lib.rs
@@ -23,15 +23,12 @@ use execution_core::{
             PublicKey as SchnorrPublicKey, SecretKey as SchnorrSecretKey,
         },
     },
-    transfer::phoenix::{
-        PublicKey as PhoenixPublicKey, SecretKey as PhoenixSecretKey,
-    },
     BlsScalar, ContractId,
 };
 use ff::Field;
 use rusk_abi::{ContractData, Session, VM};
 
-const POINT_LIMIT: u64 = 0x1000000;
+const POINT_LIMIT: u64 = 0x4000000;
 const CHAIN_ID: u8 = 0xFA;
 
 #[test]
@@ -369,11 +366,11 @@ fn block_height() {
     assert_eq!(height, HEIGHT);
 }
 
-fn get_owner() -> &'static PhoenixPublicKey {
-    static OWNER: OnceLock<PhoenixPublicKey> = OnceLock::new();
+fn get_owner() -> &'static BlsPublicKey {
+    static OWNER: OnceLock<BlsPublicKey> = OnceLock::new();
     OWNER.get_or_init(|| {
-        let sk = PhoenixSecretKey::random(&mut OsRng);
-        PhoenixPublicKey::from(&sk)
+        let sk = BlsSecretKey::random(&mut OsRng);
+        BlsPublicKey::from(&sk)
     })
 }
 
@@ -383,7 +380,7 @@ fn owner_raw() {
         rusk_abi::new_ephemeral_vm().expect("Instantiating VM should succeed");
     let (mut session, contract_id) = instantiate(&vm, 0);
 
-    let owner: [u8; 64] = session
+    let owner: [u8; 96] = session
         .call(contract_id, "contract_owner_raw", get_owner(), POINT_LIMIT)
         .expect("Query should succeed")
         .data;
@@ -397,7 +394,7 @@ fn owner() {
         rusk_abi::new_ephemeral_vm().expect("Instantiating VM should succeed");
     let (mut session, contract_id) = instantiate(&vm, 0);
 
-    let owner: PhoenixPublicKey = session
+    let owner: BlsPublicKey = session
         .call(contract_id, "contract_owner", get_owner(), POINT_LIMIT)
         .expect("Query should succeed")
         .data;

--- a/rusk/tests/services/mod.rs
+++ b/rusk/tests/services/mod.rs
@@ -7,6 +7,7 @@
 pub mod contract_deployment;
 pub mod gas_behavior;
 pub mod multi_transfer;
+pub mod owner_calls;
 pub mod stake;
 pub mod transfer;
 pub mod unspendable;

--- a/rusk/tests/services/owner_calls.rs
+++ b/rusk/tests/services/owner_calls.rs
@@ -1,0 +1,330 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use bytecheck::CheckBytes;
+use dusk_bytes::Serializable;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use rkyv::validation::validators::DefaultValidator;
+use rkyv::{Archive, Deserialize, Infallible, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use execution_core::{
+    signatures::bls::{
+        PublicKey as BlsPublicKey, SecretKey as BlsSecretKey,
+        Signature as BlsSignature,
+    },
+    ContractId,
+};
+use rusk::gen_id::gen_contract_id;
+use rusk::{Error, Result, Rusk};
+use rusk_abi::{CallReceipt, ContractData, Session};
+use rusk_recovery_tools::state;
+use tempfile::tempdir;
+use test_wallet::{self as wallet, Wallet};
+use tokio::sync::broadcast;
+use tracing::info;
+
+use crate::common::logger;
+use crate::common::wallet::{TestStateClient, TestStore};
+
+const BLOCK_GAS_LIMIT: u64 = 1_000_000_000_000;
+const POINT_LIMIT: u64 = 0x10000000;
+
+const NON_BLS_OWNER: [u8; 32] = [1; 32];
+
+const BOB_INIT_VALUE: u8 = 5;
+
+const GUARDED_METHOD: &str = "owner_reset";
+
+const CHAIN_ID: u8 = 0xFA;
+
+fn initial_state<P: AsRef<Path>>(
+    dir: P,
+    owner: impl AsRef<[u8]>,
+) -> Result<Rusk> {
+    let dir = dir.as_ref();
+
+    let snapshot =
+        toml::from_str(include_str!("../config/contract_deployment.toml"))
+            .expect("Cannot deserialize config");
+
+    let (_vm, _commit_id) = state::deploy(dir, &snapshot, |session| {
+        let bob_bytecode = include_bytes!(
+            "../../../target/dusk/wasm32-unknown-unknown/release/bob.wasm"
+        );
+
+        session
+            .deploy(
+                bob_bytecode,
+                ContractData::builder()
+                    .owner(owner.as_ref())
+                    .constructor_arg(&BOB_INIT_VALUE)
+                    .contract_id(gen_contract_id(&bob_bytecode, 0u64, owner)),
+                POINT_LIMIT,
+            )
+            .expect("Deploying the bob contract should succeed");
+    })
+    .expect("Deploying initial state should succeed");
+
+    let (sender, _) = broadcast::channel(10);
+
+    let rusk =
+        Rusk::new(dir, CHAIN_ID, None, None, BLOCK_GAS_LIMIT, u64::MAX, sender)
+            .expect("Instantiating rusk should succeed");
+    Ok(rusk)
+}
+
+#[allow(dead_code)]
+struct Fixture {
+    pub rusk: Rusk,
+    pub wallet: Wallet<TestStore, TestStateClient>,
+    pub bob_bytecode: Vec<u8>,
+    pub contract_id: ContractId,
+    pub path: PathBuf,
+    pub session: Option<Session>,
+}
+
+impl Fixture {
+    fn build(owner: impl AsRef<[u8]>) -> Self {
+        let tmp =
+            tempdir().expect("Should be able to create temporary directory");
+        let rusk = initial_state(&tmp, owner.as_ref())
+            .expect("Initializing should succeed");
+
+        let cache = Arc::new(RwLock::new(HashMap::new()));
+
+        let wallet = wallet::Wallet::new(
+            TestStore,
+            TestStateClient {
+                rusk: rusk.clone(),
+                cache,
+            },
+        );
+
+        let original_root = rusk.state_root();
+
+        info!("Original Root: {:?}", hex::encode(original_root));
+
+        let bob_bytecode = include_bytes!(
+            "../../../target/dusk/wasm32-unknown-unknown/release/bob.wasm"
+        )
+        .to_vec();
+        let contract_id = gen_contract_id(&bob_bytecode, 0u64, owner.as_ref());
+
+        let path = tmp.into_path();
+        Self {
+            rusk,
+            wallet,
+            bob_bytecode,
+            contract_id,
+            path,
+            session: None,
+        }
+    }
+
+    pub fn assert_bob_contract_is_deployed(&self) {
+        const BOB_ECHO_VALUE: u64 = 775;
+        let commit = self.rusk.state_root();
+        let vm = rusk_abi::new_vm(self.path.as_path())
+            .expect("VM creation should succeed");
+        let mut session = rusk_abi::new_session(&vm, commit, CHAIN_ID, 0)
+            .expect("Session creation should succeed");
+        let result = session.call::<_, u64>(
+            self.contract_id,
+            "echo",
+            &BOB_ECHO_VALUE,
+            u64::MAX,
+        );
+        assert_eq!(
+            result.expect("Echo call should succeed").data,
+            BOB_ECHO_VALUE
+        );
+        let result =
+            session.call::<_, u8>(self.contract_id, "value", &(), u64::MAX);
+        assert_eq!(
+            result.expect("Value call should succeed").data,
+            BOB_INIT_VALUE
+        );
+    }
+
+    pub fn set_session(&mut self) {
+        let commit = self.rusk.state_root();
+        let vm = rusk_abi::new_vm(self.path.as_path())
+            .expect("VM creation should succeed");
+        self.session = Some(
+            rusk_abi::new_session(&vm, commit, CHAIN_ID, 0)
+                .expect("Session creation should succeed"),
+        );
+    }
+
+    pub fn query_contract<R>(
+        &mut self,
+        method: impl AsRef<str>,
+    ) -> Result<CallReceipt<R>, Error>
+    where
+        R: Archive,
+        R::Archived: Deserialize<R, Infallible>
+            + for<'b> CheckBytes<DefaultValidator<'b>>,
+    {
+        assert!(self.session.is_some());
+        self.session
+            .as_mut()
+            .unwrap()
+            .call::<_, R>(self.contract_id, method.as_ref(), &(), u64::MAX)
+            .map_err(Error::Vm)
+    }
+}
+
+// this struct needs to be rkyv-serialization compatible between
+// the contract caller and the contract, i.e., it doesn't need to be
+// identical but it needs to rkyv-serialize to an identical slice of bytes
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
+#[archive_attr(derive(CheckBytes))]
+pub struct OwnerMessage {
+    pub contract_id: ContractId,
+    pub args: u8,
+    pub fname: String,
+    pub nonce: u64,
+}
+
+// performs a call to a method which may verify that it is called by the owner
+fn make_owner_only_call<R>(
+    contract_id: ContractId,
+    args: u8,
+    fname: impl AsRef<str>,
+    nonce: u64,
+    owner_sk: &BlsSecretKey,
+    session: &mut Session,
+) -> Result<CallReceipt<R>, Error>
+where
+    R: Archive,
+    R::Archived:
+        Deserialize<R, Infallible> + for<'b> CheckBytes<DefaultValidator<'b>>,
+{
+    let msg = OwnerMessage {
+        contract_id,
+        args,
+        fname: fname.as_ref().to_string(),
+        nonce,
+    };
+    let msg_bytes = rkyv::to_bytes::<_, 4096>(&msg)
+        .expect("Message should serialize correctly")
+        .to_vec();
+    let sig: BlsSignature = owner_sk.sign(&msg_bytes);
+    let args = (sig, msg.clone());
+    session
+        .call::<(BlsSignature, OwnerMessage), R>(
+            contract_id,
+            fname.as_ref(),
+            &args,
+            u64::MAX,
+        )
+        .map_err(Error::Vm)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn non_bls_owner_guarded_call() -> Result<(), Error> {
+    logger();
+    const VALUE: u8 = 244;
+    let rng = &mut StdRng::seed_from_u64(0xcafe);
+    let sk = BlsSecretKey::random(rng);
+    let mut f = Fixture::build(NON_BLS_OWNER);
+    f.assert_bob_contract_is_deployed();
+    f.set_session();
+
+    let r = make_owner_only_call::<()>(
+        f.contract_id,
+        VALUE,
+        GUARDED_METHOD,
+        0,
+        &sk,
+        f.session.as_mut().unwrap(),
+    );
+    assert!(r.is_err());
+    Ok(())
+}
+
+/// owner is a BLS public key, method called is guarded
+#[tokio::test(flavor = "multi_thread")]
+pub async fn bls_owner_guarded_call() -> Result<(), Error> {
+    logger();
+    const VALUE1: u8 = 244;
+    const VALUE2: u8 = 233;
+    let rng = &mut StdRng::seed_from_u64(0xcafe);
+    let sk = BlsSecretKey::random(rng);
+    let pk = BlsPublicKey::from(&sk);
+    let owner = pk.to_bytes();
+
+    let mut f = Fixture::build(&owner);
+    f.assert_bob_contract_is_deployed();
+    f.set_session();
+
+    let nonce = f.query_contract::<u64>("nonce")?.data;
+
+    make_owner_only_call::<()>(
+        f.contract_id,
+        VALUE1,
+        GUARDED_METHOD,
+        nonce,
+        &sk,
+        f.session.as_mut().unwrap(),
+    )?;
+    let value = f.query_contract::<u8>("value")?;
+    assert_eq!(VALUE1, value.data);
+
+    // make sure the next call will fail if we do not increase the nonce
+    let r = make_owner_only_call::<()>(
+        f.contract_id,
+        VALUE2,
+        GUARDED_METHOD,
+        nonce,
+        &sk,
+        f.session.as_mut().unwrap(),
+    );
+    assert!(r.is_err());
+
+    // next call should work if we increase the nonce
+    make_owner_only_call::<()>(
+        f.contract_id,
+        VALUE2,
+        GUARDED_METHOD,
+        nonce + 1,
+        &sk,
+        f.session.as_mut().unwrap(),
+    )?;
+    let value = f.query_contract::<u8>("value")?;
+    assert_eq!(VALUE2, value.data);
+
+    // call should fail if method name is incorrect
+    let r = make_owner_only_call::<()>(
+        f.contract_id,
+        VALUE2,
+        "incorrect",
+        nonce + 2,
+        &sk,
+        f.session.as_mut().unwrap(),
+    );
+    assert!(r.is_err());
+
+    // call should fail if contract id is incorrect
+    let mut contract_id_bytes = f.contract_id.to_bytes();
+    contract_id_bytes[0] ^= 0xff;
+    let incorrect_contract_id = ContractId::from_bytes(contract_id_bytes);
+    let r = make_owner_only_call::<()>(
+        incorrect_contract_id,
+        VALUE2,
+        GUARDED_METHOD,
+        nonce + 2,
+        &sk,
+        f.session.as_mut().unwrap(),
+    );
+    assert!(r.is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
This PR makes it possible to implement contract method which will enforce that only contract owner is able to call it.
The PR contains necessary changes in rusk-abi as well as a reference implementation and tests.
Implements #2230
