### PR TITLE
transfer-contract: add sync methods

### DIFF
--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -111,6 +111,13 @@ unsafe fn sync(arg_len: u32) -> u32 {
     })
 }
 
+#[no_mangle]
+unsafe fn sync_nullifiers(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |(from, count_limint)| {
+        STATE.sync_nullifiers(from, count_limint)
+    })
+}
+
 // "Management" transactions
 
 #[no_mangle]

--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -125,6 +125,13 @@ unsafe fn sync_contract_balances(arg_len: u32) -> u32 {
     })
 }
 
+#[no_mangle]
+unsafe fn sync_accounts(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |(from, count_limint)| {
+        STATE.sync_accounts(from, count_limint)
+    })
+}
+
 // "Management" transactions
 
 #[no_mangle]

--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -118,6 +118,13 @@ unsafe fn sync_nullifiers(arg_len: u32) -> u32 {
     })
 }
 
+#[no_mangle]
+unsafe fn sync_contract_balances(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |(from, count_limint)| {
+        STATE.sync_contract_balances(from, count_limint)
+    })
+}
+
 // "Management" transactions
 
 #[no_mangle]

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -720,6 +720,19 @@ impl TransferState {
         }
     }
 
+    pub fn sync_nullifiers(&self, from: u64, count_limit: u64) {
+        let iter = self.nullifiers.iter().skip(from as usize);
+        if count_limit == 0 {
+            for n in iter {
+                rusk_abi::feed(*n);
+            }
+        } else {
+            for n in iter.take(count_limit as usize) {
+                rusk_abi::feed(*n);
+            }
+        }
+    }
+
     /// Update the root for of the tree.
     pub fn update_root(&mut self) {
         let root = self.tree.root();

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -753,6 +753,20 @@ impl TransferState {
         }
     }
 
+    pub fn sync_accounts(&self, from: u64, count_limit: u64) {
+        let iter = self.accounts.iter().skip(from as usize);
+
+        if count_limit == 0 {
+            for (_, (account, key)) in iter {
+                rusk_abi::feed((account.clone(), *key));
+            }
+        } else {
+            for (_, (account, key)) in iter.take(count_limit as usize) {
+                rusk_abi::feed((account.clone(), *key));
+            }
+        }
+    }
+
     /// Update the root for of the tree.
     pub fn update_root(&mut self) {
         let root = self.tree.root();

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -733,6 +733,20 @@ impl TransferState {
         }
     }
 
+    pub fn sync_contract_balances(&self, from: u64, count_limit: u64) {
+        let iter = self.contract_balances.iter().skip(from as usize);
+
+        if count_limit == 0 {
+            for (contract, balance) in iter {
+                rusk_abi::feed((*contract, *balance));
+            }
+        } else {
+            for (contract, balance) in iter.take(count_limit as usize) {
+                rusk_abi::feed((*contract, *balance));
+            }
+        }
+    }
+
     /// Update the root for of the tree.
     pub fn update_root(&mut self) {
         let root = self.tree.root();

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -13,6 +13,7 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::vec::Vec;
 
 use dusk_bytes::Serializable;
+use execution_core::stake::EPOCH;
 use ringbuffer::{ConstGenericRingBuffer, RingBuffer};
 
 use execution_core::{
@@ -40,7 +41,7 @@ use crate::transitory;
 use transitory::Deposit;
 
 /// Number of roots stored
-pub const MAX_ROOTS: usize = 5000;
+pub const MAX_ROOTS: usize = 2 * EPOCH as usize;
 
 /// An empty account, used as the default return and for instantiating new
 /// entries.


### PR DESCRIPTION
- Add `sync_accounts`
- Add `sync_contract_balances`
- Add `sync_nullifiers`

Additionally:
- Change max_roots to 2*EPOCH (just to remove magic number)

⚠️ Change state to store AccountPublicKey ⚠️
To improve the sync performance, we need to avoid PublicKey::from_bytes() during the feed (exactly like we do for the stake_contract)
Another way to achieve the same benefit (or even more), is using PublicKey::to_raw_bytes() as key, and call the PublicKey::from_raw_bytes() during the sync (PR [here](https://github.com/dusk-network/rusk/pull/2331))