### PR TITLE
stake-contract: events

### DIFF
--- a/contracts/stake/tests/common/assert.rs
+++ b/contracts/stake/tests/common/assert.rs
@@ -9,7 +9,7 @@ use rkyv::{check_archived_root, Deserialize, Infallible};
 
 use execution_core::{
     signatures::bls::PublicKey as BlsPublicKey,
-    stake::{Reward, StakeEvent, StakeWithReceiverEvent},
+    stake::{Reward, SlashEvent, StakeEvent},
     Event,
 };
 
@@ -27,17 +27,7 @@ pub fn assert_event<S>(
         .find(|e| e.topic == topic)
         .expect(&format!("event: {topic} should exist in the event list",));
 
-    if topic == "unstake" || topic == "withdraw" {
-        let staking_event_data = check_archived_root::<StakeWithReceiverEvent>(
-            event.data.as_slice(),
-        )
-        .expect("Stake event data should deserialize correctly");
-        let staking_event_data: StakeWithReceiverEvent = staking_event_data
-            .deserialize(&mut Infallible)
-            .expect("Infallible");
-        assert_eq!(staking_event_data.value, should_amount);
-        assert_eq!(staking_event_data.account.to_bytes(), should_pk.to_bytes());
-    } else if topic == "reward" {
+    if topic == "reward" {
         let reward_event_data = rkyv::from_bytes::<Vec<Reward>>(&event.data)
             .expect("Reward event data should deserialize correctly");
 
@@ -53,5 +43,38 @@ pub fn assert_event<S>(
             .expect("Infallible");
         assert_eq!(staking_event_data.value, should_amount);
         assert_eq!(staking_event_data.account.to_bytes(), should_pk.to_bytes());
+    }
+}
+
+pub fn assert_slash_event<S, E: Into<Option<u64>>>(
+    events: &Vec<Event>,
+    topic: S,
+    should_pk: &BlsPublicKey,
+    should_amount: u64,
+    should_eligibility: E,
+) where
+    S: AsRef<str>,
+{
+    let topic = topic.as_ref();
+    let event = events
+        .iter()
+        .find(|e| e.topic == topic)
+        .expect(&format!("event: {topic} should exist in the event list",));
+
+    if topic == "slash" || topic == "hard_slash" {
+        let staking_event_data =
+            check_archived_root::<SlashEvent>(event.data.as_slice())
+                .expect("Stake event data should deserialize correctly");
+        let staking_event_data: SlashEvent = staking_event_data
+            .deserialize(&mut Infallible)
+            .expect("Infallible");
+        assert_eq!(staking_event_data.value, should_amount);
+        assert_eq!(staking_event_data.account.to_bytes(), should_pk.to_bytes());
+        let should_eligibility: Option<u64> = should_eligibility.into();
+        if let Some(should_eligibility) = should_eligibility {
+            assert_eq!(staking_event_data.next_eligibility, should_eligibility);
+        }
+    } else {
+        panic!("{topic} topic cannot be verified with assert_slash_event");
     }
 }

--- a/contracts/stake/tests/events.rs
+++ b/contracts/stake/tests/events.rs
@@ -6,6 +6,7 @@
 
 pub mod common;
 
+use common::assert::assert_slash_event;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
@@ -89,7 +90,7 @@ fn reward_slash() -> Result<(), PiecrustError> {
         u64::MAX,
     )?;
     assert!(receipt.events.len() == 1, "No shift at first warn");
-    assert_event(&receipt.events, "slash", &stake_pk, slash_amount);
+    assert_slash_event(&receipt.events, "slash", &stake_pk, slash_amount, None);
     let stake_amount = stake_amount - slash_amount;
 
     let receipt = session.call::<_, ()>(
@@ -100,8 +101,7 @@ fn reward_slash() -> Result<(), PiecrustError> {
     )?;
     // 10% of current amount
     let slash_amount = stake_amount / 10;
-    assert_event(&receipt.events, "slash", &stake_pk, slash_amount);
-    assert_event(&receipt.events, "suspended", &stake_pk, 4320);
+    assert_slash_event(&receipt.events, "slash", &stake_pk, slash_amount, 4320);
 
     let receipt = session.call::<_, ()>(
         STAKE_CONTRACT,
@@ -113,8 +113,7 @@ fn reward_slash() -> Result<(), PiecrustError> {
 
     // 20% of current amount
     let slash_amount = stake_amount / 100 * 20;
-    assert_event(&receipt.events, "slash", &stake_pk, slash_amount);
-    assert_event(&receipt.events, "suspended", &stake_pk, 6480);
+    assert_slash_event(&receipt.events, "slash", &stake_pk, slash_amount, 6480);
 
     Ok(())
 }
@@ -175,7 +174,14 @@ fn stake_hard_slash() -> Result<(), PiecrustError> {
         u64::MAX,
     )?;
     let expected_slash = stake_amount / 100 * 10;
-    assert_event(&receipt.events, "hard_slash", &stake_pk, expected_slash);
+    assert_slash_event(
+        &receipt.events,
+        "hard_slash",
+        &stake_pk,
+        expected_slash,
+        None,
+    );
+    println!("f1");
     cur_balance -= expected_slash;
 
     // Severe hard fault (slash 30%)
@@ -186,7 +192,13 @@ fn stake_hard_slash() -> Result<(), PiecrustError> {
         u64::MAX,
     )?;
     let expected_slash = cur_balance / 100 * (1 + severity) * 10;
-    assert_event(&receipt.events, "hard_slash", &stake_pk, expected_slash);
+    assert_slash_event(
+        &receipt.events,
+        "hard_slash",
+        &stake_pk,
+        expected_slash,
+        None,
+    );
     cur_balance -= expected_slash;
 
     // Direct slash (slash hard_slash_amount)
@@ -196,7 +208,13 @@ fn stake_hard_slash() -> Result<(), PiecrustError> {
         &(stake_pk, Some(hard_slash_amount), None::<u8>),
         u64::MAX,
     )?;
-    assert_event(&receipt.events, "hard_slash", &stake_pk, hard_slash_amount);
+    assert_slash_event(
+        &receipt.events,
+        "hard_slash",
+        &stake_pk,
+        hard_slash_amount,
+        None,
+    );
     cur_balance -= hard_slash_amount;
 
     let rewards = vec![Reward {
@@ -218,7 +236,13 @@ fn stake_hard_slash() -> Result<(), PiecrustError> {
         u64::MAX,
     )?;
     let expected_slash = cur_balance / 100 * 10;
-    assert_event(&receipt.events, "hard_slash", &stake_pk, expected_slash);
+    assert_slash_event(
+        &receipt.events,
+        "hard_slash",
+        &stake_pk,
+        expected_slash,
+        None,
+    );
 
     Ok(())
 }

--- a/execution-core/src/stake.rs
+++ b/execution-core/src/stake.rs
@@ -17,7 +17,7 @@ use crate::{
         PublicKey as BlsPublicKey, SecretKey as BlsSecretKey,
         Signature as BlsSignature,
     },
-    transfer::withdraw::{Withdraw as TransferWithdraw, WithdrawReceiver},
+    transfer::withdraw::Withdraw as TransferWithdraw,
     ContractId,
 };
 
@@ -196,22 +196,20 @@ impl Withdraw {
 pub struct StakeEvent {
     /// Account associated to the event.
     pub account: BlsPublicKey,
-    /// Value of the relevant operation, be it `stake`, `reward` or `slash`.
-    ///
-    /// In case of `suspended` the amount refers to the next eligibility
+    /// Value of the relevant operation, be it `stake`, `unstake`,`withdraw`
     pub value: u64,
 }
 
-/// Event emitted after a stake contract operation is performed.
+/// Event emitted after a slash operation is performed.
 #[derive(Debug, Clone, Archive, Deserialize, Serialize)]
 #[archive_attr(derive(CheckBytes))]
-pub struct StakeWithReceiverEvent {
-    /// Account associated to the event.
+pub struct SlashEvent {
+    /// Account slashed.
     pub account: BlsPublicKey,
-    /// Value of the relevant operation, be it `unstake` or `withdraw`.
+    /// Slashed amount
     pub value: u64,
-    /// The receiver of the action
-    pub receiver: Option<WithdrawReceiver>,
+    /// New eligibility for the slashed account
+    pub next_eligibility: u64,
 }
 
 /// The minimum amount of Dusk one can stake.


### PR DESCRIPTION

> ### Stake Events
> 
> - Stake
> 	* Emit event with the account that staked and the staked amount
> - Unstake
> 	* Remove receiver of the withdraw, relying on the transfer contract to inform of the mint
> - Withdraw
> 	* Remove receiver of the withdraw, relying on the transfer contract to inform of the mint
> - Reward
> 	* Change the `reward` function to take a vector of keys and values, to emit a single event. #2292 
> 	* Add reason for reward - possibly a byte is enough. #2292
> - Slash
> 	* Merge the `suspended` and `slash` events into one
> - Hard Slash
> 	* Merge the `suspended` and `hard_slash` events into one

See also #2265 