### PR TITLE
CI: Add section to copy rusk artifact to shared folder on the CI host

### DIFF
--- a/.github/workflows/rusk_ci.yml
+++ b/.github/workflows/rusk_ci.yml
@@ -79,7 +79,7 @@ jobs:
   copy_to_host:
     needs: test_nightly
     runs-on: core
-    if: needs.test_nightly.result == 'success' && github.base_ref == 'main'
+    if: needs.test_nightly.result == 'success' && github.base_ref == 'master'
     continue-on-error: true
     steps:
       - name: "Download Rusk Artifact"

--- a/.github/workflows/rusk_ci.yml
+++ b/.github/workflows/rusk_ci.yml
@@ -79,14 +79,18 @@ jobs:
   copy_to_host:
     needs: test_nightly
     runs-on: core
-    if: needs.test_nightly.result == 'success' && github.base_ref == 'master'
+    if: needs.test_nightly.result == 'success' && github.base_ref == 'main'
     continue-on-error: true
     steps:
-      - name: "Download Rusk Artifact"
-        uses: actions/download-artifact@v3
-        with:
-          name: rusk-artifact
-      - name: "Copy Rusk to host"
+      - name: "Check and Copy Rusk Artifact to Host"
         run: |
+          # Ensure the target directory exists
           mkdir -p /var/opt/rusk-artifacts
-          cp ./target/release/rusk /var/opt/rusk-artifacts
+          
+          # Check if the rusk artifact exists before copying
+          if [ -f ./target/release/rusk ]; then
+            echo "Rusk artifact found. Copying to host."
+            cp ./target/release/rusk /var/opt/rusk-artifacts
+          else
+            echo "Rusk artifact not found. Skipping copy."
+          fi

--- a/.github/workflows/rusk_ci.yml
+++ b/.github/workflows/rusk_ci.yml
@@ -76,3 +76,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
       - run: cargo fmt --all -- --check
+  copy_to_host:
+    needs: test_nightly
+    runs-on: core
+    if: needs.test_nightly.result == 'success' && github.base_ref == 'main'
+    continue-on-error: true
+    steps:
+      - name: "Download Rusk Artifact"
+        uses: actions/download-artifact@v3
+        with:
+          name: rusk-artifact
+      - name: "Copy Rusk to host"
+        run: |
+          mkdir -p /path/in/container/rusk-artifacts
+          cp ./target/release/rusk /var/opt/rusk-artifacts

--- a/.github/workflows/rusk_ci.yml
+++ b/.github/workflows/rusk_ci.yml
@@ -88,5 +88,5 @@ jobs:
           name: rusk-artifact
       - name: "Copy Rusk to host"
         run: |
-          mkdir -p /path/in/container/rusk-artifacts
+          mkdir -p /var/opt/rusk-artifacts
           cp ./target/release/rusk /var/opt/rusk-artifacts


### PR DESCRIPTION
As per request by the core team, adding in the main CI a section to copy the artifact on the host machine via a shared folder.
The runners have already been updated to mount the shared folder on launch.