### PR TITLE
Introduce transaction memos

### DIFF
--- a/contracts/stake/tests/common/utils.rs
+++ b/contracts/stake/tests/common/utils.rs
@@ -10,7 +10,7 @@ use rand::rngs::StdRng;
 
 use execution_core::{
     transfer::{
-        contract_exec::ContractExec,
+        data::TransactionData,
         phoenix::{
             Note, NoteLeaf, NoteOpening, NoteTreeItem,
             PublicKey as PhoenixPublicKey, SecretKey as PhoenixSecretKey,
@@ -153,7 +153,7 @@ pub fn create_transaction<const I: usize>(
     transfer_value: u64,
     obfuscated_transaction: bool,
     deposit: u64,
-    exec: Option<impl Into<ContractExec>>,
+    data: Option<impl Into<TransactionData>>,
 ) -> Transaction {
     // Get the root of the tree of phoenix-notes.
     let root = root(session).expect("Getting the anchor should be successful");
@@ -197,7 +197,7 @@ pub fn create_transaction<const I: usize>(
         gas_limit,
         gas_price,
         chain_id,
-        exec.map(Into::into),
+        data.map(Into::into),
     )
     .expect("creating the creation shouldn't fail")
     .into()

--- a/contracts/stake/tests/stake.rs
+++ b/contracts/stake/tests/stake.rs
@@ -15,7 +15,7 @@ use execution_core::{
     signatures::bls::{PublicKey as BlsPublicKey, SecretKey as BlsSecretKey},
     stake::{Stake, StakeData, Withdraw as StakeWithdraw, STAKE_CONTRACT},
     transfer::{
-        contract_exec::ContractCall,
+        data::ContractCall,
         phoenix::{
             PublicKey as PhoenixPublicKey, SecretKey as PhoenixSecretKey,
             ViewKey as PhoenixViewKey,

--- a/contracts/transfer/tests/common/utils.rs
+++ b/contracts/transfer/tests/common/utils.rs
@@ -9,7 +9,7 @@ use std::sync::mpsc;
 use execution_core::{
     signatures::bls::PublicKey as AccountPublicKey,
     transfer::{
-        contract_exec::ContractExec,
+        data::TransactionData,
         moonlight::AccountData,
         phoenix::{
             Note, NoteLeaf, NoteOpening, NoteTreeItem, PublicKey, SecretKey,
@@ -188,7 +188,7 @@ pub fn create_phoenix_transaction<const I: usize>(
     transfer_value: u64,
     obfuscated_transaction: bool,
     deposit: u64,
-    exec: Option<impl Into<ContractExec>>,
+    data: Option<impl Into<TransactionData>>,
 ) -> PhoenixTransaction {
     // Get the root of the tree of phoenix-notes.
     let root = root(session).expect("Getting the anchor should be successful");
@@ -232,7 +232,7 @@ pub fn create_phoenix_transaction<const I: usize>(
         gas_limit,
         gas_price,
         chain_id,
-        exec.map(Into::into),
+        data.map(Into::into),
     )
     .expect("creating the creation shouldn't fail")
 }

--- a/contracts/transfer/tests/transfer.rs
+++ b/contracts/transfer/tests/transfer.rs
@@ -23,7 +23,7 @@ use execution_core::{
         PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
     },
     transfer::{
-        contract_exec::{ContractCall, ContractExec},
+        data::{ContractCall, TransactionData},
         moonlight::Transaction as MoonlightTransaction,
         phoenix::{
             Note, PublicKey as PhoenixPublicKey, SecretKey as PhoenixSecretKey,
@@ -281,8 +281,9 @@ fn moonlight_transfer() {
         LUX,
         sender_account.nonce + 1,
         chain_id,
-        None::<ContractExec>,
-    );
+        None::<TransactionData>,
+    )
+    .expect("Creating moonlight transaction should succeed");
 
     let gas_spent = execute(session, transaction)
         .expect("Transaction should succeed")
@@ -417,7 +418,8 @@ fn moonlight_alice_ping() {
         acc.nonce + 1,
         chain_id,
         contract_call,
-    );
+    )
+    .expect("Creating moonlight transaction should succeed");
 
     let gas_spent = execute(session, transaction)
         .expect("Transaction should succeed")
@@ -775,7 +777,8 @@ fn moonlight_to_phoenix_swap() {
         nonce,
         chain_id,
         Some(contract_call),
-    );
+    )
+    .expect("Creating moonlight transaction should succeed");
 
     let gas_spent = execute(&mut session, tx)
         .expect("Executing transaction should succeed")
@@ -878,7 +881,8 @@ fn swap_wrong_contract_targeted() {
         nonce,
         chain_id,
         Some(contract_call),
-    );
+    )
+    .expect("Creating moonlight transaction should succeed");
 
     let receipt = execute(&mut session, tx)
         .expect("Executing transaction should succeed");
@@ -967,7 +971,8 @@ fn transfer_to_contract() {
         acc.nonce + 1,
         chain_id,
         contract_call,
-    );
+    )
+    .expect("Creating moonlight transaction should succeed");
 
     let receipt =
         execute(session, transaction).expect("Transaction should succeed");
@@ -1019,7 +1024,8 @@ fn transfer_to_contract() {
         acc.nonce + 1,
         chain_id,
         contract_call,
-    );
+    )
+    .expect("Creating moonlight transaction should succeed");
 
     let receipt =
         execute(session, transaction).expect("Transaction should succeed");

--- a/execution-core/CHANGELOG.md
+++ b/execution-core/CHANGELOG.md
@@ -48,10 +48,10 @@ signatures::{
     }
 }
 transfer::{
-    contract_exec::{
+    data::{
         ContractBytecode;
         ContractCall;
-        ContractExec;
+        TransactionData;
     };
     moonlight::{
         AccountData;

--- a/execution-core/src/error.rs
+++ b/execution-core/src/error.rs
@@ -30,6 +30,11 @@ pub enum Error {
     InvalidChar(char, usize),
     /// Rkyv serialization.
     Rkyv(String),
+    /// The provided memo is too large. Contains the memo size used. The max
+    /// size is [`MAX_MEMO_SIZE`].
+    ///
+    /// [`MAX_MEMO_SIZE`]: crate::transfer::data::MAX_MEMO_SIZE
+    MemoTooLarge(usize),
 }
 
 impl fmt::Display for Error {

--- a/execution-core/src/transfer/data.rs
+++ b/execution-core/src/transfer/data.rs
@@ -4,7 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-//! Wrapper for a strip-able bytecode that we want to keep the integrity of.
+//! Extra data that may be sent with the `data` field of either transaction
+//! type.
 
 use alloc::format;
 use alloc::string::String;
@@ -18,25 +19,32 @@ use rkyv::{
 
 use crate::{ContractId, Error, ARGBUF_LEN};
 
+/// The maximum size of a memo.
+pub const MAX_MEMO_SIZE: usize = 512;
+
 /// Data for either contract call or contract deployment.
 #[derive(Debug, Clone, PartialEq, Eq, Archive, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]
-pub enum ContractExec {
+#[allow(clippy::large_enum_variant)]
+pub enum TransactionData {
     /// Data for a contract call.
     Call(ContractCall),
     /// Data for a contract deployment.
     Deploy(ContractDeploy),
+    /// Additional data added to a transaction, that is not a deployment or a
+    /// call.
+    Memo(Vec<u8>),
 }
 
-impl From<ContractCall> for ContractExec {
+impl From<ContractCall> for TransactionData {
     fn from(c: ContractCall) -> Self {
-        ContractExec::Call(c)
+        TransactionData::Call(c)
     }
 }
 
-impl From<ContractDeploy> for ContractExec {
+impl From<ContractDeploy> for TransactionData {
     fn from(d: ContractDeploy) -> Self {
-        ContractExec::Deploy(d)
+        TransactionData::Deploy(d)
     }
 }
 

--- a/execution-core/src/transfer/moonlight.rs
+++ b/execution-core/src/transfer/moonlight.rs
@@ -18,10 +18,11 @@ use crate::{
         PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
         Signature as AccountSignature,
     },
-    transfer::contract_exec::{
-        ContractBytecode, ContractCall, ContractDeploy, ContractExec,
+    transfer::data::{
+        ContractBytecode, ContractCall, ContractDeploy, TransactionData,
+        MAX_MEMO_SIZE,
     },
-    BlsScalar,
+    BlsScalar, Error,
 };
 
 /// A Moonlight account's information.
@@ -44,7 +45,10 @@ pub struct Transaction {
 
 impl Transaction {
     /// Create a new transaction.
-    #[must_use]
+    ///
+    /// # Errors
+    /// The creation of a transaction is not possible and will error if:
+    /// - the memo, if given, is too large
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         from_sk: &AccountSecretKey,
@@ -55,8 +59,16 @@ impl Transaction {
         gas_price: u64,
         nonce: u64,
         chain_id: u8,
-        exec: Option<impl Into<ContractExec>>,
-    ) -> Self {
+        data: Option<impl Into<TransactionData>>,
+    ) -> Result<Self, Error> {
+        let data = data.map(Into::into);
+
+        if let Some(TransactionData::Memo(memo)) = data.as_ref() {
+            if memo.len() > MAX_MEMO_SIZE {
+                return Err(Error::MemoTooLarge(memo.len()));
+            }
+        }
+
         let payload = Payload {
             chain_id,
             from_account: AccountPublicKey::from(from_sk),
@@ -66,13 +78,13 @@ impl Transaction {
             gas_limit,
             gas_price,
             nonce,
-            exec: exec.map(Into::into),
+            data,
         };
 
         let digest = payload.signature_message();
         let signature = from_sk.sign(&digest);
 
-        Self { payload, signature }
+        Ok(Self { payload, signature })
     }
 
     /// The proof of the transaction.
@@ -133,8 +145,8 @@ impl Transaction {
     #[must_use]
     pub fn call(&self) -> Option<&ContractCall> {
         #[allow(clippy::match_wildcard_for_single_variants)]
-        match self.exec()? {
-            ContractExec::Call(ref c) => Some(c),
+        match self.data()? {
+            TransactionData::Call(ref c) => Some(c),
             _ => None,
         }
     }
@@ -143,16 +155,25 @@ impl Transaction {
     #[must_use]
     pub fn deploy(&self) -> Option<&ContractDeploy> {
         #[allow(clippy::match_wildcard_for_single_variants)]
-        match self.exec()? {
-            ContractExec::Deploy(ref d) => Some(d),
+        match self.data()? {
+            TransactionData::Deploy(ref d) => Some(d),
             _ => None,
         }
     }
 
-    /// Returns the contract execution, if it exists.
+    /// Returns the memo used with the transaction, if any.
     #[must_use]
-    fn exec(&self) -> Option<&ContractExec> {
-        self.payload.exec.as_ref()
+    pub fn memo(&self) -> Option<&[u8]> {
+        match self.data()? {
+            TransactionData::Memo(memo) => Some(memo),
+            _ => None,
+        }
+    }
+
+    /// Returns the transaction data, if it exists.
+    #[must_use]
+    fn data(&self) -> Option<&TransactionData> {
+        self.payload.data.as_ref()
     }
 
     /// Creates a modified clone of this transaction if it contains data for
@@ -162,7 +183,7 @@ impl Transaction {
     pub fn strip_off_bytecode(&self) -> Option<Self> {
         let deploy = self.deploy()?;
 
-        let stripped_deploy = ContractExec::Deploy(ContractDeploy {
+        let stripped_deploy = TransactionData::Deploy(ContractDeploy {
             owner: deploy.owner.clone(),
             constructor_args: deploy.constructor_args.clone(),
             bytecode: ContractBytecode {
@@ -173,7 +194,7 @@ impl Transaction {
         });
 
         let mut stripped_transaction = self.clone();
-        stripped_transaction.payload.exec = Some(stripped_deploy);
+        stripped_transaction.payload.data = Some(stripped_deploy);
 
         Some(stripped_transaction)
     }
@@ -267,8 +288,8 @@ struct Payload {
     ///
     /// The current nonce is queryable via the transfer contract.
     pub nonce: u64,
-    /// Data to do a contract call or deployment.
-    pub exec: Option<ContractExec>,
+    /// Data to do a contract call, deployment, or insert a memo.
+    pub data: Option<TransactionData>,
 }
 
 impl Payload {
@@ -296,15 +317,20 @@ impl Payload {
         bytes.extend(self.gas_price.to_bytes());
         bytes.extend(self.nonce.to_bytes());
 
-        // serialize the contract call/deployment
-        match &self.exec {
-            Some(ContractExec::Deploy(deploy)) => {
+        // serialize the contract call, deployment or memo, if present.
+        match &self.data {
+            Some(TransactionData::Call(call)) => {
+                bytes.push(1);
+                bytes.extend(call.to_var_bytes());
+            }
+            Some(TransactionData::Deploy(deploy)) => {
                 bytes.push(2);
                 bytes.extend(deploy.to_var_bytes());
             }
-            Some(ContractExec::Call(call)) => {
-                bytes.push(1);
-                bytes.extend(call.to_var_bytes());
+            Some(TransactionData::Memo(memo)) => {
+                bytes.push(3);
+                bytes.extend((memo.len() as u64).to_bytes());
+                bytes.extend(memo);
             }
             _ => bytes.push(0),
         }
@@ -338,11 +364,25 @@ impl Payload {
         let gas_price = u64::from_reader(&mut buf)?;
         let nonce = u64::from_reader(&mut buf)?;
 
-        // deserialize contract call/deploy data
-        let exec = match u8::from_reader(&mut buf)? {
+        // deserialize contract call, deploy data, or memo, if present
+        let data = match u8::from_reader(&mut buf)? {
             0 => None,
-            1 => Some(ContractExec::Call(ContractCall::from_slice(buf)?)),
-            2 => Some(ContractExec::Deploy(ContractDeploy::from_slice(buf)?)),
+            1 => Some(TransactionData::Call(ContractCall::from_slice(buf)?)),
+            2 => {
+                Some(TransactionData::Deploy(ContractDeploy::from_slice(buf)?))
+            }
+            3 => {
+                // we only build for 64-bit so this truncation is impossible
+                #[allow(clippy::cast_possible_truncation)]
+                let size = u64::from_reader(&mut buf)? as usize;
+
+                if buf.len() != size || size > MAX_MEMO_SIZE {
+                    return Err(BytesError::InvalidData);
+                }
+
+                let memo = buf[..size].to_vec();
+                Some(TransactionData::Memo(memo))
+            }
             _ => {
                 return Err(BytesError::InvalidData);
             }
@@ -357,7 +397,7 @@ impl Payload {
             gas_limit,
             gas_price,
             nonce,
-            exec,
+            data,
         })
     }
 
@@ -379,20 +419,23 @@ impl Payload {
         bytes.extend(self.gas_price.to_bytes());
         bytes.extend(self.nonce.to_bytes());
 
-        match &self.exec {
-            Some(ContractExec::Deploy(d)) => {
+        match &self.data {
+            Some(TransactionData::Deploy(d)) => {
                 bytes.extend(&d.bytecode.to_hash_input_bytes());
                 bytes.extend(&d.owner);
                 if let Some(constructor_args) = &d.constructor_args {
                     bytes.extend(constructor_args);
                 }
             }
-            Some(ContractExec::Call(c)) => {
+            Some(TransactionData::Call(c)) => {
                 bytes.extend(c.contract.as_bytes());
                 bytes.extend(c.fn_name.as_bytes());
                 bytes.extend(&c.fn_args);
             }
-            _ => {}
+            Some(TransactionData::Memo(m)) => {
+                bytes.extend(m);
+            }
+            None => {}
         }
 
         bytes

--- a/node-data/src/ledger/transaction.rs
+++ b/node-data/src/ledger/transaction.rs
@@ -120,7 +120,7 @@ pub mod faker {
     use super::*;
     use crate::ledger::Dummy;
     use execution_core::transfer::{
-        contract_exec::{ContractCall, ContractExec},
+        data::{ContractCall, TransactionData},
         phoenix::{
             Fee, Note, Payload as PhoenixPayload,
             PublicKey as PhoenixPublicKey, SecretKey as PhoenixSecretKey,
@@ -184,7 +184,7 @@ pub mod faker {
             chain_id: 0xFA,
             tx_skeleton,
             fee,
-            exec: Some(ContractExec::Call(contract_call)),
+            data: Some(TransactionData::Call(contract_call)),
         };
         let proof = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 

--- a/rusk/src/lib/error.rs
+++ b/rusk/src/lib/error.rs
@@ -58,6 +58,8 @@ pub enum Error {
     CommitNotFound([u8; 32]),
     /// Invalid credits count
     InvalidCreditsCount(u64, usize),
+    /// Memo too large
+    MemoTooLarge(usize),
 }
 
 impl std::error::Error for Error {}
@@ -106,6 +108,7 @@ impl From<execution_core::Error> for Error {
                 })
             }
             ExecErr::Rkyv(e) => Self::Transaction(ExecErr::Rkyv(e)),
+            ExecErr::MemoTooLarge(size) => Self::MemoTooLarge(size),
         }
     }
 }
@@ -190,6 +193,9 @@ impl fmt::Display for Error {
                     "Invalid credits count, height = {}, credits = {}",
                     height, credits
                 )
+            }
+            Error::MemoTooLarge(size) => {
+                write!(f, "The memo size {size} is too large")
             }
         }
     }

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -26,7 +26,7 @@ use execution_core::{
     signatures::bls::PublicKey as BlsPublicKey,
     stake::{StakeData, STAKE_CONTRACT},
     transfer::{
-        contract_exec::{ContractBytecode, ContractDeploy},
+        data::{ContractBytecode, ContractDeploy},
         moonlight::AccountData,
         Transaction as ProtocolTransaction, TRANSFER_CONTRACT,
     },

--- a/rusk/tests/services/contract_deployment.rs
+++ b/rusk/tests/services/contract_deployment.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 use execution_core::{
-    transfer::contract_exec::{ContractBytecode, ContractDeploy, ContractExec},
+    transfer::data::{ContractBytecode, ContractDeploy, TransactionData},
     ContractId,
 };
 use rand::prelude::*;
@@ -128,7 +128,7 @@ fn make_and_execute_transaction_deploy(
             gas_limit,
             GAS_PRICE,
             0u64,
-            ContractExec::Deploy(ContractDeploy {
+            TransactionData::Deploy(ContractDeploy {
                 bytecode: ContractBytecode {
                     hash,
                     bytes: bytecode.as_ref().to_vec(),

--- a/rusk/tests/services/gas_behavior.rs
+++ b/rusk/tests/services/gas_behavior.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 
 use execution_core::transfer::{
-    contract_exec::{ContractCall, ContractExec},
+    data::{ContractCall, TransactionData},
     TRANSFER_CONTRACT,
 };
 use rand::prelude::*;
@@ -83,7 +83,7 @@ fn make_transactions(
             GAS_LIMIT_0,
             GAS_PRICE,
             DEPOSIT,
-            ContractExec::Call(contract_call.clone()),
+            TransactionData::Call(contract_call.clone()),
         )
         .expect("Making the transaction should succeed");
 

--- a/rusk/tests/services/stake.rs
+++ b/rusk/tests/services/stake.rs
@@ -12,7 +12,7 @@ use execution_core::{
     dusk,
     signatures::bls::PublicKey as BlsPublicKey,
     stake::{StakeAmount, STAKE_CONTRACT},
-    transfer::contract_exec::ContractCall,
+    transfer::data::ContractCall,
 };
 
 use rand::prelude::*;

--- a/rusk/tests/services/unspendable.rs
+++ b/rusk/tests/services/unspendable.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 
 use execution_core::transfer::{
-    contract_exec::{ContractCall, ContractExec},
+    data::{ContractCall, TransactionData},
     TRANSFER_CONTRACT,
 };
 use rand::prelude::*;
@@ -95,7 +95,7 @@ fn make_transactions(
             GAS_LIMIT_0,
             GAS_PRICE,
             DEPOSIT,
-            ContractExec::Call(contract_call.clone()),
+            TransactionData::Call(contract_call.clone()),
         )
         .expect("Making the transaction should succeed");
 
@@ -109,7 +109,7 @@ fn make_transactions(
             GAS_LIMIT_1,
             GAS_PRICE,
             DEPOSIT,
-            ContractExec::Call(contract_call.clone()),
+            TransactionData::Call(contract_call.clone()),
         )
         .expect("Making the transaction should succeed");
 

--- a/test-wallet/src/imp.rs
+++ b/test-wallet/src/imp.rs
@@ -23,7 +23,7 @@ use execution_core::{
     signatures::bls::{PublicKey as BlsPublicKey, SecretKey as BlsSecretKey},
     stake::StakeData,
     transfer::{
-        contract_exec::ContractExec,
+        data::TransactionData,
         moonlight::{AccountData, Transaction as MoonlightTransaction},
         phoenix::{
             Note, NoteLeaf, NoteOpening, PublicKey as PhoenixPublicKey,
@@ -351,7 +351,7 @@ where
         gas_limit: u64,
         gas_price: u64,
         deposit: u64,
-        exec: impl Into<ContractExec>,
+        data: impl Into<TransactionData>,
     ) -> Result<Transaction, Error<S, SC>> {
         let mut sender_sk = self.phoenix_secret_key(sender_index)?;
         let receiver_pk = self.phoenix_public_key(sender_index)?;
@@ -383,7 +383,7 @@ where
             gas_limit,
             gas_price,
             chain_id,
-            Some(exec),
+            Some(data),
         )?;
 
         sender_sk.zeroize();
@@ -415,7 +415,7 @@ where
         let obfuscated_transaction = true;
         let deposit = 0;
 
-        let exec: Option<ContractExec> = None;
+        let data: Option<TransactionData> = None;
 
         let chain_id =
             self.state.fetch_chain_id().map_err(Error::from_state_err)?;
@@ -433,7 +433,7 @@ where
             gas_limit,
             gas_price,
             chain_id,
-            exec,
+            data,
         )?;
 
         sender_sk.zeroize();
@@ -606,7 +606,7 @@ where
         gas_price: u64,
     ) -> Result<Transaction, Error<S, SC>> {
         let deposit = 0;
-        let exec: Option<ContractExec> = None;
+        let data: Option<TransactionData> = None;
 
         self.moonlight_transaction(
             from_index,
@@ -615,7 +615,7 @@ where
             deposit,
             gas_limit,
             gas_price,
-            exec,
+            data,
         )
     }
 
@@ -629,7 +629,7 @@ where
         deposit: u64,
         gas_limit: u64,
         gas_price: u64,
-        exec: Option<impl Into<ContractExec>>,
+        data: Option<impl Into<TransactionData>>,
     ) -> Result<Transaction, Error<S, SC>> {
         let mut seed = self.store.get_seed().map_err(Error::from_store_err)?;
         let mut from_sk = derive_bls_sk(&seed, from_index);
@@ -653,8 +653,8 @@ where
 
         let tx = MoonlightTransaction::new(
             &from_sk, to_account, value, deposit, gas_limit, gas_price, nonce,
-            chain_id, exec,
-        );
+            chain_id, data,
+        )?;
 
         seed.zeroize();
         from_sk.zeroize();

--- a/wallet-core/src/transaction.rs
+++ b/wallet-core/src/transaction.rs
@@ -17,7 +17,7 @@ use execution_core::{
     signatures::bls::SecretKey as BlsSecretKey,
     stake::{Stake, Withdraw as StakeWithdraw, STAKE_CONTRACT},
     transfer::{
-        contract_exec::{ContractCall, ContractExec},
+        data::{ContractCall, TransactionData},
         phoenix::{
             Note, NoteOpening, Prove, PublicKey as PhoenixPublicKey,
             SecretKey as PhoenixSecretKey, Transaction as PhoenixTransaction,
@@ -60,7 +60,7 @@ pub fn phoenix<R: RngCore + CryptoRng, P: Prove>(
     gas_limit: u64,
     gas_price: u64,
     chain_id: u8,
-    exec: Option<impl Into<ContractExec>>,
+    data: Option<impl Into<TransactionData>>,
 ) -> Result<Transaction, Error> {
     Ok(PhoenixTransaction::new::<R, P>(
         rng,
@@ -75,7 +75,7 @@ pub fn phoenix<R: RngCore + CryptoRng, P: Prove>(
         gas_limit,
         gas_price,
         chain_id,
-        exec,
+        data,
     )?
     .into())
 }


### PR DESCRIPTION
In this PR we introduce memos - small pieces of data that a transfer may carry that can be useful in a myriad of situations. Memos are often used by exchanges to be able to target internal accounts whilst using a single key/address for receiving deposits.

This implementation overloads the `ContractExec` enum with an additional `Memo` variant, where the transactor may place at most 512 bytes of information. This has the advantage of not adding an additional optional field in a transaction, but comes at the cost of memos only being available for transactions that don't include a contract call or deployment.

Due to this enum overloading, the name `ContractExec` no longer makes sense, so we rename it to `TransactionData`, together with the `exec` fields in the transaction structures - which are renamed to `data`.

Memos are available in both Moonlight and Phoenix transactions, but are arguably more useful in Moonlight due to the transparency of the sender.

Resolves: #2264