### PR TITLE
Archive node feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Cargo.lock
 **/target
 **/*.rs.bk
 .rusk
+.vscode

--- a/node-data/Cargo.toml
+++ b/node-data/Cargo.toml
@@ -17,6 +17,7 @@ block-modes = "0.8"
 aes = "0.7"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_with = { version = "3.1", features = ["hex"] }
 base64 = "0.13"
 async-channel = "1.7"
 chrono = "0.4"

--- a/node-data/src/archive.rs
+++ b/node-data/src/archive.rs
@@ -11,6 +11,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::ledger::Hash;
 
+/// Contract event with optional origin (tx hash).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractTxEvent {
+    pub event: ContractEvent,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<[u8; 32]>,
+}
+
 /// Wrapper around a contract event that is to be archived.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ContractEvent {
@@ -28,7 +36,7 @@ pub struct ContractEvent {
 pub enum ArchivalData {
     /// List of contract events from one block together with the block height
     /// and block hash.
-    ArchivedEvents(u64, Hash, Vec<ContractEvent>),
+    ArchivedEvents(u64, Hash, Vec<ContractTxEvent>),
 }
 
 impl ArchivalData {

--- a/node-data/src/archive.rs
+++ b/node-data/src/archive.rs
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use execution_core::ContractId;
+use execution_core::Event;
+use execution_core::CONTRACT_ID_BYTES;
+use serde::{Deserialize, Serialize};
+
+use crate::ledger::Hash;
+
+/// Wrapper around a contract event that is to be archived.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContractEvent {
+    pub source: [u8; CONTRACT_ID_BYTES],
+    pub topic: String,
+    pub data: Vec<u8>,
+}
+
+/// Defined data, that the archivist will store.
+///
+/// This is also the type of the mpsc channel where the archivist listens for
+/// data to archive.
+///
+/// Any data that archive nodes can store must be defined here
+pub enum ArchivalData {
+    /// List of contract events from one block together with the block height
+    /// and block hash.
+    ArchivedEvents(u64, Hash, Vec<ContractEvent>),
+}
+
+impl ArchivalData {
+    /// Returns the block height of the data.
+    pub fn block_height(&self) -> u64 {
+        match self {
+            ArchivalData::ArchivedEvents(height, _, _) => *height,
+        }
+    }
+
+    /// Returns the block hash of the data.
+    pub fn block_hash(&self) -> &Hash {
+        match self {
+            ArchivalData::ArchivedEvents(_, hash, _) => hash,
+        }
+    }
+}
+
+impl From<Event> for ContractEvent {
+    fn from(event: Event) -> Self {
+        ContractEvent {
+            source: event.source.to_bytes(),
+            topic: event.topic,
+            data: event.data,
+        }
+    }
+}
+
+impl From<ContractEvent> for Event {
+    fn from(contract_event: ContractEvent) -> Self {
+        Event {
+            source: ContractId::from_bytes(contract_event.source),
+            topic: contract_event.topic,
+            data: contract_event.data,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use execution_core::ContractId;
+
+    fn exec_core_event() -> Event {
+        Event {
+            source: ContractId::from_bytes([0; 32]),
+            topic: "contract".to_string(),
+            data: vec![1, 2, 3],
+        }
+    }
+
+    #[test]
+    fn test_converting_contract_event() {
+        let contract_event: ContractEvent = exec_core_event().into();
+
+        assert_eq!(Event::from(contract_event), exec_core_event());
+    }
+
+    #[test]
+    fn test_serialize_contract_event() {
+        let event: ContractEvent = exec_core_event().into();
+        let json_event = serde_json::to_string(&event).unwrap();
+        assert_eq!(event, serde_json::from_str(&json_event).unwrap());
+
+        let events: Vec<ContractEvent> = vec![event.clone(), event];
+        let json_events = serde_json::to_string(&events).unwrap();
+        assert_eq!(
+            events,
+            serde_json::from_str::<Vec<ContractEvent>>(&json_events).unwrap()
+        );
+
+        let empty_events: Vec<ContractEvent> = vec![];
+        let empty_json_events = serde_json::to_string(&empty_events).unwrap();
+        assert_eq!(
+            empty_events,
+            serde_json::from_str::<Vec<ContractEvent>>(&empty_json_events)
+                .unwrap()
+        );
+    }
+}

--- a/node-data/src/archive.rs
+++ b/node-data/src/archive.rs
@@ -6,8 +6,8 @@
 
 use execution_core::ContractId;
 use execution_core::Event;
-use execution_core::CONTRACT_ID_BYTES;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Deserializer, Serializer};
+use anyhow::Result;
 
 use crate::ledger::Hash;
 
@@ -19,11 +19,49 @@ pub struct ContractTxEvent {
     pub origin: Option<[u8; 32]>,
 }
 
-/// Wrapper around a contract event that is to be archived.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+#[repr(C)]
+pub struct WrappedContractId(pub ContractId);
+
+impl Serialize for WrappedContractId {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let source_hex = hex::encode(self.0.as_bytes());
+        s.serialize_str(&source_hex)
+    }
+}
+
+impl<'de> Deserialize<'de> for WrappedContractId {
+    fn deserialize<D>(deserializer: D) -> Result<WrappedContractId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let source_hex: String = Deserialize::deserialize(deserializer)?;
+        let source_bytes = hex::decode(source_hex).map_err(serde::de::Error::custom)?;
+        let mut source_array = [0u8; 32];
+
+        if source_bytes.len() != 32 {
+            //return Err(Error::invalid_length(source_hex.len(), &"32"));
+            return Err(serde::de::Error::custom(format!(
+                "Invalid length: expected 32 bytes, got {}",
+                source_bytes.len()
+            )));
+        }
+
+        source_array.copy_from_slice(&source_bytes);
+        Ok(WrappedContractId(ContractId::from_bytes(source_array)))
+    }
+}
+
+/// Wrapper around a contract event that is to be archived or sent to a websocket client.
+#[serde_with::serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ContractEvent {
-    pub source: [u8; CONTRACT_ID_BYTES],
+    pub target: WrappedContractId,
     pub topic: String,
+    #[serde_as(as = "serde_with::hex::Hex")]
     pub data: Vec<u8>,
 }
 
@@ -55,10 +93,10 @@ impl ArchivalData {
     }
 }
 
-impl From<Event> for ContractEvent {
-    fn from(event: Event) -> Self {
-        ContractEvent {
-            source: event.source.to_bytes(),
+impl From<execution_core::Event> for ContractEvent {
+    fn from(event: execution_core::Event) -> Self {
+        Self {
+            target: WrappedContractId(event.source),
             topic: event.topic,
             data: event.data,
         }
@@ -68,7 +106,7 @@ impl From<Event> for ContractEvent {
 impl From<ContractEvent> for Event {
     fn from(contract_event: ContractEvent) -> Self {
         Event {
-            source: ContractId::from_bytes(contract_event.source),
+            source: contract_event.target.0,
             topic: contract_event.topic,
             data: contract_event.data,
         }

--- a/node-data/src/archive.rs
+++ b/node-data/src/archive.rs
@@ -4,66 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use execution_core::ContractId;
-use execution_core::Event;
-use serde::{Deserialize, Serialize, Deserializer, Serializer};
-use anyhow::Result;
-
+use crate::events::contract::ContractTxEvent;
 use crate::ledger::Hash;
-
-/// Contract event with optional origin (tx hash).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ContractTxEvent {
-    pub event: ContractEvent,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub origin: Option<[u8; 32]>,
-}
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
-#[repr(C)]
-pub struct WrappedContractId(pub ContractId);
-
-impl Serialize for WrappedContractId {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let source_hex = hex::encode(self.0.as_bytes());
-        s.serialize_str(&source_hex)
-    }
-}
-
-impl<'de> Deserialize<'de> for WrappedContractId {
-    fn deserialize<D>(deserializer: D) -> Result<WrappedContractId, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let source_hex: String = Deserialize::deserialize(deserializer)?;
-        let source_bytes = hex::decode(source_hex).map_err(serde::de::Error::custom)?;
-        let mut source_array = [0u8; 32];
-
-        if source_bytes.len() != 32 {
-            //return Err(Error::invalid_length(source_hex.len(), &"32"));
-            return Err(serde::de::Error::custom(format!(
-                "Invalid length: expected 32 bytes, got {}",
-                source_bytes.len()
-            )));
-        }
-
-        source_array.copy_from_slice(&source_bytes);
-        Ok(WrappedContractId(ContractId::from_bytes(source_array)))
-    }
-}
-
-/// Wrapper around a contract event that is to be archived or sent to a websocket client.
-#[serde_with::serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ContractEvent {
-    pub target: WrappedContractId,
-    pub topic: String,
-    #[serde_as(as = "serde_with::hex::Hex")]
-    pub data: Vec<u8>,
-}
 
 /// Defined data, that the archivist will store.
 ///
@@ -71,6 +13,7 @@ pub struct ContractEvent {
 /// data to archive.
 ///
 /// Any data that archive nodes can store must be defined here
+#[derive(Debug)]
 pub enum ArchivalData {
     /// List of contract events from one block together with the block height
     /// and block hash.
@@ -90,68 +33,5 @@ impl ArchivalData {
         match self {
             ArchivalData::ArchivedEvents(_, hash, _) => hash,
         }
-    }
-}
-
-impl From<execution_core::Event> for ContractEvent {
-    fn from(event: execution_core::Event) -> Self {
-        Self {
-            target: WrappedContractId(event.source),
-            topic: event.topic,
-            data: event.data,
-        }
-    }
-}
-
-impl From<ContractEvent> for Event {
-    fn from(contract_event: ContractEvent) -> Self {
-        Event {
-            source: contract_event.target.0,
-            topic: contract_event.topic,
-            data: contract_event.data,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use execution_core::ContractId;
-
-    fn exec_core_event() -> Event {
-        Event {
-            source: ContractId::from_bytes([0; 32]),
-            topic: "contract".to_string(),
-            data: vec![1, 2, 3],
-        }
-    }
-
-    #[test]
-    fn test_converting_contract_event() {
-        let contract_event: ContractEvent = exec_core_event().into();
-
-        assert_eq!(Event::from(contract_event), exec_core_event());
-    }
-
-    #[test]
-    fn test_serialize_contract_event() {
-        let event: ContractEvent = exec_core_event().into();
-        let json_event = serde_json::to_string(&event).unwrap();
-        assert_eq!(event, serde_json::from_str(&json_event).unwrap());
-
-        let events: Vec<ContractEvent> = vec![event.clone(), event];
-        let json_events = serde_json::to_string(&events).unwrap();
-        assert_eq!(
-            events,
-            serde_json::from_str::<Vec<ContractEvent>>(&json_events).unwrap()
-        );
-
-        let empty_events: Vec<ContractEvent> = vec![];
-        let empty_json_events = serde_json::to_string(&empty_events).unwrap();
-        assert_eq!(
-            empty_events,
-            serde_json::from_str::<Vec<ContractEvent>>(&empty_json_events)
-                .unwrap()
-        );
     }
 }

--- a/node-data/src/archive.rs
+++ b/node-data/src/archive.rs
@@ -7,6 +7,8 @@
 use crate::events::contract::ContractTxEvent;
 use crate::ledger::Hash;
 
+type HexHash = String;
+
 /// Defined data, that the archivist will store.
 ///
 /// This is also the type of the mpsc channel where the archivist listens for
@@ -18,20 +20,6 @@ pub enum ArchivalData {
     /// List of contract events from one block together with the block height
     /// and block hash.
     ArchivedEvents(u64, Hash, Vec<ContractTxEvent>),
-}
-
-impl ArchivalData {
-    /// Returns the block height of the data.
-    pub fn block_height(&self) -> u64 {
-        match self {
-            ArchivalData::ArchivedEvents(height, _, _) => *height,
-        }
-    }
-
-    /// Returns the block hash of the data.
-    pub fn block_hash(&self) -> &Hash {
-        match self {
-            ArchivalData::ArchivedEvents(_, hash, _) => hash,
-        }
-    }
+    FinalizedBlock(u64, HexHash),
+    DeletedBlock(u64, HexHash),
 }

--- a/node-data/src/events.rs
+++ b/node-data/src/events.rs
@@ -5,6 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 mod blocks;
+pub mod contract;
 mod transactions;
 
 pub use blocks::{BlockEvent, BLOCK_CONFIRMED, BLOCK_FINALIZED};

--- a/node-data/src/events.rs
+++ b/node-data/src/events.rs
@@ -5,8 +5,9 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 mod blocks;
-pub mod contract;
 mod transactions;
+
+pub mod contract;
 
 pub use blocks::{BlockEvent, BLOCK_CONFIRMED, BLOCK_FINALIZED};
 pub use transactions::TransactionEvent;

--- a/node-data/src/events/blocks.rs
+++ b/node-data/src/events/blocks.rs
@@ -10,6 +10,33 @@ use crate::ledger::{Block, Hash};
 pub const BLOCK_FINALIZED: &str = "finalized";
 pub const BLOCK_CONFIRMED: &str = "confirmed";
 
+/// Represents events related to blocks in the chain.
+///
+/// - `Accepted(&'b Block)`
+///
+///     Indicates that a block has been accepted into the chain.
+///
+/// - `StateChange`
+///
+///     Represents a change in the state of a block.
+///
+///     - `hash: Hash` The unique identifier of the block whose state has
+///       changed.
+///
+///     - `state: &'static str` Describes the new state of the block (e.g.,
+///       `"finalized"`, `"confirmed"`).
+///
+///     - `height: u64` Indicates at which block height the state changed.
+#[derive(Clone, Debug)]
+pub enum BlockEvent<'b> {
+    Accepted(&'b Block),
+    StateChange {
+        hash: Hash,
+        state: &'static str,
+        height: u64,
+    },
+}
+
 impl EventSource for BlockEvent<'_> {
     const COMPONENT: &'static str = "blocks";
 
@@ -48,31 +75,4 @@ impl EventSource for BlockEvent<'_> {
         };
         hex::encode(hash)
     }
-}
-
-/// Represents events related to blocks in the chain.
-///
-/// - `Accepted(&'b Block)`
-///
-///     Indicates that a block has been accepted into the chain.
-///
-/// - `StateChange`
-///
-///     Represents a change in the state of a block.
-///
-///     - `hash: Hash` The unique identifier of the block whose state has
-///       changed.
-///
-///     - `state: &'static str` Describes the new state of the block (e.g.,
-///       `"finalized"`, `"confirmed"`).
-///
-///     - `height: u64` Indicates at which block height the state changed.
-#[derive(Clone, Debug)]
-pub enum BlockEvent<'b> {
-    Accepted(&'b Block),
-    StateChange {
-        hash: Hash,
-        state: &'static str,
-        height: u64,
-    },
 }

--- a/node-data/src/events/blocks.rs
+++ b/node-data/src/events/blocks.rs
@@ -35,6 +35,10 @@ pub enum BlockEvent<'b> {
         state: &'static str,
         height: u64,
     },
+    Deleted {
+        hash: Hash,
+        height: u64,
+    },
 }
 
 impl EventSource for BlockEvent<'_> {
@@ -44,6 +48,7 @@ impl EventSource for BlockEvent<'_> {
         match self {
             Self::Accepted(_) => "accepted",
             Self::StateChange { .. } => "statechange",
+            BlockEvent::Deleted { .. } => "deleted",
         }
     }
     fn data(&self) -> Option<serde_json::Value> {
@@ -65,6 +70,11 @@ impl EventSource for BlockEvent<'_> {
                     "atHeight": height,
                 })
             }
+            BlockEvent::Deleted { height, .. } => {
+                serde_json::json!({
+                    "atHeight": height,
+                })
+            }
         };
         Some(data)
     }
@@ -72,6 +82,7 @@ impl EventSource for BlockEvent<'_> {
         let hash = match self {
             Self::Accepted(block) => block.header().hash,
             Self::StateChange { hash, .. } => *hash,
+            Self::Deleted { hash, .. } => *hash,
         };
         hex::encode(hash)
     }

--- a/node-data/src/events/contract.rs
+++ b/node-data/src/events/contract.rs
@@ -7,8 +7,7 @@
 //! This module defines the contract event type and related types.
 
 use anyhow::Result;
-use execution_core::ContractId;
-use execution_core::Event;
+use execution_core::{ContractId, Event, CONTRACT_ID_BYTES};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Contract event with optional origin (tx hash).
@@ -41,11 +40,12 @@ impl<'de> Deserialize<'de> for WrappedContractId {
         let source_hex: String = Deserialize::deserialize(deserializer)?;
         let source_bytes =
             hex::decode(source_hex).map_err(serde::de::Error::custom)?;
-        let mut source_array = [0u8; 32];
+        let mut source_array = [0u8; CONTRACT_ID_BYTES];
 
-        if source_bytes.len() != 32 {
+        if source_bytes.len() != CONTRACT_ID_BYTES {
             return Err(serde::de::Error::custom(format!(
-                "Invalid length: expected 32 bytes, got {}",
+                "Invalid length: expected {} bytes, got {}",
+                CONTRACT_ID_BYTES,
                 source_bytes.len()
             )));
         }
@@ -93,7 +93,7 @@ mod tests {
 
     fn exec_core_event() -> Event {
         Event {
-            source: ContractId::from_bytes([0; 32]),
+            source: ContractId::from_bytes([0; CONTRACT_ID_BYTES]),
             topic: "contract".to_string(),
             data: vec![1, 2, 3],
         }

--- a/node-data/src/events/contract.rs
+++ b/node-data/src/events/contract.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+//! This module defines the contract event type and related types.
+
 use anyhow::Result;
 use execution_core::ContractId;
 use execution_core::Event;

--- a/node-data/src/events/contract.rs
+++ b/node-data/src/events/contract.rs
@@ -1,0 +1,128 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use anyhow::Result;
+use execution_core::ContractId;
+use execution_core::Event;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Contract event with optional origin (tx hash).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractTxEvent {
+    pub event: ContractEvent,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<[u8; 32]>,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+#[repr(C)]
+pub struct WrappedContractId(pub ContractId);
+
+impl Serialize for WrappedContractId {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let source_hex = hex::encode(self.0.as_bytes());
+        s.serialize_str(&source_hex)
+    }
+}
+
+impl<'de> Deserialize<'de> for WrappedContractId {
+    fn deserialize<D>(deserializer: D) -> Result<WrappedContractId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let source_hex: String = Deserialize::deserialize(deserializer)?;
+        let source_bytes =
+            hex::decode(source_hex).map_err(serde::de::Error::custom)?;
+        let mut source_array = [0u8; 32];
+
+        if source_bytes.len() != 32 {
+            return Err(serde::de::Error::custom(format!(
+                "Invalid length: expected 32 bytes, got {}",
+                source_bytes.len()
+            )));
+        }
+
+        source_array.copy_from_slice(&source_bytes);
+        Ok(WrappedContractId(ContractId::from_bytes(source_array)))
+    }
+}
+
+/// Wrapper around a contract event that is to be archived or sent to a
+/// websocket client.
+#[serde_with::serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContractEvent {
+    pub target: WrappedContractId,
+    pub topic: String,
+    #[serde_as(as = "serde_with::hex::Hex")]
+    pub data: Vec<u8>,
+}
+
+impl From<execution_core::Event> for ContractEvent {
+    fn from(event: execution_core::Event) -> Self {
+        Self {
+            target: WrappedContractId(event.source),
+            topic: event.topic,
+            data: event.data,
+        }
+    }
+}
+
+impl From<ContractEvent> for Event {
+    fn from(contract_event: ContractEvent) -> Self {
+        Event {
+            source: contract_event.target.0,
+            topic: contract_event.topic,
+            data: contract_event.data,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use execution_core::ContractId;
+
+    fn exec_core_event() -> Event {
+        Event {
+            source: ContractId::from_bytes([0; 32]),
+            topic: "contract".to_string(),
+            data: vec![1, 2, 3],
+        }
+    }
+
+    #[test]
+    fn test_converting_contract_event() {
+        let contract_event: ContractEvent = exec_core_event().into();
+
+        assert_eq!(Event::from(contract_event), exec_core_event());
+    }
+
+    #[test]
+    fn test_serialize_contract_event() {
+        let event: ContractEvent = exec_core_event().into();
+        let json_event = serde_json::to_string(&event).unwrap();
+        assert_eq!(event, serde_json::from_str(&json_event).unwrap());
+
+        let events: Vec<ContractEvent> = vec![event.clone(), event];
+        let json_events = serde_json::to_string(&events).unwrap();
+        assert_eq!(
+            events,
+            serde_json::from_str::<Vec<ContractEvent>>(&json_events).unwrap()
+        );
+
+        let empty_events: Vec<ContractEvent> = vec![];
+        let empty_json_events = serde_json::to_string(&empty_events).unwrap();
+        assert_eq!(
+            empty_events,
+            serde_json::from_str::<Vec<ContractEvent>>(&empty_json_events)
+                .unwrap()
+        );
+    }
+}

--- a/node-data/src/lib.rs
+++ b/node-data/src/lib.rs
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+pub mod archive;
 pub mod bls;
 pub mod encoding;
 pub mod events;

--- a/node/.env
+++ b/node/.env
@@ -1,2 +1,0 @@
-# export DATABASE_URL={db_protocol}://{user}:{password}@{host}:{port}/{database}
-DATABASE_URL=sqlite:///tmp/temp.sqlite3

--- a/node/.env
+++ b/node/.env
@@ -1,0 +1,2 @@
+# export DATABASE_URL={db_protocol}://{user}:{password}@{host}:{port}/{database}
+DATABASE_URL=sqlite:///tmp/temp.sqlite3

--- a/node/.sqlx/query-14e22bec4a8a50d407955a5db5fdf66138a9e1a0f14967134e3f2370d12d3173.json
+++ b/node/.sqlx/query-14e22bec4a8a50d407955a5db5fdf66138a9e1a0f14967134e3f2370d12d3173.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM archive WHERE block_hash = ? AND (finalized IS NULL OR finalized = 0)\n            RETURNING block_height\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "block_height",
+        "ordinal": 0,
+        "type_info": "Int64"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "14e22bec4a8a50d407955a5db5fdf66138a9e1a0f14967134e3f2370d12d3173"
+}

--- a/node/.sqlx/query-56e2b507ef0b75a8ce74c034caa97c769a0fdd06dd02daf0a589f94191104333.json
+++ b/node/.sqlx/query-56e2b507ef0b75a8ce74c034caa97c769a0fdd06dd02daf0a589f94191104333.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE archive SET finalized = 1 WHERE block_hash = ?\n            RETURNING block_height\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "block_height",
+        "ordinal": 0,
+        "type_info": "Int64"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "56e2b507ef0b75a8ce74c034caa97c769a0fdd06dd02daf0a589f94191104333"
+}

--- a/node/.sqlx/query-92d1fbef465114b1b5cf9fd4bd2c5de7cf64f166957e61082f1a02b9b1988ae2.json
+++ b/node/.sqlx/query-92d1fbef465114b1b5cf9fd4bd2c5de7cf64f166957e61082f1a02b9b1988ae2.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT json_contract_events FROM archive WHERE block_height = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "json_contract_events",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "92d1fbef465114b1b5cf9fd4bd2c5de7cf64f166957e61082f1a02b9b1988ae2"
+}

--- a/node/.sqlx/query-d9caf75d1a861747219f81ab0badbd7f8c96b61ba05f051db1ca653618cf7ae2.json
+++ b/node/.sqlx/query-d9caf75d1a861747219f81ab0badbd7f8c96b61ba05f051db1ca653618cf7ae2.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO archive (block_height, block_hash, json_contract_events) VALUES (?, ?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "d9caf75d1a861747219f81ab0badbd7f8c96b61ba05f051db1ca653618cf7ae2"
+}

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -35,6 +35,8 @@ thiserror = "1"
 metrics = "0.22"
 metrics-exporter-prometheus = "0.14"
 memory-stats = "1.0"
+sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-native-tls", "sqlite", "migrate"], optional = true }
+serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 fake = { version = "2.5", features = ['derive'] }
@@ -46,7 +48,7 @@ criterion = { version = "0.5", features = ["async_futures"] }
 
 [features]
 with_telemetry = ["dep:console-subscriber"]
-
+archive = ["dep:sqlx", "dep:serde_json"]
 
 [[bench]]
 name = "accept"

--- a/node/README.md
+++ b/node/README.md
@@ -4,11 +4,25 @@ The Dusk Node functionality crate.
 
 ## Archive feature
 
-The current archive makes use of SQLite and SQLx.
+The current archive makes use of SQLite and SQLx in [offline mode](https://docs.rs/sqlx/latest/sqlx/macro.query.html#offline-mode).
 
-In order for the `sqlx::query` macro to successfully expand during compile time checks, a database must exist beforehand.
+Installing sqlx-cli with ``cargo install sqlx-cli --features openssl-vendored``
+
+### Offline mode
+
+**If the queries don't change, nothing needs to be done.**
+
+If queries do change, you need to set a database env var and update the offline .sqlx queries folder.
 
 This can be done through:
-1. Installing sqlx-cli with ``cargo install sqlx-cli --features openssl-vendored``
-2. Create a db with ``sqlx database create`` (this takes the db info out of .env if no DATABASE_URL is set)
+1. ``export DATABASE_URL=sqlite:///tmp/temp.sqlite3``
+2. ``cargo sqlx prepare -- --all-targets --all-features``
+
+### Non offline mode
+
+In order for the `sqlx::query` macro to successfully expand during compile time checks, a database must exist beforehand if not run in offline mode.
+
+This can be done through:
+1. Set DATABASE_URL or create .env file with ``DATABASE_URL=sqlite:///tmp/temp.sqlite3``
+2. Create a db with ``sqlx database create`` 
 3. Run the migrations with ``sqlx migrate run``

--- a/node/README.md
+++ b/node/README.md
@@ -1,3 +1,14 @@
  # Dusk node library
 
 The Dusk Node functionality crate.
+
+## Archive feature
+
+The current archive makes use of SQLite and SQLx.
+
+In order for the `sqlx::query` macro to successfully expand during compile time checks, a database must exist beforehand.
+
+This can be done through:
+1. Installing sqlx-cli with ``cargo install sqlx-cli --features openssl-vendored``
+2. Create a db with ``sqlx database create`` (this takes the db info out of .env if no DATABASE_URL is set)
+3. Run the migrations with ``sqlx migrate run``

--- a/node/migrations/20240908201150_archive.sql
+++ b/node/migrations/20240908201150_archive.sql
@@ -1,0 +1,11 @@
+-- Sqlite schema for the archive table
+CREATE TABLE archive (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    block_height INTEGER NOT NULL,
+    block_hash TEXT NOT NULL,
+    -- Json array of contract events emitted within the block
+    json_contract_events TEXT NOT NULL DEFAULT '[]'
+);
+
+CREATE UNIQUE INDEX block_height_idx ON archive (block_height);
+--CREATE UNIQUE INDEX block_hash_idx ON archive (block_hash);

--- a/node/migrations/20240908201150_archive.sql
+++ b/node/migrations/20240908201150_archive.sql
@@ -4,8 +4,9 @@ CREATE TABLE archive (
     block_height INTEGER NOT NULL,
     block_hash TEXT NOT NULL,
     -- Json array of contract events emitted within the block
-    json_contract_events TEXT NOT NULL DEFAULT '[]'
+    json_contract_events TEXT NOT NULL DEFAULT '[]',
+    finalized BOOLEAN
 );
 
 CREATE UNIQUE INDEX block_height_idx ON archive (block_height);
---CREATE UNIQUE INDEX block_hash_idx ON archive (block_hash);
+CREATE UNIQUE INDEX block_hash_idx ON archive (block_hash);

--- a/node/src/archivist.rs
+++ b/node/src/archivist.rs
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use core::panic;
+use std::sync::{mpsc, Arc};
+
+use async_trait::async_trait;
+use node_data::archive::ArchivalData;
+use tokio::sync::Mutex;
+use tracing::error;
+
+use crate::database::archive::SQLiteArchive;
+use crate::database::Archivist;
+use crate::{database, vm, LongLivedService, Network};
+
+pub struct ArchivistSrv {
+    pub archive_receiver: Mutex<mpsc::Receiver<ArchivalData>>,
+    pub archivist: SQLiteArchive,
+}
+
+#[async_trait]
+impl<N: Network, DB: database::DB, VM: vm::VMExecution>
+    LongLivedService<N, DB, VM> for ArchivistSrv
+{
+    async fn execute(
+        &mut self,
+        _: Arc<tokio::sync::RwLock<N>>,
+        _: Arc<tokio::sync::RwLock<DB>>,
+        _: Arc<tokio::sync::RwLock<VM>>,
+    ) -> anyhow::Result<usize> {
+        loop {
+            if let Ok(msg) = self.archive_receiver.lock().await.recv() {
+                match msg {
+                    ArchivalData::ArchivedEvents(
+                        block_height,
+                        block_hash,
+                        events,
+                    ) => {
+                        if let Err(e) = self
+                            .archivist
+                            .store_vm_events(block_height, block_hash, events)
+                            .await
+                        {
+                            error!(
+                                "Failed to archive block vm events: {:?}",
+                                e
+                            );
+                        }
+                    }
+                }
+            } else {
+                error!(
+                    "Sending side of the archive data channel has been closed"
+                );
+
+                break;
+            }
+        }
+
+        Ok(0)
+    }
+
+    /// Returns service name.
+    fn name(&self) -> &'static str {
+        "archive"
+    }
+}

--- a/node/src/archivist.rs
+++ b/node/src/archivist.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use node_data::archive::ArchivalData;
 use std::sync::Arc;
 use tokio::sync::mpsc::Receiver;
+use tokio::sync::RwLock;
 use tracing::error;
 
 pub struct ArchivistSrv {
@@ -24,9 +25,9 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
 {
     async fn execute(
         &mut self,
-        _: Arc<tokio::sync::RwLock<N>>,
-        _: Arc<tokio::sync::RwLock<DB>>,
-        _: Arc<tokio::sync::RwLock<VM>>,
+        _: Arc<RwLock<N>>,
+        _: Arc<RwLock<DB>>,
+        _: Arc<RwLock<VM>>,
     ) -> anyhow::Result<usize> {
         loop {
             if let Some(msg) = self.archive_receiver.recv().await {

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -663,7 +663,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
     /// - List of the new finalized state root
     fn rolling_finality<D: database::DB>(
         &self,
-        pni: u8,
+        pni: u8, // Previous Non-Attested Iterations
         blk: &Block,
         db: &D::P<'_>,
         events: &mut Vec<Event>,
@@ -856,6 +856,16 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
                 if height == 0 {
                     panic!("revert to genesis block failed");
                 }
+
+                if let Err(e) = self.event_sender.try_send(
+                    BlockEvent::Deleted {
+                        hash: h.hash,
+                        height: h.height,
+                    }
+                    .into(),
+                ) {
+                    warn!("cannot notify event {e}")
+                };
 
                 info!(
                     event = "block deleted",

--- a/node/src/database.rs
+++ b/node/src/database.rs
@@ -13,9 +13,8 @@ pub mod rocksdb;
 
 use anyhow::Result;
 #[cfg(feature = "archive")]
-use node_data::events::contract::ContractTxEvent;
-#[cfg(feature = "archive")]
-use node_data::ledger::Hash;
+use {node_data::events::contract::ContractTxEvent, node_data::ledger::Hash};
+
 use node_data::ledger::{self, Fault, Label, SpendingId, SpentTransaction};
 
 use serde::{Deserialize, Serialize};
@@ -234,4 +233,16 @@ pub(crate) trait Archivist {
         &self,
         block_height: u64,
     ) -> Result<Vec<ContractTxEvent>>;
+
+    async fn mark_block_finalized(
+        &self,
+        block_height: u64,
+        hex_block_hash: String,
+    ) -> Result<()>;
+
+    async fn remove_deleted_block(
+        &self,
+        block_height: u64,
+        hex_block_hash: String,
+    ) -> Result<bool>;
 }

--- a/node/src/database.rs
+++ b/node/src/database.rs
@@ -13,13 +13,11 @@ pub mod rocksdb;
 
 use anyhow::Result;
 #[cfg(feature = "archive")]
-use node_data::archive::ContractEvent;
+use node_data::archive::ContractTxEvent;
 #[cfg(feature = "archive")]
 use node_data::ledger::Hash;
 use node_data::ledger::{self, Fault, Label, SpendingId, SpentTransaction};
 
-#[cfg(feature = "archive")]
-use execution_core::signatures::bls::PublicKey as AccountPublicKey;
 use serde::{Deserialize, Serialize};
 
 pub struct LightBlock {
@@ -229,11 +227,11 @@ pub(crate) trait Archivist {
         &self,
         block_height: u64,
         block_hash: Hash,
-        events: Vec<ContractEvent>,
+        events: Vec<ContractTxEvent>,
     ) -> Result<()>;
 
     async fn fetch_vm_events(
         &self,
         block_height: u64,
-    ) -> Result<Vec<ContractEvent>>;
+    ) -> Result<Vec<ContractTxEvent>>;
 }

--- a/node/src/database.rs
+++ b/node/src/database.rs
@@ -13,7 +13,7 @@ pub mod rocksdb;
 
 use anyhow::Result;
 #[cfg(feature = "archive")]
-use node_data::archive::ContractTxEvent;
+use node_data::events::contract::ContractTxEvent;
 #[cfg(feature = "archive")]
 use node_data::ledger::Hash;
 use node_data::ledger::{self, Fault, Label, SpendingId, SpentTransaction};

--- a/node/src/database/archive.rs
+++ b/node/src/database/archive.rs
@@ -1,0 +1,171 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+use node_data::archive::ContractEvent;
+use node_data::ledger::Hash;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool};
+use tracing::info;
+
+use super::Archivist;
+
+const ARCHIVE_FOLDER_NAME: &str = "archive";
+const SQLITE_DB_NAME: &str = "archive.sqlite3";
+
+#[derive(Debug)]
+pub struct SQLiteArchive {
+    archive_db: SqlitePool,
+}
+
+impl SQLiteArchive {
+    pub async fn create_or_open<T>(path: T) -> Self
+    where
+        T: AsRef<Path>,
+    {
+        let path = path.as_ref().join(ARCHIVE_FOLDER_NAME);
+        info!("Opening archive db in {path:?}");
+
+        // Recursively create the archive folder if it doesn't exist already
+        fs::create_dir_all(&path)
+            .expect("creating directory in {path} should not fail");
+
+        let db_options = SqliteConnectOptions::new()
+            // append the database name to the path
+            .filename(path.join(SQLITE_DB_NAME))
+            .create_if_missing(true);
+
+        // Open the database, create it if it doesn't exist
+        let archive_db = SqlitePool::connect_with(db_options)
+            .await
+            .expect("Failed to open database");
+
+        // Run the migrations
+        sqlx::migrate!("./migrations")
+            .run(&archive_db)
+            .await
+            .expect("Failed to run migrations");
+
+        Self { archive_db }
+    }
+
+    /// Fetch the json string of all vm events form a given block height
+    pub async fn fetch_json_vm_events(
+        &self,
+        block_height: u64,
+    ) -> Result<String> {
+        let block_height: i64 = block_height as i64;
+
+        let mut conn = self.archive_db.acquire().await?;
+
+        let events = sqlx::query!(
+            r#"SELECT json_contract_events FROM archive WHERE block_height = ?"#,
+            block_height
+        ).fetch_one(&mut *conn).await?;
+
+        Ok(events.json_contract_events)
+    }
+}
+
+impl Archivist for SQLiteArchive {
+    /// Store the list of all vm events from the block of the given height.
+    async fn store_vm_events(
+        &self,
+        block_height: u64,
+        block_hash: Hash,
+        events: Vec<ContractEvent>,
+    ) -> Result<()> {
+        let block_height: i64 = block_height as i64;
+        let block_hash = hex::encode(block_hash);
+        // Serialize the events to a json string
+        let json_contract_events = serde_json::to_string(&events).unwrap();
+
+        let mut conn = self.archive_db.acquire().await?;
+
+        sqlx::query!(
+             r#"INSERT INTO archive (block_height, block_hash, json_contract_events) VALUES (?, ?, ?)"#,
+            block_height, block_hash, json_contract_events
+        ).execute(&mut *conn).await?.rows_affected();
+
+        info!("Stored events in block: {}", block_height);
+
+        Ok(())
+    }
+
+    async fn fetch_vm_events(
+        &self,
+        block_height: u64,
+    ) -> Result<Vec<ContractEvent>> {
+        let block_height: i64 = block_height as i64;
+
+        let mut conn = self.archive_db.acquire().await?;
+
+        let events = sqlx::query!(
+            r#"SELECT json_contract_events FROM archive WHERE block_height = ?"#,
+            block_height
+        ).fetch_one(&mut *conn).await?;
+
+        // convert the json string to a vector of ContractEvent and return it
+        Ok(serde_json::from_str(&events.json_contract_events)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{distributions::Alphanumeric, Rng};
+    use std::env;
+    use std::path::{self, PathBuf};
+
+    // Construct a random test directory path in the temp folder of the OS
+    fn get_test_dir() -> PathBuf {
+        let mut test_dir = "archive-db-test-".to_owned();
+        let rand_string: String = rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(20)
+            .map(char::from)
+            .collect();
+        test_dir.push_str(&rand_string);
+
+        env::temp_dir().join(test_dir)
+    }
+
+    #[tokio::test]
+    async fn test_store_fetch_vm_events() {
+        let path = get_test_dir();
+
+        let archive = SQLiteArchive::create_or_open(path).await;
+
+        let events = vec![
+            ContractEvent {
+                source: [0; 32],
+                topic: "contract1".to_string(),
+                data: vec![1, 6, 1, 8],
+            },
+            ContractEvent {
+                source: [0; 32],
+                topic: "contract2".to_string(),
+                data: vec![1, 2, 3],
+            },
+        ];
+
+        archive
+            .store_vm_events(1, [5; 32], events.clone())
+            .await
+            .unwrap();
+
+        let fetched_events = archive.fetch_vm_events(1).await.unwrap();
+
+        // Check if the events are the same
+        for (event, fetched_event) in events.iter().zip(fetched_events.iter()) {
+            assert_eq!(event.source, fetched_event.source);
+            assert_eq!(event.topic, fetched_event.topic);
+            assert_eq!(event.data, fetched_event.data);
+        }
+    }
+}

--- a/node/src/database/archive.rs
+++ b/node/src/database/archive.rs
@@ -146,7 +146,7 @@ mod tests {
         let events = vec![
             ContractTxEvent {
                 event: ContractEvent {
-                    source: [0; 32],
+                    target: [0; 32],
                     topic: "contract1".to_string(),
                     data: vec![1, 6, 1, 8],
                 },
@@ -154,7 +154,7 @@ mod tests {
             },
             ContractTxEvent {
                 event: ContractEvent {
-                    source: [0; 32],
+                    target: [0; 32],
                     topic: "contract2".to_string(),
                     data: vec![1, 2, 3],
                 },
@@ -174,8 +174,8 @@ mod tests {
             events.iter().zip(fetched_events.iter())
         {
             assert_eq!(
-                contract_tx_event.event.source,
-                fetched_event.event.source
+                contract_tx_event.event.target,
+                fetched_event.event.target
             );
             assert_eq!(
                 contract_tx_event.event.topic,

--- a/node/src/database/archive.rs
+++ b/node/src/database/archive.rs
@@ -83,7 +83,7 @@ impl Archivist for SQLiteArchive {
         let block_height: i64 = block_height as i64;
         let hex_block_hash = hex::encode(block_hash);
         // Serialize the events to a json string
-        let json_contract_events = serde_json::to_string(&events).unwrap();
+        let json_contract_events = serde_json::to_string(&events)?;
 
         let mut conn = self.archive_db.acquire().await?;
 
@@ -190,13 +190,19 @@ impl Archivist for SQLiteArchive {
 mod util {
     /// Truncate a string to at most 35 characters.
     pub fn truncate_string(s: &str) -> String {
-        if s.len() <= 32 {
+        if s.len() <= 35 {
             return s.to_string();
         }
 
-        let first_part = &s[..16];
-        let last_part = &s[s.len() - 16..];
-        format!("{}...{}", first_part, last_part)
+        s.chars().take(16).collect::<String>()
+            + "..."
+            + &s.chars()
+                .rev()
+                .take(16)
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect::<String>()
     }
 }
 

--- a/node/src/database/archive.rs
+++ b/node/src/database/archive.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::Result;
-use node_data::archive::ContractTxEvent;
+use node_data::events::contract::ContractTxEvent;
 use node_data::ledger::Hash;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePool};
 use tracing::info;
@@ -119,7 +119,8 @@ impl Archivist for SQLiteArchive {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use node_data::archive::ContractEvent;
+    use execution_core::ContractId;
+    use node_data::events::contract::{ContractEvent, WrappedContractId};
     use rand::{distributions::Alphanumeric, Rng};
     use std::env;
     use std::path::PathBuf;
@@ -146,7 +147,7 @@ mod tests {
         let events = vec![
             ContractTxEvent {
                 event: ContractEvent {
-                    target: [0; 32],
+                    target: WrappedContractId(ContractId::from_bytes([0; 32])),
                     topic: "contract1".to_string(),
                     data: vec![1, 6, 1, 8],
                 },
@@ -154,7 +155,7 @@ mod tests {
             },
             ContractTxEvent {
                 event: ContractEvent {
-                    target: [0; 32],
+                    target: WrappedContractId(ContractId::from_bytes([1; 32])),
                     topic: "contract2".to_string(),
                     data: vec![1, 2, 3],
                 },

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -6,6 +6,8 @@
 
 #![feature(lazy_cell)]
 
+#[cfg(feature = "archive")]
+pub mod archivist;
 pub mod chain;
 pub mod database;
 pub mod databroker;

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -99,6 +99,7 @@ recovery-keys = ["rusk-recovery/keys"]
 prover = ["dep:rusk-prover"]
 testwallet = ["dep:futures"]
 node = ["dep:node", "dep:dusk-consensus", "dep:node-data"]
+archive = ["node", "node/archive"]
 http-wasm = []
 
 [[bench]]

--- a/rusk/benches/block_ingestion.rs
+++ b/rusk/benches/block_ingestion.rs
@@ -114,6 +114,7 @@ fn bench_accept(
 ) {
     const BLOCK_HEIGHT: u64 = 1;
     const BLOCK_GAS_LIMIT: u64 = 1_000_000_000_000;
+    const BLOCK_HASH: [u8; 32] = [0u8; 32];
 
     let generator = {
         let mut rng = StdRng::seed_from_u64(0xbeef);
@@ -137,6 +138,7 @@ fn bench_accept(
                     rusk.accept_transactions(
                         BLOCK_HEIGHT,
                         BLOCK_GAS_LIMIT,
+                        BLOCK_HASH,
                         generator,
                         txs,
                         None,

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -108,7 +108,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_rues(_event_sender);
 
         #[cfg(feature = "archive")]
-        let node_builder = node_builder.with_archivist(archive_receiver);
+        let node_builder =
+            node_builder.with_archivist(archive_sender, archive_receiver);
 
         #[allow(clippy::let_and_return)]
         node_builder

--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -921,7 +921,9 @@ mod tests {
     use event::Event as EventRequest;
 
     use execution_core::ContractId;
-    use node_data::events::contract::{ContractTxEvent, WrappedContractId};
+    use node_data::events::contract::{
+        ContractEvent, ContractTxEvent, WrappedContractId,
+    };
     use std::net::TcpStream;
     use tungstenite::client;
 

--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -73,7 +73,7 @@ pub use self::event::{RuesDispatchEvent, RuesEvent, RUES_LOCATION_PREFIX};
 use self::event::{MessageRequest, ResponseData, RuesEventUri, SessionId};
 use self::stream::{Listener, Stream};
 #[cfg(feature = "node")]
-use node_data::archive::ContractEvent;
+use node_data::events::contract::ContractEvent;
 
 const RUSK_VERSION_HEADER: &str = "Rusk-Version";
 
@@ -908,7 +908,7 @@ mod tests {
     use event::Event as EventRequest;
 
     use execution_core::ContractId;
-    use node_data::archive::{ContractTxEvent, WrappedContractId};
+    use node_data::events::contract::{ContractTxEvent, WrappedContractId};
     use std::net::TcpStream;
     use tungstenite::client;
 

--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -65,6 +65,9 @@ use anyhow::Error as AnyhowError;
 use hyper_util::rt::TokioIo;
 use rand::rngs::OsRng;
 
+#[cfg(feature = "node")]
+use node_data::events::contract::ContractEvent;
+
 use crate::http::event::FullOrStreamBody;
 use crate::VERSION;
 
@@ -72,8 +75,6 @@ pub use self::event::{RuesDispatchEvent, RuesEvent, RUES_LOCATION_PREFIX};
 
 use self::event::{MessageRequest, ResponseData, RuesEventUri, SessionId};
 use self::stream::{Listener, Stream};
-#[cfg(feature = "node")]
-use node_data::events::contract::ContractEvent;
 
 const RUSK_VERSION_HEADER: &str = "Rusk-Version";
 

--- a/rusk/src/lib/http/event.rs
+++ b/rusk/src/lib/http/event.rs
@@ -975,8 +975,8 @@ impl RuesEvent {
 }
 
 #[cfg(feature = "node")]
-impl From<crate::node::ContractTxEvent> for RuesEvent {
-    fn from(tx_event: crate::node::ContractTxEvent) -> Self {
+impl From<node_data::archive::ContractTxEvent> for RuesEvent {
+    fn from(tx_event: node_data::archive::ContractTxEvent) -> Self {
         let mut headers = serde_json::Map::new();
         if let Some(origin) = tx_event.origin {
             headers.insert("Rusk-Origin".into(), hex::encode(origin).into());
@@ -985,7 +985,7 @@ impl From<crate::node::ContractTxEvent> for RuesEvent {
         Self {
             uri: RuesEventUri {
                 component: "contracts".into(),
-                entity: Some(hex::encode(event.source.as_bytes())),
+                entity: Some(hex::encode(event.source)),
                 topic: event.topic,
             },
             data: event.data.into(),

--- a/rusk/src/lib/http/event.rs
+++ b/rusk/src/lib/http/event.rs
@@ -819,6 +819,8 @@ impl RuesEventUri {
 #[serde_with::serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ContractEvent {
+    // TODO: Move this into node-data and merge it with the ContractEvent used
+    // for archival so that all events are handled in the same way
     pub target: WrappedContractId,
     pub topic: String,
     #[serde_as(as = "serde_with::hex::Hex")]

--- a/rusk/src/lib/http/event.rs
+++ b/rusk/src/lib/http/event.rs
@@ -921,8 +921,8 @@ impl RuesEvent {
 }
 
 #[cfg(feature = "node")]
-impl From<node_data::archive::ContractTxEvent> for RuesEvent {
-    fn from(tx_event: node_data::archive::ContractTxEvent) -> Self {
+impl From<node_data::events::contract::ContractTxEvent> for RuesEvent {
+    fn from(tx_event: node_data::events::contract::ContractTxEvent) -> Self {
         let mut headers = serde_json::Map::new();
         if let Some(origin) = tx_event.origin {
             headers.insert("Rusk-Origin".into(), hex::encode(origin).into());

--- a/rusk/src/lib/node/events.rs
+++ b/rusk/src/lib/node/events.rs
@@ -34,6 +34,10 @@ impl<N: Network, DB: database::DB, VM: node::vm::VMExecution>
         loop {
             if let Some(msg) = self.node_receiver.recv().await {
                 if let Err(e) = self.rues_sender.send(msg.into()) {
+                    // NB: This service receives all events and forwards them to
+                    // RUES. We can forward them here to the
+                    // ArchivistSrv too and directly be able to store all
+                    // events.
                     error!("Cannot send to rues {e:?}");
                 }
             }

--- a/rusk/src/lib/node/events.rs
+++ b/rusk/src/lib/node/events.rs
@@ -13,12 +13,19 @@ use node_data::events::Event as ChainEvent;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc::Receiver;
 use tracing::error;
+#[cfg(feature = "archive")]
+use {
+    node_data::archive::ArchivalData, node_data::events::BLOCK_FINALIZED,
+    serde_json::Value, tokio::sync::mpsc::Sender,
+};
 
 use crate::http::RuesEvent;
 
 pub(crate) struct ChainEventStreamer {
     pub node_receiver: Receiver<ChainEvent>,
     pub rues_sender: broadcast::Sender<RuesEvent>,
+    #[cfg(feature = "archive")]
+    pub archivist_sender: Sender<ArchivalData>,
 }
 
 #[async_trait]
@@ -33,12 +40,64 @@ impl<N: Network, DB: database::DB, VM: node::vm::VMExecution>
     ) -> anyhow::Result<usize> {
         loop {
             if let Some(msg) = self.node_receiver.recv().await {
-                if let Err(e) = self.rues_sender.send(msg.into()) {
-                    // NB: This service receives all events and forwards them to
-                    // RUES. We can forward them here to the
-                    // ArchivistSrv too and directly be able to store all
-                    // events.
+                if let Err(e) = self.rues_sender.send(msg.clone().into()) {
                     error!("Cannot send to rues {e:?}");
+                }
+
+                #[cfg(feature = "archive")]
+                {
+                    // NB: This is a temporary solution to send finalized and
+                    // deleted blocks to the archivist in a decoupled way.
+                    // We can remove this once the consensus acceptor can send
+                    // these events directly to the archivist service.
+                    match msg.topic {
+                        // "statechange" & "deleted" are only in msg.component
+                        // == "blocks"
+                        "statechange" => {
+                            if let Some(json_val) = msg.data {
+                                let state = json_val
+                                    .get("state")
+                                    .and_then(Value::as_str)
+                                    .unwrap_or_default();
+                                let at_height = json_val
+                                    .get("atHeight")
+                                    .and_then(Value::as_u64)
+                                    .unwrap_or_default();
+
+                                if state == BLOCK_FINALIZED {
+                                    if let Err(e) = self
+                                        .archivist_sender
+                                        .try_send(ArchivalData::FinalizedBlock(
+                                            at_height,
+                                            msg.entity.clone(),
+                                        ))
+                                    {
+                                        error!(
+                                            "Cannot send to archivist {e:?}"
+                                        );
+                                    };
+                                }
+                            };
+                        }
+                        "deleted" => {
+                            if let Some(json_val) = msg.data {
+                                let at_height = json_val
+                                    .get("atHeight")
+                                    .and_then(Value::as_u64)
+                                    .unwrap_or_default();
+
+                                if let Err(e) = self.archivist_sender.try_send(
+                                    ArchivalData::DeletedBlock(
+                                        at_height,
+                                        msg.entity.clone(),
+                                    ),
+                                ) {
+                                    error!("Cannot send to archivist {e:?}");
+                                };
+                            };
+                        }
+                        _ => (),
+                    }
                 }
             }
         }

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -48,7 +48,7 @@ use crate::gen_id::gen_contract_id;
 use crate::http::RuesEvent;
 use crate::Error::InvalidCreditsCount;
 use crate::{Error, Result, DELETING_VM_FNAME};
-use node_data::archive::ContractTxEvent;
+use node_data::events::contract::ContractTxEvent;
 
 pub static DUSK_KEY: LazyLock<BlsPublicKey> = LazyLock::new(|| {
     let dusk_cpk_bytes = include_bytes!("../../assets/dusk.cpk");

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -799,7 +799,7 @@ fn update_hasher(hasher: &mut Sha3_256, events: &[ContractTxEvent]) {
             hasher.update(origin);
         }
         let event = &tx_event.event;
-        hasher.update(event.source);
+        hasher.update(event.target.0);
         hasher.update(event.topic.as_bytes());
         hasher.update(&event.data);
     }

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -34,21 +34,19 @@ use execution_core::{
     },
     BlsScalar, ContractError, Dusk, Event,
 };
-#[cfg(feature = "archive")]
-use node_data::archive::ArchivalData;
+use node_data::events::contract::ContractTxEvent;
 use node_data::ledger::{Hash, Slash, SpentTransaction, Transaction};
 use rusk_abi::{CallReceipt, PiecrustError, Session, VM};
 use rusk_profile::to_rusk_state_id_path;
 use tokio::sync::broadcast;
 #[cfg(feature = "archive")]
-use tokio::sync::mpsc::Sender;
+use {node_data::archive::ArchivalData, tokio::sync::mpsc::Sender};
 
-use super::{coinbase_value, Rusk, RuskTip};
 use crate::gen_id::gen_contract_id;
 use crate::http::RuesEvent;
+use crate::node::{coinbase_value, Rusk, RuskTip};
 use crate::Error::InvalidCreditsCount;
 use crate::{Error, Result, DELETING_VM_FNAME};
-use node_data::events::contract::ContractTxEvent;
 
 pub static DUSK_KEY: LazyLock<BlsPublicKey> = LazyLock::new(|| {
     let dusk_cpk_bytes = include_bytes!("../../assets/dusk.cpk");

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -35,18 +35,20 @@ use execution_core::{
     BlsScalar, ContractError, Dusk, Event,
 };
 #[cfg(feature = "archive")]
-use node_data::archive::{ArchivalData, ContractEvent};
+use node_data::archive::ArchivalData;
 use node_data::ledger::{Hash, Slash, SpentTransaction, Transaction};
 use rusk_abi::{CallReceipt, PiecrustError, Session, VM};
 use rusk_profile::to_rusk_state_id_path;
 use tokio::sync::broadcast;
+#[cfg(feature = "archive")]
+use tokio::sync::mpsc::Sender;
 
-use super::vm::ContractTxEvent;
 use super::{coinbase_value, Rusk, RuskTip};
 use crate::gen_id::gen_contract_id;
 use crate::http::RuesEvent;
 use crate::Error::InvalidCreditsCount;
 use crate::{Error, Result, DELETING_VM_FNAME};
+use node_data::archive::ContractTxEvent;
 
 pub static DUSK_KEY: LazyLock<BlsPublicKey> = LazyLock::new(|| {
     let dusk_cpk_bytes = include_bytes!("../../assets/dusk.cpk");
@@ -68,9 +70,7 @@ impl Rusk {
         block_gas_limit: u64,
         feeder_gas_limit: u64,
         event_sender: broadcast::Sender<RuesEvent>,
-        #[cfg(feature = "archive")] archive_sender: mpsc::SyncSender<
-            ArchivalData,
-        >,
+        #[cfg(feature = "archive")] archive_sender: Sender<ArchivalData>,
     ) -> Result<Self> {
         let dir = dir.as_ref();
         let commit_id_path = to_rusk_state_id_path(dir);
@@ -210,7 +210,7 @@ impl Rusk {
                         .events
                         .into_iter()
                         .map(|event| ContractTxEvent {
-                            event,
+                            event: event.into(),
                             origin: Some(tx_id),
                         })
                         .collect();
@@ -258,7 +258,7 @@ impl Rusk {
         let coinbase_events: Vec<_> = coinbase_events
             .into_iter()
             .map(|event| ContractTxEvent {
-                event,
+                event: event.into(),
                 origin: None,
             })
             .collect();
@@ -344,24 +344,20 @@ impl Rusk {
 
         self.set_current_commit(session.commit()?);
 
-        // Convert vm events to ContractEvent and sent to archive
+        // Sent events to archivist
         #[cfg(feature = "archive")]
         {
-            let _ = self.archive_sender.send(ArchivalData::ArchivedEvents(
+            let _ = self.archive_sender.try_send(ArchivalData::ArchivedEvents(
                 block_height,
                 _archive_block_hash,
-                events
-                    .clone()
-                    .into_iter()
-                    .map(|event| ContractEvent::from(event))
-                    .collect(),
+                events.clone(),
             ));
         }
 
         for event in events {
             // Send VN event to RUES
             let event = RuesEvent::from(event);
-            let _ = self.event_sender.send(event.into());
+            let _ = self.event_sender.send(event);
         }
 
         Ok((spent_txs, verification_output))
@@ -579,7 +575,7 @@ fn accept(
             .events
             .into_iter()
             .map(|event| ContractTxEvent {
-                event,
+                event: event.into(),
                 origin: Some(tx_id),
             })
             .collect();
@@ -615,7 +611,7 @@ fn accept(
     let coinbase_events: Vec<_> = coinbase_events
         .into_iter()
         .map(|event| ContractTxEvent {
-            event,
+            event: event.into(),
             origin: None,
         })
         .collect();
@@ -803,7 +799,7 @@ fn update_hasher(hasher: &mut Sha3_256, events: &[ContractTxEvent]) {
             hasher.update(origin);
         }
         let event = &tx_event.event;
-        hasher.update(event.source.as_bytes());
+        hasher.update(event.source);
         hasher.update(event.topic.as_bytes());
         hasher.update(&event.data);
     }

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -14,19 +14,13 @@ use dusk_consensus::user::provisioners::Provisioners;
 use dusk_consensus::user::stake::Stake;
 use execution_core::{
     signatures::bls::PublicKey as BlsPublicKey, stake::StakeData,
-    transfer::Transaction as ProtocolTransaction, Event,
+    transfer::Transaction as ProtocolTransaction,
 };
 use node::vm::VMExecution;
 use node_data::bls::PublicKey;
 use node_data::ledger::{Block, Slash, SpentTransaction, Transaction};
 
 use super::Rusk;
-
-#[derive(Debug, Clone)]
-pub struct ContractTxEvent {
-    pub event: Event,
-    pub origin: Option<[u8; 32]>,
-}
 
 impl VMExecution for Rusk {
     fn execute_state_transition<I: Iterator<Item = Transaction>>(

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -90,6 +90,7 @@ impl VMExecution for Rusk {
             .accept_transactions(
                 blk.header().height,
                 blk.header().gas_limit,
+                blk.header().hash,
                 generator,
                 blk.txs().clone(),
                 Some(VerificationOutput {


### PR DESCRIPTION
This PR introduces the "archive" feature flag to rusk and node. Another PR would build on top of this and introduce serving them through an http api.

When run with:
`DUSK_CONSENSUS_KEYS_PASS=password cargo r --release --features archive -p rusk  -- -s /tmp/example.state`, the archive feature is active and starts archiving contract events from the vm into an SQLite database.

This was done by adding a new service, ArchivistSrv, to the node's service_list. This service listens on a channel that receives the VM events from a sender that sends them during the execution of the `accept_transactions` function of the Rusk struct (the same place where VM events are sent to RUES).

The ArchivistSrv, upon receiving new VM events, calls the SQLiteArchive (which manages a SQLite db) and stores all `ContractTxEvent` events from a block in a json serialized column.

Considerations:
- ~Merge ContractEvent in rusk http lib with the one in node-data~
- Make SQLite more performant with pragmas in the next PR (e.g. `PRAGMA journal_mode=WAL;`)
- We can add query CI checks with `cargo install sqlx-cli && cargo sqlx prepare --check -- --all-targets --all-features` for the queries
- Migrate to rocksdb, lmdb or similar at the earliest feasible time