### PR TITLE
Disable future message repropagation

### DIFF
--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -295,6 +295,20 @@ impl<'a, T: Operations + 'static> ExecutionCtx<'a, T> {
         phase: Arc<Mutex<C>>,
         msg: Message,
     ) -> Option<Message> {
+        // If it's a message from a future iteration of the current round, we
+        // generate the committees so that we can pre-verify its validity.
+        // We do it here because we need the IterationCtx
+        if msg.header.round == self.round_update.round
+            && msg.header.iteration > self.iteration
+        {
+            // Generate committees for the iteration
+            self.iter_ctx.generate_iteration_committees(
+                msg.header.iteration,
+                self.provisioners,
+                self.round_update.seed(),
+            );
+        }
+
         let committee = self
             .get_current_committee()
             .expect("committee to be created before run");

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -300,6 +300,7 @@ impl<'a, T: Operations + 'static> ExecutionCtx<'a, T> {
         // We do it here because we need the IterationCtx
         if msg.header.round == self.round_update.round
             && msg.header.iteration > self.iteration
+            && msg.header.prev_block_hash == self.round_update.hash()
         {
             // Generate committees for the iteration
             self.iter_ctx.generate_iteration_committees(

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -322,7 +322,11 @@ impl<'a, T: Operations + 'static> ExecutionCtx<'a, T> {
             Err(ConsensusError::FutureEvent) => {
                 trace!("future msg {:?}", msg);
 
-                self.outbound.try_send(msg.clone());
+                // Re-propagate messages from future iterations of the current
+                // round
+                if msg.header.round == self.round_update.round {
+                    self.outbound.try_send(msg.clone());
+                }
 
                 self.future_msgs.lock().await.put_msg(
                     msg.header.round,

--- a/consensus/src/iteration_ctx.rs
+++ b/consensus/src/iteration_ctx.rs
@@ -216,10 +216,12 @@ impl IterationCtx {
         // If the step is Proposal, the only extracted member is the generator
         // For Validation and Ratification steps, extracted members are
         // delegated to vote on the candidate block
-        let step_committee = Committee::new(
-            provisioners,
-            &self.get_sortition_config(seed, step_name, exclusion),
-        );
+
+        let sortition_step = step_name.to_step(iteration);
+        let mut config_step =
+            self.get_sortition_config(seed, step_name, exclusion);
+        config_step.step = sortition_step;
+        let step_committee = Committee::new(provisioners, &config_step);
 
         debug!(
             event = "committee_generated",

--- a/consensus/src/iteration_ctx.rs
+++ b/consensus/src/iteration_ctx.rs
@@ -147,11 +147,11 @@ impl IterationCtx {
 
     pub(crate) fn generate_committee(
         &mut self,
+        iteration: u8,
         step_name: StepName,
         provisioners: &Provisioners,
         seed: Seed,
     ) {
-        let iteration = self.iter;
         let step = step_name.to_step(iteration);
 
         // Check if we already generated the committee.
@@ -227,6 +227,23 @@ impl IterationCtx {
         );
 
         self.committees.insert(step, step_committee);
+    }
+
+    pub(crate) fn generate_iteration_committees(
+        &mut self,
+        iteration: u8,
+        provisioners: &Provisioners,
+        seed: Seed,
+    ) {
+        let stepnames = [
+            StepName::Proposal,
+            StepName::Validation,
+            StepName::Ratification,
+        ];
+
+        for stepname in &stepnames {
+            self.generate_committee(iteration, *stepname, provisioners, seed);
+        }
     }
 
     pub(crate) fn get_generator(&self, iter: u8) -> Option<PublicKeyBytes> {

--- a/consensus/src/proposal/handler.rs
+++ b/consensus/src/proposal/handler.rs
@@ -16,7 +16,7 @@ use node_data::bls::PublicKeyBytes;
 use node_data::message::payload::Candidate;
 
 use crate::iteration_ctx::RoundCommittees;
-use node_data::message::{Message, Payload, StepMessage};
+use node_data::message::{Message, Payload, StepMessage, WireMessage};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -36,7 +36,8 @@ impl<D: Database> MsgHandler for ProposalHandler<D> {
         let generator = round_committees
             .get_generator(iteration)
             .expect("committee to be created before run");
-        self.verify_new_block(msg, &generator)?;
+        let p = Self::unwrap_msg(msg)?;
+        super::handler::verify_new_block(p, &generator)?;
 
         Ok(())
     }
@@ -80,65 +81,75 @@ impl<D: Database> ProposalHandler<D> {
         Self { db }
     }
 
-    fn verify_new_block(
-        &self,
-        msg: &Message,
-        expected_generator: &PublicKeyBytes,
-    ) -> Result<(), ConsensusError> {
-        let p = Self::unwrap_msg(msg)?;
-
-        if expected_generator != p.sign_info.signer.bytes() {
-            return Err(ConsensusError::NotCommitteeMember);
-        }
-
-        let candidate_size = p
-            .candidate
-            .size()
-            .map_err(|_| ConsensusError::UnknownBlockSize)?;
-        if candidate_size > MAX_BLOCK_SIZE {
-            return Err(ConsensusError::InvalidBlockSize(candidate_size));
-        }
-
-        //  Verify new_block msg signature
-        p.verify_signature()?;
-
-        if msg.header.prev_block_hash != p.candidate.header().prev_block_hash {
-            return Err(ConsensusError::InvalidBlockHash);
-        }
-
-        if p.candidate.txs().len() > MAX_NUMBER_OF_TRANSACTIONS {
-            return Err(ConsensusError::TooManyTransactions(
-                p.candidate.txs().len(),
-            ));
-        }
-
-        let tx_hashes: Vec<_> =
-            p.candidate.txs().iter().map(|t| t.hash()).collect();
-        let tx_root = merkle_root(&tx_hashes[..]);
-        if tx_root != p.candidate.header().txroot {
-            return Err(ConsensusError::InvalidBlock);
-        }
-
-        if p.candidate.faults().len() > MAX_NUMBER_OF_FAULTS {
-            return Err(ConsensusError::TooManyFaults(
-                p.candidate.faults().len(),
-            ));
-        }
-
-        let fault_hashes: Vec<_> =
-            p.candidate.faults().iter().map(|t| t.hash()).collect();
-        let fault_root = merkle_root(&fault_hashes[..]);
-        if fault_root != p.candidate.header().faultroot {
-            return Err(ConsensusError::InvalidBlock);
-        }
-
-        Ok(())
-    }
-
     fn unwrap_msg(msg: &Message) -> Result<&Candidate, ConsensusError> {
         match &msg.payload {
             Payload::Candidate(c) => Ok(c),
             _ => Err(ConsensusError::InvalidMsgType),
         }
     }
+}
+
+fn verify_new_block(
+    p: &Candidate,
+    expected_generator: &PublicKeyBytes,
+) -> Result<(), ConsensusError> {
+    if expected_generator != p.sign_info.signer.bytes() {
+        return Err(ConsensusError::NotCommitteeMember);
+    }
+
+    let candidate_size = p
+        .candidate
+        .size()
+        .map_err(|_| ConsensusError::UnknownBlockSize)?;
+    if candidate_size > MAX_BLOCK_SIZE {
+        return Err(ConsensusError::InvalidBlockSize(candidate_size));
+    }
+
+    //  Verify new_block msg signature
+    p.verify_signature()?;
+
+    if p.consensus_header().prev_block_hash
+        != p.candidate.header().prev_block_hash
+    {
+        return Err(ConsensusError::InvalidBlockHash);
+    }
+
+    if p.candidate.txs().len() > MAX_NUMBER_OF_TRANSACTIONS {
+        return Err(ConsensusError::TooManyTransactions(
+            p.candidate.txs().len(),
+        ));
+    }
+
+    let tx_hashes: Vec<_> =
+        p.candidate.txs().iter().map(|t| t.hash()).collect();
+    let tx_root = merkle_root(&tx_hashes[..]);
+    if tx_root != p.candidate.header().txroot {
+        return Err(ConsensusError::InvalidBlock);
+    }
+
+    if p.candidate.faults().len() > MAX_NUMBER_OF_FAULTS {
+        return Err(ConsensusError::TooManyFaults(p.candidate.faults().len()));
+    }
+
+    let fault_hashes: Vec<_> =
+        p.candidate.faults().iter().map(|t| t.hash()).collect();
+    let fault_root = merkle_root(&fault_hashes[..]);
+    if fault_root != p.candidate.header().faultroot {
+        return Err(ConsensusError::InvalidBlock);
+    }
+
+    Ok(())
+}
+
+pub fn verify_stateless(
+    c: &Candidate,
+    round_committees: &RoundCommittees,
+) -> Result<(), ConsensusError> {
+    let iteration = c.header.iteration;
+    let generator = round_committees
+        .get_generator(iteration)
+        .expect("committee to be created before run");
+    verify_new_block(c, &generator)?;
+
+    Ok(())
 }


### PR DESCRIPTION
Resolves #2247 

Protocol Changes:
- Disable repropagation of future-round messages
- Pre-verify future-iteration messages for the current round, before repropagating them or putting them in the queue

Refactoring
- Add a `generate_iteration_committees` to IterationCtx
- Use `generation_iteration_committees` for:
 - re-generating committees when restoring iteration after restart
 - generate iteration committees at the beginning of a new iteration
 - generate iteration committees before verifying future-iteration messages