### PR TITLE
Consolidate `reward` calls into one

### DIFF
--- a/contracts/stake/src/lib.rs
+++ b/contracts/stake/src/lib.rs
@@ -92,9 +92,9 @@ unsafe fn insert_stake(arg_len: u32) -> u32 {
 
 #[no_mangle]
 unsafe fn reward(arg_len: u32) -> u32 {
-    rusk_abi::wrap_call(arg_len, |(pk, value)| {
+    rusk_abi::wrap_call(arg_len, |arg| {
         assert_external_caller();
-        STATE.reward(&pk, value);
+        STATE.reward(arg);
     })
 }
 

--- a/contracts/stake/tests/common/assert.rs
+++ b/contracts/stake/tests/common/assert.rs
@@ -9,7 +9,7 @@ use rkyv::{check_archived_root, Deserialize, Infallible};
 
 use execution_core::{
     signatures::bls::PublicKey as BlsPublicKey,
-    stake::{StakeEvent, StakeWithReceiverEvent},
+    stake::{Reward, StakeEvent, StakeWithReceiverEvent},
     Event,
 };
 
@@ -37,6 +37,13 @@ pub fn assert_event<S>(
             .expect("Infallible");
         assert_eq!(staking_event_data.value, should_amount);
         assert_eq!(staking_event_data.account.to_bytes(), should_pk.to_bytes());
+    } else if topic == "reward" {
+        let reward_event_data = rkyv::from_bytes::<Vec<Reward>>(&event.data)
+            .expect("Reward event data should deserialize correctly");
+
+        assert!(reward_event_data.iter().any(|reward| {
+            &reward.account == should_pk && reward.value == should_amount
+        }))
     } else {
         let staking_event_data =
             check_archived_root::<StakeEvent>(event.data.as_slice())

--- a/contracts/stake/tests/stake.rs
+++ b/contracts/stake/tests/stake.rs
@@ -13,7 +13,10 @@ use rand::SeedableRng;
 use execution_core::{
     dusk,
     signatures::bls::{PublicKey as BlsPublicKey, SecretKey as BlsSecretKey},
-    stake::{Stake, StakeData, Withdraw as StakeWithdraw, STAKE_CONTRACT},
+    stake::{
+        Reward, RewardReason, Stake, StakeData, Withdraw as StakeWithdraw,
+        STAKE_CONTRACT,
+    },
     transfer::{
         data::ContractCall,
         phoenix::{
@@ -132,13 +135,14 @@ fn stake_withdraw_unstake() {
 
     const REWARD_AMOUNT: u64 = dusk(5.0);
 
+    let rewards = vec![Reward {
+        account: stake_pk,
+        value: REWARD_AMOUNT,
+        reason: RewardReason::Other,
+    }];
+
     let receipt = session
-        .call::<_, ()>(
-            STAKE_CONTRACT,
-            "reward",
-            &(stake_pk, REWARD_AMOUNT),
-            POINT_LIMIT,
-        )
+        .call::<_, ()>(STAKE_CONTRACT, "reward", &rewards, POINT_LIMIT)
         .expect("Rewarding a key should succeed");
 
     assert_event(&receipt.events, "reward", &stake_pk, REWARD_AMOUNT);

--- a/execution-core/CHANGELOG.md
+++ b/execution-core/CHANGELOG.md
@@ -100,6 +100,8 @@ stake::{
     StakeData;
     StakeEvent;
     Withdraw;
+    Reward;
+    RewardReason;
     EPOCH;
     STAKE_CONTRACT;
     STAKE_WARNINGS;

--- a/execution-core/src/stake.rs
+++ b/execution-core/src/stake.rs
@@ -457,3 +457,30 @@ impl Serializable<STAKE_AMOUNT_SIZE> for StakeAmount {
         buf
     }
 }
+
+/// Used in a `reward` call to reward a given account with an amount of Dusk,
+/// and emitted as an event, once a reward succeeds.
+#[derive(Debug, Clone, PartialEq, Eq, Archive, Serialize, Deserialize)]
+#[archive_attr(derive(CheckBytes))]
+pub struct Reward {
+    /// The account to be rewarded.
+    pub account: BlsPublicKey,
+    /// The amount to reward.
+    pub value: u64,
+    /// The reason for the reward.
+    pub reason: RewardReason,
+}
+
+/// The reason that a reward is issued.
+#[derive(Debug, Clone, PartialEq, Eq, Archive, Serialize, Deserialize)]
+#[archive_attr(derive(CheckBytes))]
+pub enum RewardReason {
+    /// The fixed amount awarded to a generator.
+    GeneratorFixed,
+    /// Extra amount awarded to a generator.
+    GeneratorExtra,
+    /// Amount awarded to a voter.
+    Voter,
+    /// Amount awarded for another reason, such as rewarding Dusk.
+    Other,
+}

--- a/rusk/tests/services/contract_deployment.rs
+++ b/rusk/tests/services/contract_deployment.rs
@@ -81,7 +81,7 @@ fn initial_state<P: AsRef<Path>>(dir: P, deploy_bob: bool) -> Result<Rusk> {
                     bob_bytecode,
                     ContractData::builder()
                         .owner(OWNER)
-                        .constructor_arg(&BOB_INIT_VALUE)
+                        .init_arg(&BOB_INIT_VALUE)
                         .contract_id(gen_contract_id(
                             &bob_bytecode,
                             0u64,

--- a/rusk/tests/services/owner_calls.rs
+++ b/rusk/tests/services/owner_calls.rs
@@ -64,7 +64,7 @@ fn initial_state<P: AsRef<Path>>(
                 bob_bytecode,
                 ContractData::builder()
                     .owner(owner.as_ref())
-                    .constructor_arg(&BOB_INIT_VALUE)
+                    .init_arg(&BOB_INIT_VALUE)
                     .contract_id(gen_contract_id(&bob_bytecode, 0u64, owner)),
                 POINT_LIMIT,
             )


### PR DESCRIPTION
This is not only a performance optimization, but also useful for minimizing the amount of events emitted - which has a storage impact on prospective archivers.

