### PR TITLE
Add memo to transaction events

### DIFF
--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -622,6 +622,11 @@ impl TransferState {
             _ => None,
         };
 
+        let mut memo = Vec::new();
+        if let Some(m) = ongoing.tx.memo() {
+            memo = m.to_vec();
+        }
+
         // in phoenix, a refund note is with the unspent amount to the stealth
         // address in the `Fee` structure, while in moonlight we simply refund
         // the `from` account for what it didn't spend
@@ -650,6 +655,7 @@ impl TransferState {
                     PhoenixTransactionEvent {
                         nullifiers: tx.nullifiers().to_vec(),
                         notes,
+                        memo,
                         gas_spent,
                     },
                 );
@@ -673,6 +679,7 @@ impl TransferState {
                         from: *tx.from_account(),
                         to: tx.to_account().copied(),
                         value: tx.value(),
+                        memo,
                         gas_spent,
                     },
                 );

--- a/execution-core/src/transfer.rs
+++ b/execution-core/src/transfer.rs
@@ -469,6 +469,8 @@ pub struct PhoenixTransactionEvent {
     pub nullifiers: Vec<BlsScalar>,
     /// Notes produced during the transaction.
     pub notes: Vec<Note>,
+    /// The memo included in the transaction.
+    pub memo: Vec<u8>,
     /// Gas spent by the transaction.
     pub gas_spent: u64,
 }
@@ -483,6 +485,8 @@ pub struct MoonlightTransactionEvent {
     pub to: Option<AccountPublicKey>,
     /// Transfer amount
     pub value: u64,
+    /// The memo included in the transaction.
+    pub memo: Vec<u8>,
     /// Gas spent by the transaction.
     pub gas_spent: u64,
 }


### PR DESCRIPTION
We decided against placing the full result of a contract call, or the contract ID of a deployment contract in the transaction events. However we did agree that it would be nice if the optional memo was available to any event listener.

This PR adds a `memo` field to `PhoenixTransactionEvent` and `MoonlightTransactionEvent`, and adjust the transfer contract to emit an empty `Vec<u8>` in said field if there is no memo, and the memo included with the transaction if it exists.