### PR TITLE
rusk: Enrich contract events with transaction id

### DIFF
--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -1293,4 +1293,18 @@ mod tests {
         let data = data.to_vec().into();
         Ok(RuesEvent { data, headers, uri })
     }
+
+    impl From<ContractEvent> for RuesEvent {
+        fn from(event: ContractEvent) -> Self {
+            Self {
+                uri: RuesEventUri {
+                    component: "contracts".into(),
+                    entity: Some(hex::encode(event.target.0.as_bytes())),
+                    topic: event.topic,
+                },
+                data: event.data.into(),
+                headers: Default::default(),
+            }
+        }
+    }
 }

--- a/rusk/src/lib/http/event.rs
+++ b/rusk/src/lib/http/event.rs
@@ -835,16 +835,6 @@ impl From<execution_core::Event> for ContractEvent {
     }
 }
 
-impl From<ContractEvent> for execution_core::Event {
-    fn from(event: ContractEvent) -> Self {
-        Self {
-            source: event.target.0,
-            topic: event.topic,
-            data: event.data,
-        }
-    }
-}
-
 /// A RUES event
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RuesEvent {
@@ -982,23 +972,23 @@ impl RuesEvent {
     }
 }
 
-impl From<ContractEvent> for RuesEvent {
-    fn from(event: ContractEvent) -> Self {
+#[cfg(feature = "node")]
+impl From<crate::node::ContractTxEvent> for RuesEvent {
+    fn from(tx_event: crate::node::ContractTxEvent) -> Self {
+        let mut headers = serde_json::Map::new();
+        if let Some(origin) = tx_event.origin {
+            headers.insert("Rusk-Origin".into(), hex::encode(origin).into());
+        }
+        let event = tx_event.event;
         Self {
             uri: RuesEventUri {
                 component: "contracts".into(),
-                entity: Some(hex::encode(event.target.0.as_bytes())),
+                entity: Some(hex::encode(event.source.as_bytes())),
                 topic: event.topic,
             },
             data: event.data.into(),
-            headers: Default::default(),
+            headers,
         }
-    }
-}
-
-impl From<execution_core::Event> for RuesEvent {
-    fn from(event: execution_core::Event) -> Self {
-        Self::from(ContractEvent::from(event))
     }
 }
 

--- a/rusk/src/lib/node.rs
+++ b/rusk/src/lib/node.rs
@@ -31,6 +31,8 @@ use tokio::sync::{broadcast, mpsc};
 
 use crate::http::{HandleRequest, RuesEvent};
 
+pub use vm::ContractTxEvent;
+
 #[derive(Debug, Clone, Copy)]
 pub struct RuskTip {
     pub current: [u8; 32],

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -14,12 +14,18 @@ use dusk_consensus::user::provisioners::Provisioners;
 use dusk_consensus::user::stake::Stake;
 use execution_core::{
     signatures::bls::PublicKey as BlsPublicKey, stake::StakeData,
-    transfer::Transaction as ProtocolTransaction,
+    transfer::Transaction as ProtocolTransaction, Event,
 };
 use node::vm::VMExecution;
 use node_data::ledger::{Block, Slash, SpentTransaction, Transaction};
 
 use super::Rusk;
+
+#[derive(Debug, Clone)]
+pub struct ContractTxEvent {
+    pub event: Event,
+    pub origin: Option<[u8; 32]>,
+}
 
 impl VMExecution for Rusk {
     fn execute_state_transition<I: Iterator<Item = Transaction>>(


### PR DESCRIPTION
"Just to" improve the info available to the Archival

This PR doesn't impact performance of the VM, since the TX_ID is enriched at node level.

When events are dispatched through RUES, the new field is added as `Rusk-Origin` header in the response (without changing the event data) ensuring smooth deserialization for backward compatibility. 