### PR TITLE
rusk: remove dirty state folders

### DIFF
--- a/rusk/src/bin/args/state.rs
+++ b/rusk/src/bin/args/state.rs
@@ -8,6 +8,7 @@ use super::*;
 
 use std::{env, fs, io};
 
+use rusk::DELETING_VM_FNAME;
 use rusk_recovery_tools::state::{deploy, restore_state, tar};
 use rusk_recovery_tools::Theme;
 use tracing::info;
@@ -42,6 +43,15 @@ pub fn recovery_state(
     }
 
     let state_dir = rusk_profile::get_rusk_state_dir()?;
+
+    let paths = fs::read_dir(&state_dir)?;
+    for dir in paths.flatten() {
+        if dir.path().join(DELETING_VM_FNAME).exists() {
+            info!("{} dirty state {:?}", theme.info("Deleting"), dir.path());
+            fs::remove_dir_all(dir.path())?
+        }
+    }
+
     let state_id_path = rusk_profile::to_rusk_state_id_path(&state_dir);
 
     let _ = rusk_abi::new_vm(&state_dir)?;

--- a/rusk/src/lib/lib.rs
+++ b/rusk/src/lib/lib.rs
@@ -21,5 +21,7 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 #[cfg(feature = "node")]
 pub use node::Rusk;
 
+pub const DELETING_VM_FNAME: &str = ".delete";
+
 #[cfg(feature = "testwallet")]
 mod test_utils;


### PR DESCRIPTION
When a node is restarted during a commit deletion, some folder are dirty.

This lead to rusk-recovery to not be able to load the VM

This PR flags the commit folder for deletion, and remove them (if needed) while restoring the state