### PR TITLE
transfer-contract: add richer event emissions

### DIFF
--- a/contracts/transfer/src/transitory.rs
+++ b/contracts/transfer/src/transitory.rs
@@ -4,10 +4,24 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+//! This module contains data that is transitory - i.e. is built up in the
+//! context of a transaction in [`spend_and_execute`] and then discarded or
+//! considered void after a call to [`refund`].
+//!
+//! [`spend_and_execute`]: crate::spend_and_execute
+//! [`refund`]: crate::refund
+
+use core::mem;
+use core::ptr::{self, addr_of_mut};
+
+use alloc::vec::Vec;
+
 use execution_core::{
+    signatures::bls::PublicKey as AccountPublicKey,
     transfer::{
         moonlight::Transaction as MoonlightTransaction,
-        phoenix::Transaction as PhoenixTransaction, Transaction,
+        phoenix::{Note, Transaction as PhoenixTransaction},
+        Transaction,
     },
     ContractId,
 };
@@ -15,30 +29,142 @@ use execution_core::{
 /// The state of a deposit while a transaction is executing.
 pub enum Deposit {
     /// There is a deposit and its still available for pick up.
-    Available(ContractId, u64),
+    Available {
+        sender: Option<AccountPublicKey>,
+        target: ContractId,
+        value: u64,
+    },
     /// There is a deposit and it has already been picked up.
-    Taken(ContractId, u64),
+    Taken {
+        sender: Option<AccountPublicKey>,
+        target: ContractId,
+        value: u64,
+    },
     /// There is no deposit.
     None,
 }
 
-/// The fields kept here are transitory, in the sense that they only "live"
-/// while the transaction is being executed.
-struct CurrentTransaction {
-    tx: Transaction,
-    deposit: Deposit,
+impl Deposit {
+    /// Sets the state of a deposit to be `Deposit::Taken`, if it is currently
+    /// in the `Deposit::Available` state. Otherwise it does nothing.
+    pub fn set_taken(&mut self) {
+        let mut tmp = Deposit::None;
+
+        mem::swap(self, &mut tmp);
+
+        match tmp {
+            Deposit::Available {
+                sender,
+                target,
+                value,
+            } => {
+                *self = Deposit::Taken {
+                    sender,
+                    target,
+                    value,
+                }
+            }
+            _ => mem::swap(self, &mut tmp),
+        }
+    }
 }
 
-static mut CURRENT_TX: Option<CurrentTransaction> = None;
+/// The fields kept here are transitory, in the sense that they only "live"
+/// while the transaction is being executed.
+pub struct OngoingTransaction {
+    /// The transaction currently being executed.
+    pub tx: Transaction,
+    /// The deposit's current state.
+    pub deposit: Deposit,
+    /// The notes that have been inserted into the tree.
+    pub notes: Vec<Note>,
+}
 
-/// Get a reference to the deposit information for the currently ongoing
-/// transaction.
-pub fn deposit_info() -> &'static Deposit {
+static mut CURRENT_TX: Option<OngoingTransaction> = None;
+
+/// Insert the transaction into the state.
+///
+/// Calling this is required to use any of the other functions in this module
+/// without panicking.
+///
+/// After you're done, you can [`take_ongoing`] to reset everything.
+pub fn put_transaction(tx: impl Into<Transaction>) {
+    unsafe {
+        let tx = tx.into();
+
+        let sender = tx.from_account().copied();
+        let value = tx.deposit();
+
+        let mut deposit = Deposit::None;
+        if value > 0 {
+            let target = tx
+                .call()
+                .expect("There must be a contract when depositing funds")
+                .contract;
+
+            // When a transaction is initially inserted, any deposit is
+            // available for pick up.
+            deposit = Deposit::Available {
+                sender,
+                target,
+                value,
+            };
+        }
+
+        CURRENT_TX = Some(OngoingTransaction {
+            tx,
+            deposit,
+            notes: Vec::new(),
+        });
+    }
+}
+
+/// Takes the ongoing transaction information, "removing" it from the state.
+///
+/// [`put_transaction`] must be called after this to perform any other action
+/// with the functions in this module.
+pub fn take_ongoing() -> OngoingTransaction {
+    unsafe {
+        let mut tmp = None;
+        ptr::swap(&mut tmp, addr_of_mut!(CURRENT_TX));
+        tmp.expect("There must be an ongoing transaction")
+    }
+}
+
+/// Push the note into the ongoing cache.
+pub fn push_note(note: Note) {
+    unsafe {
+        let notes = &mut CURRENT_TX
+            .as_mut()
+            .expect("There must be an ongoing transaction")
+            .notes;
+        notes.push(note);
+    }
+}
+
+/// Get a reference of the current ongoing transaction.
+pub fn transaction() -> &'static Transaction {
     unsafe {
         &CURRENT_TX
             .as_ref()
             .expect("There must be an ongoing transaction")
-            .deposit
+            .tx
+    }
+}
+
+/// Get a reference of the current ongoing transaction, assuming it's Moonlight.
+pub fn moonlight_transaction() -> &'static MoonlightTransaction {
+    match transaction() {
+        Transaction::Moonlight(ref tx) => tx,
+        _ => panic!("Expected Moonlight TX, found Phoenix"),
+    }
+}
+
+/// Get a reference of the current ongoing transaction, assuming it's Phoenix.
+pub fn phoenix_transaction() -> &'static PhoenixTransaction {
+    match transaction() {
+        Transaction::Phoenix(ref tx) => tx,
+        _ => panic!("Expected Phoenix TX, found Moonlight"),
     }
 }
 
@@ -50,67 +176,5 @@ pub fn deposit_info_mut() -> &'static mut Deposit {
             .as_mut()
             .expect("There must be an ongoing transaction")
             .deposit
-    }
-}
-
-/// Insert the transaction into the state.
-pub fn put_transaction(tx: impl Into<Transaction>) {
-    unsafe {
-        let tx = tx.into();
-
-        let d = tx.deposit();
-
-        let mut deposit = Deposit::None;
-        if d > 0 {
-            let contract = tx
-                .call()
-                .expect("There must be a contract when depositing funds")
-                .contract;
-
-            // When a transaction is initially inserted, any deposit is
-            // available for pick up.
-            deposit = Deposit::Available(contract, d);
-        }
-
-        CURRENT_TX = Some(CurrentTransaction { tx, deposit });
-    }
-}
-
-pub fn unwrap_tx() -> &'static Transaction {
-    unsafe {
-        &CURRENT_TX
-            .as_ref()
-            .expect("There must be an ongoing transaction")
-            .tx
-    }
-}
-
-/// Unwrap ongoing transaction in the state, assuming it's Moonlight.
-pub fn unwrap_moonlight_tx() -> &'static MoonlightTransaction {
-    unsafe {
-        let tx = &CURRENT_TX
-            .as_ref()
-            .expect("There must be an ongoing transaction")
-            .tx;
-
-        match tx {
-            Transaction::Moonlight(ref tx) => tx,
-            _ => panic!("Expected Moonlight TX, found Phoenix"),
-        }
-    }
-}
-
-/// Unwrap ongoing transaction in the state, assuming it's Phoenix.
-pub fn unwrap_phoenix_tx() -> &'static PhoenixTransaction {
-    unsafe {
-        let tx = &CURRENT_TX
-            .as_ref()
-            .expect("There must be an ongoing transaction")
-            .tx;
-
-        match tx {
-            Transaction::Phoenix(ref tx) => tx,
-            _ => panic!("Expected Phoenix TX, found Moonlight"),
-        }
     }
 }

--- a/contracts/transfer/src/tree.rs
+++ b/contracts/transfer/src/tree.rs
@@ -26,11 +26,7 @@ impl Tree {
         }
     }
 
-    pub fn get(&self, pos: u64) -> Option<NoteLeaf> {
-        self.leaves.get(pos as usize).cloned()
-    }
-
-    pub fn push(&mut self, mut leaf: NoteLeaf) -> u64 {
+    pub fn push(&mut self, mut leaf: NoteLeaf) -> Note {
         // update the position before computing the hash
         let pos = self.leaves.len() as u64;
         leaf.note.set_pos(pos);
@@ -40,22 +36,27 @@ impl Tree {
         let item = NoteTreeItem { hash, data: () };
 
         self.tree.insert(pos, item);
-        self.leaves.push(leaf);
+        self.leaves.push(leaf.clone());
 
-        pos
+        leaf.note
     }
 
     pub fn extend_notes<I: IntoIterator<Item = Note>>(
         &mut self,
         block_height: u64,
         notes: I,
-    ) {
+    ) -> Vec<Note> {
+        let mut n = Vec::new();
+
         for note in notes {
             // skip transparent notes with a value of 0
             if !note.value(None).is_ok_and(|value| value == 0) {
-                self.push(NoteLeaf { block_height, note });
+                let note = self.push(NoteLeaf { block_height, note });
+                n.push(note);
             }
         }
+
+        n
     }
 
     pub fn root(&self) -> BlsScalar {

--- a/execution-core/CHANGELOG.md
+++ b/execution-core/CHANGELOG.md
@@ -51,6 +51,13 @@ transfer::{
     TransferToContract;
     ReceiveFromContract;
     TransferToAccount;
+    WithdrawEvent;
+    ConvertEvent;
+    DepositEvent;
+    TransferToContractEvent;
+    TransferToAccountEvent;
+    PhoenixTransactionEvent;
+    MoonlightTransactionEvent;
     data::{
         ContractBytecode;
         ContractCall;

--- a/execution-core/src/transfer/withdraw.rs
+++ b/execution-core/src/transfer/withdraw.rs
@@ -37,9 +37,9 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Archive, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]
 pub struct Withdraw {
-    contract: ContractId,
-    value: u64,
-    receiver: WithdrawReceiver,
+    pub(super) contract: ContractId,
+    pub(super) value: u64,
+    pub(super) receiver: WithdrawReceiver,
     token: WithdrawReplayToken,
     signature: WithdrawSignature,
 }


### PR DESCRIPTION
The following events are added, which are emitted when the function with their same name is successful:

- `mint`, using `WithdrawEvent`
- `withdraw`, using `WithdrawEvent`
- `convert`, using `ConvertEvent`
- `deposit`, using `DepositEvent`
- `transfer_to_contract`, using `TransferToContractEvent`
- `transfer_to_account`, using `TransferToAccountEvent`

Additionally an event is emitted at the end of any transaction ingestion. This event will either be `phoenix` or `moonlight`, using either `PhoenixTransactionEvent` or `MoonlightTransactionEvent` respectively, depending on the model used, and are emitted during the host's call to `refund`. This is so that the event data can contain both the change and gas spent.

As a consequence of the above changes, we needed to slightly change the way in which we insert notes into the tree, and make some changes to the `transitory` module to support including the change note in the emission event.

See-also: https://github.com/dusk-network/rusk/issues/2265