### PR TITLE
Improved deployment pricing

### DIFF
--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow state transitions to be executed in parallel with queries [#970]
 - Change dependencies declarations enforce bytecheck [#1371]
 - Fixed tests passing incorrect arguments [#1371]
+- Adjusted deployment charging [#2207]
 
 ### Added
 
@@ -211,6 +212,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add linking between Rusk and Protobuff structs
 - Add build system that generates keys for circuits and caches them.
 
+[#2207]: https://github.com/dusk-network/rusk/issues/2207
 [#1884]: https://github.com/dusk-network/rusk/issues/1884
 [#1882]: https://github.com/dusk-network/rusk/issues/1882
 [#1675]: https://github.com/dusk-network/rusk/issues/1675

--- a/rusk/default.config.toml
+++ b/rusk/default.config.toml
@@ -14,6 +14,7 @@
 #generation_timeout = '3s'
 # Note: changing the gas per deploy byte parameter is equivalent to forking the chain.
 #gas_per_deploy_byte = 100
+#min_deployment_gas_price = 2000
 
 [databroker]
 max_inv_entries = 100

--- a/rusk/src/bin/config/chain.rs
+++ b/rusk/src/bin/config/chain.rs
@@ -27,6 +27,7 @@ pub(crate) struct ChainConfig {
     // NB: changing the gas_per_deploy_byte/block_gas_limit is equivalent to
     // forking the chain.
     gas_per_deploy_byte: Option<u64>,
+    min_deployment_gas_price: Option<u64>,
     block_gas_limit: Option<u64>,
 }
 
@@ -77,6 +78,10 @@ impl ChainConfig {
 
     pub(crate) fn gas_per_deploy_byte(&self) -> Option<u64> {
         self.gas_per_deploy_byte
+    }
+
+    pub(crate) fn min_deployment_gas_price(&self) -> Option<u64> {
+        self.min_deployment_gas_price
     }
 
     pub(crate) fn max_queue_size(&self) -> usize {

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -67,6 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             config.kadcast.chain_id(),
             config.chain.generation_timeout(),
             config.chain.gas_per_deploy_byte(),
+            config.chain.min_deployment_gas_price(),
             config.chain.block_gas_limit(),
             config.http.feeder_call_gas,
             _event_sender.clone(),

--- a/rusk/src/lib/node.rs
+++ b/rusk/src/lib/node.rs
@@ -45,6 +45,7 @@ pub struct Rusk {
     pub(crate) chain_id: u8,
     pub(crate) generation_timeout: Option<Duration>,
     pub(crate) gas_per_deploy_byte: Option<u64>,
+    pub(crate) min_deployment_gas_price: Option<u64>,
     pub(crate) feeder_gas_limit: u64,
     pub(crate) block_gas_limit: u64,
     pub(crate) event_sender: broadcast::Sender<RuesEvent>,

--- a/rusk/tests/common/state.rs
+++ b/rusk/tests/common/state.rs
@@ -44,9 +44,17 @@ pub fn new_state<P: AsRef<Path>>(
 
     let (sender, _) = broadcast::channel(10);
 
-    let rusk =
-        Rusk::new(dir, CHAIN_ID, None, None, block_gas_limit, u64::MAX, sender)
-            .expect("Instantiating rusk should succeed");
+    let rusk = Rusk::new(
+        dir,
+        CHAIN_ID,
+        None,
+        None,
+        None,
+        block_gas_limit,
+        u64::MAX,
+        sender,
+    )
+    .expect("Instantiating rusk should succeed");
 
     assert_eq!(
         commit_id,

--- a/rusk/tests/config/contract_deployment.toml
+++ b/rusk/tests/config/contract_deployment.toml
@@ -1,4 +1,4 @@
 [[phoenix_balance]]
 address = "ivmscertKgRyX8wNMJJsQcSVEyPsfSMUQXSAgeAPQXsndqFq9Pmknzhm61QvcEEdxPaGgxDS4RHpb6KKccrnSKN"
 seed = 57005
-notes = [10_000_000_000]
+notes = [1_000_000_000_000]

--- a/rusk/tests/services/contract_deployment.rs
+++ b/rusk/tests/services/contract_deployment.rs
@@ -31,9 +31,8 @@ const BLOCK_HEIGHT: u64 = 1;
 const BLOCK_GAS_LIMIT: u64 = 1_000_000_000_000;
 const GAS_LIMIT: u64 = 200_000_000;
 const GAS_LIMIT_NOT_ENOUGH_TO_SPEND: u64 = 10_000_000;
-const GAS_LIMIT_NOT_ENOUGH_TO_SPEND_AND_DEPLOY: u64 = 11_000_000;
 const GAS_LIMIT_NOT_ENOUGH_TO_DEPLOY: u64 = 1_200_000;
-const GAS_PRICE: u64 = 2;
+const GAS_PRICE: u64 = 2000;
 const POINT_LIMIT: u64 = 0x10000000;
 const SENDER_INDEX: u8 = 0;
 
@@ -81,7 +80,7 @@ fn initial_state<P: AsRef<Path>>(dir: P, deploy_bob: bool) -> Result<Rusk> {
                     bob_bytecode,
                     ContractData::builder()
                         .owner(OWNER)
-                        .constructor_arg(&BOB_INIT_VALUE)
+                        .init_arg(&BOB_INIT_VALUE)
                         .contract_id(gen_contract_id(
                             &bob_bytecode,
                             0u64,
@@ -96,9 +95,17 @@ fn initial_state<P: AsRef<Path>>(dir: P, deploy_bob: bool) -> Result<Rusk> {
 
     let (sender, _) = broadcast::channel(10);
 
-    let rusk =
-        Rusk::new(dir, CHAIN_ID, None, None, BLOCK_GAS_LIMIT, u64::MAX, sender)
-            .expect("Instantiating rusk should succeed");
+    let rusk = Rusk::new(
+        dir,
+        CHAIN_ID,
+        None,
+        None,
+        None,
+        BLOCK_GAS_LIMIT,
+        u64::MAX,
+        sender,
+    )
+    .expect("Instantiating rusk should succeed");
     Ok(rusk)
 }
 
@@ -115,6 +122,7 @@ fn make_and_execute_transaction_deploy(
     init_value: u8,
     should_fail: bool,
     should_discard: bool,
+    gas_price: u64,
 ) {
     let mut rng = StdRng::seed_from_u64(0xcafe);
 
@@ -126,7 +134,7 @@ fn make_and_execute_transaction_deploy(
             &mut rng,
             SENDER_INDEX,
             gas_limit,
-            GAS_PRICE,
+            gas_price,
             0u64,
             TransactionData::Deploy(ContractDeploy {
                 bytecode: ContractBytecode {
@@ -282,6 +290,7 @@ pub async fn contract_deploy() {
         BOB_INIT_VALUE,
         false,
         false,
+        GAS_PRICE,
     );
     let after_balance = f.wallet_balance();
     f.assert_bob_contract_is_deployed();
@@ -307,6 +316,7 @@ pub async fn contract_already_deployed() {
         BOB_INIT_VALUE,
         true,
         false,
+        GAS_PRICE,
     );
     let after_balance = f.wallet_balance();
     let funds_spent = before_balance - after_balance;
@@ -334,6 +344,7 @@ pub async fn contract_deploy_corrupted_bytecode() {
         BOB_INIT_VALUE,
         true,
         false,
+        GAS_PRICE,
     );
     let after_balance = f.wallet_balance();
     let funds_spent = before_balance - after_balance;
@@ -360,6 +371,7 @@ pub async fn contract_deploy_charge() {
         BOB_INIT_VALUE,
         false,
         false,
+        GAS_PRICE,
     );
     let after_bob_balance = f.wallet_balance();
     make_and_execute_transaction_deploy(
@@ -370,6 +382,7 @@ pub async fn contract_deploy_charge() {
         0,
         false,
         false,
+        GAS_PRICE,
     );
     let after_license_balance = f.wallet_balance();
     let bob_deployment_cost = before_balance - after_bob_balance;
@@ -396,6 +409,7 @@ pub async fn contract_deploy_not_enough_to_spend() {
         BOB_INIT_VALUE,
         false,
         true,
+        GAS_PRICE,
     );
     let after_balance = f.wallet_balance();
     f.assert_bob_contract_is_not_deployed();
@@ -403,12 +417,11 @@ pub async fn contract_deploy_not_enough_to_spend() {
     assert_eq!(funds_spent, 0);
 }
 
-/// We deploy a contract with insufficient gas limit.
-/// The limit is such that it is enough to spend but not enough to deploy.
-/// Transaction won't be discarded and all limit will be spent by the wallet.
-/// Wallet will spend GAS_LIMIT_NOT_ENOUGH_TO_DEPLOY x GAS_PRICE of funds.
+/// We deploy a contract with insufficient gas price.
+/// Transaction will be discarded.
 #[tokio::test(flavor = "multi_thread")]
-pub async fn contract_deploy_not_enough_to_spend_and_deploy() {
+pub async fn contract_deploy_gas_price_too_low() {
+    const LOW_GAS_PRICE: u64 = 10;
     logger();
     let f = Fixture::build(false);
 
@@ -418,25 +431,23 @@ pub async fn contract_deploy_not_enough_to_spend_and_deploy() {
         &f.rusk,
         &f.wallet,
         f.bob_bytecode.clone(),
-        GAS_LIMIT_NOT_ENOUGH_TO_SPEND_AND_DEPLOY,
+        GAS_LIMIT,
         BOB_INIT_VALUE,
-        true,
         false,
+        true,
+        LOW_GAS_PRICE,
     );
     let after_balance = f.wallet_balance();
     f.assert_bob_contract_is_not_deployed();
     let funds_spent = before_balance - after_balance;
-    assert_eq!(
-        funds_spent,
-        GAS_LIMIT_NOT_ENOUGH_TO_SPEND_AND_DEPLOY * GAS_PRICE
-    );
+    assert_eq!(funds_spent, 0);
 }
 
 /// We deploy a contract with insufficient gas limit.
 /// The limit is such that it is not enough to deploy.
 /// Transaction will be discarded and no funds will be spent by the wallet.
 #[tokio::test(flavor = "multi_thread")]
-pub async fn contract_deploy_not_enough_to_deploy() {
+pub async fn contract_deploy_gas_limit_too_low() {
     logger();
     let f = Fixture::build(false);
 
@@ -450,6 +461,7 @@ pub async fn contract_deploy_not_enough_to_deploy() {
         BOB_INIT_VALUE,
         false,
         true,
+        GAS_PRICE,
     );
     let after_balance = f.wallet_balance();
     f.assert_bob_contract_is_not_deployed();

--- a/rusk/tests/services/owner_calls.rs
+++ b/rusk/tests/services/owner_calls.rs
@@ -64,7 +64,7 @@ fn initial_state<P: AsRef<Path>>(
                 bob_bytecode,
                 ContractData::builder()
                     .owner(owner.as_ref())
-                    .constructor_arg(&BOB_INIT_VALUE)
+                    .init_arg(&BOB_INIT_VALUE)
                     .contract_id(gen_contract_id(&bob_bytecode, 0u64, owner)),
                 POINT_LIMIT,
             )
@@ -74,9 +74,17 @@ fn initial_state<P: AsRef<Path>>(
 
     let (sender, _) = broadcast::channel(10);
 
-    let rusk =
-        Rusk::new(dir, CHAIN_ID, None, None, BLOCK_GAS_LIMIT, u64::MAX, sender)
-            .expect("Instantiating rusk should succeed");
+    let rusk = Rusk::new(
+        dir,
+        CHAIN_ID,
+        None,
+        None,
+        None,
+        BLOCK_GAS_LIMIT,
+        u64::MAX,
+        sender,
+    )
+    .expect("Instantiating rusk should succeed");
     Ok(rusk)
 }
 


### PR DESCRIPTION
This PR improved deployment pricing in such a way that the cost of deployment should not be negligible to the user.
The deployment charging behaviour is controlled by the following configuration items:

```
gas_per_deploy_byte
min_deployment_gas_price
```

Transaction containing deployment will be discarded if the minimum transaction gas price is insufficient.
The defaults are set as follows:

```
const DEFAULT_GAS_PER_DEPLOY_BYTE: u64 = 100;
const DEFAULT_MIN_DEPLOYMENT_GAS_PRICE: u64 = 2000;
```

Current defaults should enforce reasonable deployment costs in the real world.

Implements #2207 
