### PR TITLE
transfer-contract: add sync methods (alternative version)

### DIFF
--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -111,6 +111,13 @@ unsafe fn sync(arg_len: u32) -> u32 {
     })
 }
 
+#[no_mangle]
+unsafe fn sync_nullifiers(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |(from, count_limint)| {
+        STATE.sync_nullifiers(from, count_limint)
+    })
+}
+
 // "Management" transactions
 
 #[no_mangle]

--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -125,6 +125,13 @@ unsafe fn sync_contract_balances(arg_len: u32) -> u32 {
     })
 }
 
+#[no_mangle]
+unsafe fn sync_accounts(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |(from, count_limint)| {
+        STATE.sync_accounts(from, count_limint)
+    })
+}
+
 // "Management" transactions
 
 #[no_mangle]

--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -118,6 +118,13 @@ unsafe fn sync_nullifiers(arg_len: u32) -> u32 {
     })
 }
 
+#[no_mangle]
+unsafe fn sync_contract_balances(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |(from, count_limint)| {
+        STATE.sync_contract_balances(from, count_limint)
+    })
+}
+
 // "Management" transactions
 
 #[no_mangle]

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -720,6 +720,19 @@ impl TransferState {
         }
     }
 
+    pub fn sync_nullifiers(&self, from: u64, count_limit: u64) {
+        let iter = self.nullifiers.iter().skip(from as usize);
+        if count_limit == 0 {
+            for n in iter {
+                rusk_abi::feed(*n);
+            }
+        } else {
+            for n in iter.take(count_limit as usize) {
+                rusk_abi::feed(*n);
+            }
+        }
+    }
+
     /// Update the root for of the tree.
     pub fn update_root(&mut self) {
         let root = self.tree.root();

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -746,6 +746,20 @@ impl TransferState {
         }
     }
 
+    pub fn sync_accounts(&self, from: u64, count_limit: u64) {
+        let iter = self.accounts.iter().skip(from as usize);
+
+        if count_limit == 0 {
+            for (key, account) in iter {
+                rusk_abi::feed((account.clone(), *key));
+            }
+        } else {
+            for (key, account) in iter.take(count_limit as usize) {
+                rusk_abi::feed((account.clone(), *key));
+            }
+        }
+    }
+
     /// Update the root for of the tree.
     pub fn update_root(&mut self) {
         let root = self.tree.root();

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -733,6 +733,20 @@ impl TransferState {
         }
     }
 
+    pub fn sync_contract_balances(&self, from: u64, count_limit: u64) {
+        let iter = self.contract_balances.iter().skip(from as usize);
+
+        if count_limit == 0 {
+            for (contract, balance) in iter {
+                rusk_abi::feed((*contract, *balance));
+            }
+        } else {
+            for (contract, balance) in iter.take(count_limit as usize) {
+                rusk_abi::feed((*contract, *balance));
+            }
+        }
+    }
+
     /// Update the root for of the tree.
     pub fn update_root(&mut self) {
         let root = self.tree.root();

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -13,6 +13,7 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::vec::Vec;
 
 use dusk_bytes::Serializable;
+use execution_core::stake::EPOCH;
 use ringbuffer::{ConstGenericRingBuffer, RingBuffer};
 
 use execution_core::{
@@ -40,7 +41,7 @@ use crate::transitory;
 use transitory::Deposit;
 
 /// Number of roots stored
-pub const MAX_ROOTS: usize = 5000;
+pub const MAX_ROOTS: usize = 2 * EPOCH as usize;
 
 /// An empty account, used as the default return and for instantiating new
 /// entries.

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -12,7 +12,6 @@ use alloc::collections::btree_map::Entry;
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::vec::Vec;
 
-use dusk_bytes::Serializable;
 use execution_core::stake::EPOCH;
 use ringbuffer::{ConstGenericRingBuffer, RingBuffer};
 
@@ -70,7 +69,7 @@ pub struct TransferState {
     // NOTE: we should never remove entries from this list, since the entries
     //       contain the nonce of the given account. Doing so opens the account
     //       up to replay attacks.
-    accounts: BTreeMap<[u8; AccountPublicKey::SIZE], AccountData>,
+    accounts: BTreeMap<[u8; 193], AccountData>,
     contract_balances: BTreeMap<ContractId, u64>,
 }
 
@@ -146,7 +145,7 @@ impl TransferState {
                     panic!("Invalid signature");
                 }
 
-                let account_bytes = account.to_bytes();
+                let account_bytes = account.to_raw_bytes();
                 let account =
                     self.accounts.entry(account_bytes).or_insert(EMPTY_ACCOUNT);
 
@@ -425,7 +424,7 @@ impl TransferState {
 
         let account = self
             .accounts
-            .entry(transfer.account.to_bytes())
+            .entry(transfer.account.to_raw_bytes())
             .or_insert(EMPTY_ACCOUNT);
 
         *from_balance -= transfer.value;
@@ -560,7 +559,7 @@ impl TransferState {
         // TODO: this is expensive, maybe we should address the fact that
         //       `AccountPublicKey` doesn't `impl Ord` so we can just use it
         //       directly as a key in the `BTreeMap`
-        let from_bytes = moonlight_tx.from_account().to_bytes();
+        let from_bytes = moonlight_tx.from_account().to_raw_bytes();
 
         // the total value carried by a transaction is the sum of the value, the
         // deposit, and gas_limit * gas_price.
@@ -596,7 +595,7 @@ impl TransferState {
         // in the `to` field, we just give the value back to `from`.
         if moonlight_tx.value() > 0 {
             let key = match moonlight_tx.to_account() {
-                Some(to) => to.to_bytes(),
+                Some(to) => to.to_raw_bytes(),
                 None => from_bytes,
             };
 
@@ -662,7 +661,7 @@ impl TransferState {
                 );
             }
             Transaction::Moonlight(tx) => {
-                let from_bytes = tx.from_account().to_bytes();
+                let from_bytes = tx.from_account().to_raw_bytes();
 
                 let remaining_gas = tx.gas_limit() - gas_spent;
                 let remaining = remaining_gas * tx.gas_price()
@@ -781,7 +780,7 @@ impl TransferState {
     }
 
     pub fn account(&self, key: &AccountPublicKey) -> AccountData {
-        let key_bytes = key.to_bytes();
+        let key_bytes = key.to_raw_bytes();
         self.accounts
             .get(&key_bytes)
             .cloned()
@@ -789,13 +788,13 @@ impl TransferState {
     }
 
     pub fn add_account_balance(&mut self, key: &AccountPublicKey, value: u64) {
-        let key_bytes = key.to_bytes();
+        let key_bytes = key.to_raw_bytes();
         let account = self.accounts.entry(key_bytes).or_insert(EMPTY_ACCOUNT);
         account.balance = account.balance.saturating_add(value);
     }
 
     pub fn sub_account_balance(&mut self, key: &AccountPublicKey, value: u64) {
-        let key_bytes = key.to_bytes();
+        let key_bytes = key.to_raw_bytes();
         if let Some(account) = self.accounts.get_mut(&key_bytes) {
             account.balance = account.balance.saturating_sub(value);
         }


### PR DESCRIPTION
- Add `sync_accounts`
- Add `sync_contract_balances`
- Add `sync_nullifiers`

Additionally:
- Change max_roots to 2*EPOCH (just to remove magic number)

⚠️ Change state to store AccountPublicKey as raw_bytes ⚠️
To improve the sync performance, we need to avoid PublicKey::from_bytes() during the feed (exactly like we do for the stake_contract)
Using PublicKey::from_raw_bytes() is way faster

```
test benches::deser::bench_deser_compressed       ... bench:     235,719 ns/iter (+/- 8,456)
test benches::deser::bench_deser_uncompressed     ... bench:          50 ns/iter (+/- 2)
```