### PR TITLE
Add transaction `output` field to events

### DIFF
--- a/contracts/stake/tests/common/utils.rs
+++ b/contracts/stake/tests/common/utils.rs
@@ -129,7 +129,7 @@ pub fn execute(
         .call::<_, ()>(
             TRANSFER_CONTRACT,
             "refund",
-            &receipt.gas_spent,
+            &(receipt.gas_spent, None::<ContractId>),
             u64::MAX,
         )
         .expect("Refunding must succeed");

--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -123,9 +123,9 @@ unsafe fn spend_and_execute(arg_len: u32) -> u32 {
 
 #[no_mangle]
 unsafe fn refund(arg_len: u32) -> u32 {
-    rusk_abi::wrap_call(arg_len, |gas_spent| {
+    rusk_abi::wrap_call(arg_len, |(gas_spent, deployed_contract)| {
         assert_external_caller();
-        STATE.refund(gas_spent)
+        STATE.refund(gas_spent, deployed_contract)
     })
 }
 

--- a/contracts/transfer/src/transitory.rs
+++ b/contracts/transfer/src/transitory.rs
@@ -21,7 +21,7 @@ use execution_core::{
     transfer::{
         moonlight::Transaction as MoonlightTransaction,
         phoenix::{Note, Transaction as PhoenixTransaction},
-        Transaction,
+        Transaction, TransactionOutput,
     },
     ContractId,
 };
@@ -78,6 +78,8 @@ pub struct OngoingTransaction {
     pub deposit: Deposit,
     /// The notes that have been inserted into the tree.
     pub notes: Vec<Note>,
+    /// The output of the transaction.
+    pub output: TransactionOutput,
 }
 
 static mut CURRENT_TX: Option<OngoingTransaction> = None;
@@ -115,6 +117,7 @@ pub fn put_transaction(tx: impl Into<Transaction>) {
             tx,
             deposit,
             notes: Vec::new(),
+            output: TransactionOutput::None,
         });
     }
 }
@@ -139,6 +142,17 @@ pub fn push_note(note: Note) {
             .expect("There must be an ongoing transaction")
             .notes;
         notes.push(note);
+    }
+}
+
+/// Sets the output of the ongoing transaction
+pub fn set_output(output: TransactionOutput) {
+    unsafe {
+        let o = &mut CURRENT_TX
+            .as_mut()
+            .expect("There must be an ongoing transaction")
+            .output;
+        *o = output;
     }
 }
 

--- a/contracts/transfer/tests/common/utils.rs
+++ b/contracts/transfer/tests/common/utils.rs
@@ -141,7 +141,7 @@ pub fn execute(
         .call::<_, ()>(
             TRANSFER_CONTRACT,
             "refund",
-            &receipt.gas_spent,
+            &(receipt.gas_spent, None::<ContractId>),
             u64::MAX,
         )
         .expect("Refunding must succeed");

--- a/execution-core/CHANGELOG.md
+++ b/execution-core/CHANGELOG.md
@@ -58,6 +58,7 @@ transfer::{
     TransferToAccountEvent;
     PhoenixTransactionEvent;
     MoonlightTransactionEvent;
+    TransactionOutput;
     data::{
         ContractBytecode;
         ContractCall;


### PR DESCRIPTION
We add the `TransactionOutput` struct as a member of the `PhoenixTransactionEvent` and `MoonlightTransactionEvent` structures in the form of the `output` field to be able to inform listeners of the results of contract calls, deployment, or any included memo.
