### PR TITLE
Fix minor consistency issues

### DIFF
--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -604,7 +604,7 @@ impl TransferState {
     pub fn push_note(&mut self, block_height: u64, note: Note) -> Note {
         let tree_leaf = NoteLeaf { block_height, note };
         let pos = self.tree.push(tree_leaf.clone());
-        rusk_abi::emit("TREE_LEAF", (pos, tree_leaf));
+        rusk_abi::emit("tree_leaf", (pos, tree_leaf));
         self.get_note(pos)
             .expect("There should be a note that was just inserted")
     }

--- a/execution-core/src/transfer/data.rs
+++ b/execution-core/src/transfer/data.rs
@@ -56,8 +56,8 @@ pub struct ContractDeploy {
     pub bytecode: ContractBytecode,
     /// Owner of the contract to be deployed.
     pub owner: Vec<u8>,
-    /// Constructor arguments of the deployed contract.
-    pub constructor_args: Option<Vec<u8>>,
+    /// Init method arguments of the deployed contract.
+    pub init_args: Option<Vec<u8>>,
     /// Nonce for contract id uniqueness and vanity
     pub nonce: u64,
 }
@@ -85,11 +85,11 @@ impl ContractDeploy {
         bytes.extend((self.owner.len() as u64).to_bytes());
         bytes.extend(&self.owner);
 
-        match &self.constructor_args {
-            Some(constructor_args) => {
+        match &self.init_args {
+            Some(init_args) => {
                 bytes.push(1);
-                bytes.extend((constructor_args.len() as u64).to_bytes());
-                bytes.extend(constructor_args);
+                bytes.extend((init_args.len() as u64).to_bytes());
+                bytes.extend(init_args);
             }
             None => bytes.push(0),
         }
@@ -110,7 +110,7 @@ impl ContractDeploy {
 
         let owner = crate::read_vec(&mut buf)?;
 
-        let constructor_args = match u8::from_reader(&mut buf)? {
+        let init_args = match u8::from_reader(&mut buf)? {
             0 => None,
             1 => Some(crate::read_vec(&mut buf)?),
             _ => return Err(BytesError::InvalidData),
@@ -121,7 +121,7 @@ impl ContractDeploy {
         Ok(Self {
             bytecode,
             owner,
-            constructor_args,
+            init_args,
             nonce,
         })
     }

--- a/execution-core/src/transfer/moonlight.rs
+++ b/execution-core/src/transfer/moonlight.rs
@@ -185,7 +185,7 @@ impl Transaction {
 
         let stripped_deploy = TransactionData::Deploy(ContractDeploy {
             owner: deploy.owner.clone(),
-            constructor_args: deploy.constructor_args.clone(),
+            init_args: deploy.init_args.clone(),
             bytecode: ContractBytecode {
                 hash: deploy.bytecode.hash,
                 bytes: Vec::new(),
@@ -423,8 +423,8 @@ impl Payload {
             Some(TransactionData::Deploy(d)) => {
                 bytes.extend(&d.bytecode.to_hash_input_bytes());
                 bytes.extend(&d.owner);
-                if let Some(constructor_args) = &d.constructor_args {
-                    bytes.extend(constructor_args);
+                if let Some(init_args) = &d.init_args {
+                    bytes.extend(init_args);
                 }
             }
             Some(TransactionData::Call(c)) => {

--- a/execution-core/src/transfer/phoenix.rs
+++ b/execution-core/src/transfer/phoenix.rs
@@ -452,7 +452,7 @@ impl Transaction {
 
         let stripped_deploy = TransactionData::Deploy(ContractDeploy {
             owner: deploy.owner.clone(),
-            constructor_args: deploy.constructor_args.clone(),
+            init_args: deploy.init_args.clone(),
             bytecode: ContractBytecode {
                 hash: deploy.bytecode.hash,
                 bytes: Vec::new(),
@@ -723,8 +723,8 @@ impl Payload {
             Some(TransactionData::Deploy(d)) => {
                 bytes.extend(&d.bytecode.to_hash_input_bytes());
                 bytes.extend(&d.owner);
-                if let Some(constructor_args) = &d.constructor_args {
-                    bytes.extend(constructor_args);
+                if let Some(init_args) = &d.init_args {
+                    bytes.extend(init_args);
                 }
             }
             Some(TransactionData::Call(c)) => {

--- a/execution-core/tests/serialization.rs
+++ b/execution-core/tests/serialization.rs
@@ -206,15 +206,15 @@ fn phoenix_with_deploy() -> Result<(), Error> {
     let mut owner = [0; 32].to_vec();
     rng.fill_bytes(&mut owner);
 
-    let mut constructor_args = vec![0; 20];
-    rng.fill_bytes(&mut constructor_args);
+    let mut init_args = vec![0; 20];
+    rng.fill_bytes(&mut init_args);
 
     let nonce = rng.next_u64();
 
     let deploy = ContractDeploy {
         bytecode,
         owner,
-        constructor_args: Some(constructor_args),
+        init_args: Some(init_args),
         nonce,
     };
 
@@ -242,8 +242,8 @@ fn phoenix_with_memo() -> Result<(), Error> {
     let mut owner = [0; 32].to_vec();
     rng.fill_bytes(&mut owner);
 
-    let mut constructor_args = vec![0; 20];
-    rng.fill_bytes(&mut constructor_args);
+    let mut init_args = vec![0; 20];
+    rng.fill_bytes(&mut init_args);
 
     let memo = vec![1u8; 512];
 
@@ -313,15 +313,15 @@ fn moonlight_with_deploy() -> Result<(), Error> {
     let mut owner = [0; 32].to_vec();
     rng.fill_bytes(&mut owner);
 
-    let mut constructor_args = vec![0; 20];
-    rng.fill_bytes(&mut constructor_args);
+    let mut init_args = vec![0; 20];
+    rng.fill_bytes(&mut init_args);
 
     let nonce = rng.next_u64();
 
     let deploy = ContractDeploy {
         bytecode,
         owner,
-        constructor_args: Some(constructor_args),
+        init_args: Some(init_args),
         nonce,
     };
 
@@ -348,8 +348,8 @@ fn moonlight_with_memo() -> Result<(), Error> {
     let mut owner = [0; 32].to_vec();
     rng.fill_bytes(&mut owner);
 
-    let mut constructor_args = vec![0; 20];
-    rng.fill_bytes(&mut constructor_args);
+    let mut init_args = vec![0; 20];
+    rng.fill_bytes(&mut init_args);
 
     let memo = vec![1u8; 512];
 

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -573,7 +573,7 @@ fn contract_deploy(
                 &deploy.owner,
             )),
             deploy.bytecode.bytes.as_slice(),
-            deploy.constructor_args.clone(),
+            deploy.init_args.clone(),
             deploy.owner.clone(),
             gas_limit - receipt.gas_spent,
         );

--- a/rusk/tests/services/contract_deployment.rs
+++ b/rusk/tests/services/contract_deployment.rs
@@ -81,7 +81,7 @@ fn initial_state<P: AsRef<Path>>(dir: P, deploy_bob: bool) -> Result<Rusk> {
                     bob_bytecode,
                     ContractData::builder()
                         .owner(OWNER)
-                        .constructor_arg(&BOB_INIT_VALUE)
+                        .init_arg(&BOB_INIT_VALUE)
                         .contract_id(gen_contract_id(
                             &bob_bytecode,
                             0u64,
@@ -118,7 +118,7 @@ fn make_and_execute_transaction_deploy(
 ) {
     let mut rng = StdRng::seed_from_u64(0xcafe);
 
-    let constructor_args = Some(vec![init_value]);
+    let init_args = Some(vec![init_value]);
 
     let hash = bytecode_hash(bytecode.as_ref()).to_bytes();
     let tx = wallet
@@ -134,7 +134,7 @@ fn make_and_execute_transaction_deploy(
                     bytes: bytecode.as_ref().to_vec(),
                 },
                 owner: OWNER.to_vec(),
-                constructor_args,
+                init_args,
                 nonce: 0,
             }),
         )

--- a/rusk/tests/services/owner_calls.rs
+++ b/rusk/tests/services/owner_calls.rs
@@ -64,7 +64,7 @@ fn initial_state<P: AsRef<Path>>(
                 bob_bytecode,
                 ContractData::builder()
                     .owner(owner.as_ref())
-                    .constructor_arg(&BOB_INIT_VALUE)
+                    .init_arg(&BOB_INIT_VALUE)
                     .contract_id(gen_contract_id(&bob_bytecode, 0u64, owner)),
                 POINT_LIMIT,
             )


### PR DESCRIPTION
This PR addresses two consistency topics:

1. Every `topic` in rusk_abi::emit events used in Rusk is lower case and according to ZER0 should be lower case. So I changed the "TREE_LEAF" to "tree_leaf" as it was the only topic that used upper case.
2. Piecrust has an init method to run arbitrary initialization logic during deployment. For reasons explained in https://github.com/dusk-network/piecrust/pull/381, we have changed all related naming from constructor_ to init_, this change is now also reflected in the relevant Rusk parts.