### PR TITLE
consensus: relax emergency iterations checks

### DIFF
--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -268,11 +268,13 @@ impl<'a, T: Operations + 'static> ExecutionCtx<'a, T> {
                     }
 
                     Payload::ValidationResult(validation_result) => {
-                        self.try_cast_ratification_vote(
-                            msg_iteration,
-                            validation_result,
-                        )
-                        .await
+                        if let QuorumType::Valid = validation_result.quorum() {
+                            self.try_cast_ratification_vote(
+                                msg_iteration,
+                                validation_result,
+                            )
+                            .await
+                        }
                     }
                     _ => {
                         // Not supported.

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -120,7 +120,7 @@ impl MsgHandler for RatificationHandler {
                     event = "Cannot collect vote",
                     ?error,
                     from = p.sign_info().signer.to_bs58(),
-                    ?p.vote,
+                    vote = ?p.vote,
                     msg_step = p.get_step(),
                     msg_round = p.header().round,
                 );

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -149,7 +149,7 @@ impl MsgHandler for ValidationHandler {
                     event = "Cannot collect vote",
                     ?error,
                     from = p.sign_info().signer.to_bs58(),
-                    ?p.vote,
+                    vote = ?p.vote,
                     msg_step = p.get_step(),
                     msg_round = p.header().round,
                 );

--- a/node-data/src/ledger/faults.rs
+++ b/node-data/src/ledger/faults.rs
@@ -71,6 +71,8 @@ pub enum InvalidFault {
     PrevHashMismatch,
     #[error("Iteration mismatch")]
     IterationMismatch,
+    #[error("Faults related to emergency iteration")]
+    EmergencyIteration,
     #[error("Round mismatch")]
     RoundMismatch,
     #[error("Invalid Signature {0}")]

--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -512,6 +512,9 @@ pub mod payload {
     }
 
     impl Vote {
+        pub fn is_valid(&self) -> bool {
+            matches!(self, Vote::Valid(_))
+        }
         pub fn size(&self) -> usize {
             const ENUM_BYTE: usize = 1;
 
@@ -654,11 +657,8 @@ pub mod payload {
             })
         }
     }
-    #[derive(Clone, Copy, Debug, Default)]
-    #[cfg_attr(
-        any(feature = "faker", test),
-        derive(fake::Dummy, Eq, PartialEq)
-    )]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    #[cfg_attr(any(feature = "faker", test), derive(fake::Dummy))]
     pub enum QuorumType {
         /// Supermajority of Valid votes
         Valid = 0,


### PR DESCRIPTION
- Don't slash on emergency iterations
- Don't aggregate failing votes on emergency
- Restore iteration at emergency if last_iter was higher (Fix restart at max_iter)
- On emergency cast votes only if they are valid