### PR TITLE
rusk: refactor rusk builder

### DIFF
--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -92,13 +92,13 @@ criterion = "0.5"
 rustc_tools_util = "0.3"
 
 [features]
-default = ["ephemeral", "recovery-state", "recovery-keys", "prover", "node", "http-wasm"]
-ephemeral = ["dep:rusk-recovery", "dep:tempfile", "recovery-state", "node"]
+default = ["ephemeral", "recovery-state", "recovery-keys", "prover", "chain", "http-wasm"]
+ephemeral = ["dep:rusk-recovery", "dep:tempfile", "recovery-state", "chain"]
 recovery-state = ["rusk-recovery/state", "dep:tempfile"]
 recovery-keys = ["rusk-recovery/keys"]
 prover = ["dep:rusk-prover"]
 testwallet = ["dep:futures"]
-node = ["dep:node", "dep:dusk-consensus", "dep:node-data"]
+chain = ["dep:node", "dep:dusk-consensus", "dep:node-data"]
 http-wasm = []
 
 [[bench]]

--- a/rusk/Makefile
+++ b/rusk/Makefile
@@ -34,7 +34,7 @@ clippy: ## Run clippy
 		-- -D warnings
 	@cargo clippy \
 		--no-default-features \
-		--features node \
+		--features chain \
 		--release \
 		-- -D warnings
 	@cargo check --benches --features testwallet

--- a/rusk/src/bin/config.rs
+++ b/rusk/src/bin/config.rs
@@ -4,15 +4,15 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#[cfg(feature = "node")]
+#[cfg(feature = "chain")]
 pub mod chain;
-#[cfg(feature = "node")]
+#[cfg(feature = "chain")]
 pub mod databroker;
-#[cfg(feature = "node")]
+#[cfg(feature = "chain")]
 pub mod kadcast;
-#[cfg(feature = "node")]
+#[cfg(feature = "chain")]
 pub mod mempool;
-#[cfg(feature = "node")]
+#[cfg(feature = "chain")]
 pub mod telemetry;
 
 pub mod http;
@@ -20,19 +20,15 @@ pub mod http;
 use std::env;
 use std::str::FromStr;
 
+#[cfg(feature = "chain")]
+use self::{
+    chain::ChainConfig, databroker::DataBrokerConfig, kadcast::KadcastConfig,
+    mempool::MempoolConfig, telemetry::TelemetryConfig,
+};
+
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "node")]
-use self::chain::ChainConfig;
-#[cfg(feature = "node")]
-use self::databroker::DataBrokerConfig;
-#[cfg(feature = "node")]
-use self::kadcast::KadcastConfig;
-#[cfg(feature = "node")]
-use self::telemetry::TelemetryConfig;
 use crate::args::Args;
-#[cfg(feature = "node")]
-use crate::config::mempool::MempoolConfig;
 
 use self::http::HttpConfig;
 
@@ -42,26 +38,26 @@ pub(crate) struct Config {
     log_type: Option<String>,
     log_filter: Option<String>,
 
-    #[cfg(feature = "node")]
+    #[cfg(feature = "chain")]
     #[serde(default = "DataBrokerConfig::default")]
     pub(crate) databroker: DataBrokerConfig,
 
-    #[cfg(feature = "node")]
+    #[cfg(feature = "chain")]
     #[serde(default = "KadcastConfig::default")]
     pub(crate) kadcast: KadcastConfig,
 
-    #[cfg(feature = "node")]
+    #[cfg(feature = "chain")]
     #[serde(default = "ChainConfig::default")]
     pub(crate) chain: ChainConfig,
 
     #[serde(default = "HttpConfig::default")]
     pub(crate) http: HttpConfig,
 
-    #[cfg(feature = "node")]
+    #[cfg(feature = "chain")]
     #[serde(default = "TelemetryConfig::default")]
     pub(crate) telemetry: TelemetryConfig,
 
-    #[cfg(feature = "node")]
+    #[cfg(feature = "chain")]
     #[serde(default = "MempoolConfig::default")]
     pub(crate) mempool: MempoolConfig,
 }
@@ -104,7 +100,7 @@ impl From<&Args> for Config {
 
         rusk_config.http.merge(args);
 
-        #[cfg(feature = "node")]
+        #[cfg(feature = "chain")]
         {
             rusk_config.kadcast.merge(args);
             rusk_config.chain.merge(args);

--- a/rusk/src/bin/config/kadcast.rs
+++ b/rusk/src/bin/config/kadcast.rs
@@ -33,8 +33,4 @@ impl KadcastConfig {
             self.0.kadcast_id = Some(network_id)
         };
     }
-
-    pub fn chain_id(&self) -> u8 {
-        self.0.kadcast_id.unwrap_or_default()
-    }
 }

--- a/rusk/src/lib/builder.rs
+++ b/rusk/src/lib/builder.rs
@@ -4,12 +4,12 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#[cfg(feature = "node")]
+#[cfg(feature = "chain")]
 mod node;
-#[cfg(feature = "node")]
+#[cfg(feature = "chain")]
 pub use node::RuskNodeBuilder as Builder;
 
-#[cfg(not(feature = "node"))]
+#[cfg(not(feature = "chain"))]
 mod http_only;
-#[cfg(not(feature = "node"))]
+#[cfg(not(feature = "chain"))]
 pub use http_only::RuskHttpBuilder as Builder;

--- a/rusk/src/lib/builder.rs
+++ b/rusk/src/lib/builder.rs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+#[cfg(feature = "node")]
+mod node;
+#[cfg(feature = "node")]
+pub use node::RuskNodeBuilder as Builder;
+
+#[cfg(not(feature = "node"))]
+mod http_only;
+#[cfg(not(feature = "node"))]
+pub use http_only::RuskHttpBuilder as Builder;

--- a/rusk/src/lib/builder/http_only.rs
+++ b/rusk/src/lib/builder/http_only.rs
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use tokio::sync::broadcast;
+use tracing::info;
+
+use crate::http::{DataSources, HttpServer, HttpServerConfig};
+
+#[derive(Default)]
+pub struct RuskHttpBuilder {
+    http: Option<HttpServerConfig>,
+}
+
+impl RuskHttpBuilder {
+    pub fn with_http(mut self, http: HttpServerConfig) -> Self {
+        self.http = Some(http);
+        self
+    }
+
+    pub async fn build_and_run(self) -> anyhow::Result<()> {
+        let (_rues_sender, rues_receiver) = broadcast::channel(1);
+
+        let mut _ws_server = None;
+        if let Some(http) = self.http {
+            info!("Configuring HTTP");
+
+            #[allow(unused_mut)]
+            let mut handler = DataSources::default();
+
+            #[cfg(feature = "prover")]
+            handler.sources.push(Box::new(rusk_prover::LocalProver));
+
+            let cert_and_key = match (http.cert, http.key) {
+                (Some(cert), Some(key)) => Some((cert, key)),
+                _ => None,
+            };
+
+            _ws_server = Some(
+                HttpServer::bind(
+                    handler,
+                    rues_receiver,
+                    http.ws_event_channel_cap,
+                    http.address,
+                    cert_and_key,
+                )
+                .await?,
+            );
+        }
+
+        if let Some(s) = _ws_server {
+            s.wait().await?;
+        }
+
+        Ok(())
+    }
+}

--- a/rusk/src/lib/builder/node.rs
+++ b/rusk/src/lib/builder/node.rs
@@ -1,0 +1,233 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kadcast::config::Config as KadcastConfig;
+use node::chain::ChainSrv;
+use node::database::rocksdb;
+use node::database::{DatabaseOptions, DB};
+use node::databroker::conf::Params as BrokerParam;
+use node::databroker::DataBrokerSrv;
+use node::mempool::conf::Params as MempoolParam;
+use node::mempool::MempoolSrv;
+use node::network::Kadcast;
+use node::telemetry::TelemetrySrv;
+use node::Node;
+
+use tokio::sync::{broadcast, mpsc};
+use tracing::info;
+
+use crate::http::{DataSources, HttpServer, HttpServerConfig};
+use crate::node::{ChainEventStreamer, RuskNode, Services};
+use crate::Rusk;
+
+#[derive(Default)]
+pub struct RuskNodeBuilder {
+    consensus_keys_path: String,
+    databroker: BrokerParam,
+    kadcast: KadcastConfig,
+    mempool: MempoolParam,
+    telemetry_address: Option<String>,
+    db_path: PathBuf,
+    db_options: DatabaseOptions,
+    max_chain_queue_size: usize,
+
+    generation_timeout: Option<Duration>,
+    gas_per_deploy_byte: Option<u64>,
+    min_deployment_gas_price: Option<u64>,
+    block_gas_limit: u64,
+    feeder_call_gas: u64,
+    state_dir: PathBuf,
+
+    http: Option<HttpServerConfig>,
+}
+
+impl RuskNodeBuilder {
+    pub fn with_consensus_keys(mut self, consensus_keys_path: String) -> Self {
+        self.consensus_keys_path = consensus_keys_path;
+        self
+    }
+
+    pub fn with_databroker<P: Into<BrokerParam>>(
+        mut self,
+        databroker: P,
+    ) -> Self {
+        self.databroker = databroker.into();
+        self
+    }
+
+    pub fn with_kadcast<K: Into<kadcast::config::Config>>(
+        mut self,
+        kadcast: K,
+    ) -> Self {
+        self.kadcast = kadcast.into();
+        self
+    }
+
+    pub fn with_db_path(mut self, db_path: PathBuf) -> Self {
+        self.db_path = db_path;
+        self
+    }
+
+    pub fn with_db_options(mut self, db_options: DatabaseOptions) -> Self {
+        self.db_options = db_options;
+        self
+    }
+
+    pub fn with_telemetry(
+        mut self,
+        telemetry_listen_add: Option<String>,
+    ) -> Self {
+        self.telemetry_address = telemetry_listen_add;
+        self
+    }
+
+    pub fn with_mempool(mut self, conf: MempoolParam) -> Self {
+        self.mempool = conf;
+        self
+    }
+
+    pub fn with_chain_queue_size(mut self, max_queue_size: usize) -> Self {
+        self.max_chain_queue_size = max_queue_size;
+        self
+    }
+
+    //new
+    pub fn with_generation_timeout(
+        mut self,
+        generation_timeout: Option<Duration>,
+    ) -> Self {
+        self.generation_timeout = generation_timeout;
+        self
+    }
+    pub fn with_gas_per_deploy_byte(
+        mut self,
+        gas_per_deploy_byte: Option<u64>,
+    ) -> Self {
+        self.gas_per_deploy_byte = gas_per_deploy_byte;
+        self
+    }
+    pub fn with_min_deployment_gas_price(
+        mut self,
+        min_deployment_gas_price: Option<u64>,
+    ) -> Self {
+        self.min_deployment_gas_price = min_deployment_gas_price;
+        self
+    }
+
+    pub fn with_block_gas_limit(mut self, block_gas_limit: u64) -> Self {
+        self.block_gas_limit = block_gas_limit;
+        self
+    }
+
+    pub fn with_feeder_call_gas(mut self, feeder_call_gas: u64) -> Self {
+        self.feeder_call_gas = feeder_call_gas;
+        self
+    }
+
+    pub fn with_state_dir(mut self, state_dir: PathBuf) -> Self {
+        self.state_dir = state_dir;
+        self
+    }
+
+    pub fn with_http(mut self, http: HttpServerConfig) -> Self {
+        self.http = Some(http);
+        self
+    }
+
+    pub async fn build_and_run(self) -> anyhow::Result<()> {
+        let channel_cap = self
+            .http
+            .as_ref()
+            .map(|h| h.ws_event_channel_cap)
+            .unwrap_or(1);
+        let (rues_sender, rues_receiver) = broadcast::channel(channel_cap);
+
+        let chain_id = self.kadcast.kadcast_id.unwrap_or_default();
+
+        let rusk = Rusk::new(
+            self.state_dir,
+            chain_id,
+            self.generation_timeout,
+            self.gas_per_deploy_byte,
+            self.min_deployment_gas_price,
+            self.block_gas_limit,
+            self.feeder_call_gas,
+            rues_sender.clone(),
+        )
+        .map_err(|e| anyhow::anyhow!("Cannot instantiate VM {e}"))?;
+        info!("Rusk VM loaded");
+
+        let node = {
+            let db = rocksdb::Backend::create_or_open(
+                self.db_path.clone(),
+                self.db_options.clone(),
+            );
+            let net = Kadcast::new(self.kadcast.clone())?;
+            RuskNode::new(Node::new(net, db, rusk.clone()))
+        };
+
+        let (sender, node_receiver) = mpsc::channel(1000);
+        let mut service_list: Vec<Box<Services>> = vec![
+            Box::new(MempoolSrv::new(self.mempool, sender.clone())),
+            Box::new(ChainSrv::new(
+                self.consensus_keys_path,
+                self.max_chain_queue_size,
+                sender.clone(),
+            )),
+            Box::new(DataBrokerSrv::new(self.databroker)),
+            Box::new(TelemetrySrv::new(self.telemetry_address)),
+        ];
+
+        let mut _ws_server = None;
+        if let Some(http) = self.http {
+            info!("Configuring HTTP");
+
+            service_list.push(Box::new(ChainEventStreamer {
+                node_receiver,
+                rues_sender,
+            }));
+
+            let mut handler = DataSources::default();
+            handler.sources.push(Box::new(rusk.clone()));
+            handler.sources.push(Box::new(node.clone()));
+
+            #[cfg(feature = "prover")]
+            handler.sources.push(Box::new(rusk_prover::LocalProver));
+
+            let cert_and_key = match (http.cert, http.key) {
+                (Some(cert), Some(key)) => Some((cert, key)),
+                _ => None,
+            };
+
+            _ws_server = Some(
+                HttpServer::bind(
+                    handler,
+                    rues_receiver,
+                    http.ws_event_channel_cap,
+                    http.address,
+                    cert_and_key,
+                )
+                .await?,
+            );
+        }
+
+        #[cfg(feature = "chain")]
+        {
+            node.inner().initialize(&mut service_list).await?;
+            node.inner().spawn_all(service_list).await?;
+        }
+
+        #[cfg(not(feature = "chain"))]
+        if let Some(s) = _ws_server {
+            s.wait().await?;
+        }
+
+        Ok(())
+    }
+}

--- a/rusk/src/lib/error.rs
+++ b/rusk/src/lib/error.rs
@@ -50,7 +50,7 @@ pub enum Error {
     /// Bad dusk spent in coinbase (got, expected).
     CoinbaseDuskSpent(Dusk, Dusk),
     /// Failed to produce proper state
-    #[cfg(feature = "node")]
+    #[cfg(feature = "chain")]
     InconsistentState(dusk_consensus::operations::VerificationOutput),
     /// Other
     Other(Box<dyn std::error::Error>),
@@ -177,7 +177,7 @@ impl fmt::Display for Error {
             Error::InvalidCircuitArguments(inputs_len, outputs_len) => {
                 write!(f,"Expected: 0 < (inputs: {inputs_len}) < 5, 0 ≤ (outputs: {outputs_len}) < 3")
             }
-            #[cfg(feature = "node")]
+            #[cfg(feature = "chain")]
             Error::InconsistentState(verification_output) => {
                 write!(
                     f,

--- a/rusk/src/lib/http/event.rs
+++ b/rusk/src/lib/http/event.rs
@@ -972,7 +972,7 @@ impl RuesEvent {
     }
 }
 
-#[cfg(feature = "node")]
+#[cfg(feature = "chain")]
 impl From<crate::node::ContractTxEvent> for RuesEvent {
     fn from(tx_event: crate::node::ContractTxEvent) -> Self {
         let mut headers = serde_json::Map::new();
@@ -992,7 +992,7 @@ impl From<crate::node::ContractTxEvent> for RuesEvent {
     }
 }
 
-#[cfg(feature = "node")]
+#[cfg(feature = "chain")]
 impl From<node_data::events::Event> for RuesEvent {
     fn from(value: node_data::events::Event) -> Self {
         let data = value.data.map_or(DataType::None, DataType::Json);

--- a/rusk/src/lib/lib.rs
+++ b/rusk/src/lib/lib.rs
@@ -11,12 +11,15 @@ pub mod gen_id;
 pub mod http;
 #[cfg(feature = "node")]
 pub mod node;
+
+mod builder;
 pub mod verifier;
 mod version;
 
 pub use crate::error::Error;
 pub use version::{VERSION, VERSION_BUILD};
 
+pub use builder::Builder;
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 #[cfg(feature = "node")]
 pub use node::Rusk;

--- a/rusk/src/lib/lib.rs
+++ b/rusk/src/lib/lib.rs
@@ -9,7 +9,7 @@
 mod error;
 pub mod gen_id;
 pub mod http;
-#[cfg(feature = "node")]
+#[cfg(feature = "chain")]
 pub mod node;
 
 mod builder;
@@ -21,7 +21,8 @@ pub use version::{VERSION, VERSION_BUILD};
 
 pub use builder::Builder;
 pub type Result<T, E = Error> = core::result::Result<T, E>;
-#[cfg(feature = "node")]
+
+#[cfg(feature = "chain")]
 pub use node::Rusk;
 
 pub const DELETING_VM_FNAME: &str = ".delete";

--- a/rusk/src/lib/node.rs
+++ b/rusk/src/lib/node.rs
@@ -12,25 +12,17 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use events::ChainEventStreamer;
 use execution_core::{dusk, Dusk};
-use kadcast::config::Config as KadcastConfig;
-use node::chain::ChainSrv;
 use node::database::rocksdb::{self, Backend};
-use node::database::{DatabaseOptions, DB};
-use node::databroker::conf::Params as BrokerParam;
-use node::databroker::DataBrokerSrv;
-use node::mempool::conf::Params as MempoolParam;
-use node::mempool::MempoolSrv;
 use node::network::Kadcast;
-use node::telemetry::TelemetrySrv;
-use node::{LongLivedService, Node};
+use node::LongLivedService;
 use parking_lot::RwLock;
 use rusk_abi::VM;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::broadcast;
 
-use crate::http::{HandleRequest, RuesEvent};
+use crate::http::RuesEvent;
 
+pub(crate) use events::ChainEventStreamer;
 pub use vm::ContractTxEvent;
 
 #[derive(Debug, Clone, Copy)]
@@ -53,153 +45,23 @@ pub struct Rusk {
     pub(crate) event_sender: broadcast::Sender<RuesEvent>,
 }
 
-type Services = dyn LongLivedService<Kadcast<255>, rocksdb::Backend, Rusk>;
+pub(crate) type Services =
+    dyn LongLivedService<Kadcast<255>, rocksdb::Backend, Rusk>;
 
+#[derive(Clone)]
 pub struct RuskNode {
     inner: node::Node<Kadcast<255>, Backend, Rusk>,
 }
 
-#[derive(Clone)]
-pub struct RuskNodeBuilder {
-    consensus_keys_path: String,
-    databroker: BrokerParam,
-    kadcast: KadcastConfig,
-    mempool: MempoolParam,
-    telemetry_address: Option<String>,
-    db_path: PathBuf,
-    db_options: DatabaseOptions,
-    max_chain_queue_size: usize,
-
-    node: Option<node::Node<Kadcast<255>, Backend, Rusk>>,
-    rusk: Rusk,
-    rues_sender: Option<broadcast::Sender<RuesEvent>>,
-}
-
-impl RuskNodeBuilder {
-    pub fn with_consensus_keys(mut self, consensus_keys_path: String) -> Self {
-        self.consensus_keys_path = consensus_keys_path;
-        self
-    }
-
-    pub fn with_databroker<P: Into<BrokerParam>>(
-        mut self,
-        databroker: P,
-    ) -> Self {
-        self.databroker = databroker.into();
-        self
-    }
-
-    pub fn with_kadcast<K: Into<kadcast::config::Config>>(
-        mut self,
-        kadcast: K,
-    ) -> Self {
-        self.kadcast = kadcast.into();
-        self
-    }
-
-    pub fn with_db_path(mut self, db_path: PathBuf) -> Self {
-        self.db_path = db_path;
-        self
-    }
-
-    pub fn with_db_options(mut self, db_options: DatabaseOptions) -> Self {
-        self.db_options = db_options;
-        self
-    }
-
-    pub fn with_rues(
-        mut self,
-        rues_sender: broadcast::Sender<RuesEvent>,
-    ) -> Self {
-        self.rues_sender = Some(rues_sender);
-        self
-    }
-
-    pub fn with_telemetry(
-        mut self,
-        telemetry_listen_add: Option<String>,
-    ) -> Self {
-        self.telemetry_address = telemetry_listen_add;
-        self
-    }
-
-    pub fn with_mempool(mut self, conf: MempoolParam) -> Self {
-        self.mempool = conf;
-        self
-    }
-
-    pub fn with_chain_queue_size(mut self, max_queue_size: usize) -> Self {
-        self.max_chain_queue_size = max_queue_size;
-        self
-    }
-
-    pub fn new(rusk: Rusk) -> Self {
-        Self {
-            consensus_keys_path: Default::default(),
-            databroker: Default::default(),
-            kadcast: Default::default(),
-            mempool: Default::default(),
-            telemetry_address: None,
-            db_path: Default::default(),
-            db_options: Default::default(),
-            max_chain_queue_size: 0,
-            node: None,
-            rusk,
-            rues_sender: None,
-        }
-    }
-
-    pub fn build_data_sources(
-        &mut self,
-    ) -> anyhow::Result<Vec<Box<dyn HandleRequest>>> {
-        let sources: Vec<Box<dyn HandleRequest>> = vec![
-            Box::new(self.rusk.clone()),
-            Box::new(self.get_or_create_node()?),
-        ];
-        Ok(sources)
-    }
-
-    fn get_or_create_node(&mut self) -> anyhow::Result<RuskNode> {
-        if self.node.is_none() {
-            let db = rocksdb::Backend::create_or_open(
-                self.db_path.clone(),
-                self.db_options.clone(),
-            );
-            let net = Kadcast::new(self.kadcast.clone())?;
-            let node = Node::new(net, db, self.rusk.clone());
-            self.node = Some(node)
-        }
-        Ok(RuskNode {
-            inner: self.node.clone().expect("Node to be initialized"),
-        })
-    }
-
-    pub async fn build_and_run(mut self) -> anyhow::Result<()> {
-        let node = self.get_or_create_node()?;
-        let (sender, node_receiver) = mpsc::channel(1000);
-        let mut service_list: Vec<Box<Services>> = vec![
-            Box::new(MempoolSrv::new(self.mempool, sender.clone())),
-            Box::new(ChainSrv::new(
-                self.consensus_keys_path,
-                self.max_chain_queue_size,
-                sender.clone(),
-            )),
-            Box::new(DataBrokerSrv::new(self.databroker)),
-            Box::new(TelemetrySrv::new(self.telemetry_address)),
-        ];
-        if let Some(rues_sender) = self.rues_sender {
-            service_list.push(Box::new(ChainEventStreamer {
-                rues_sender,
-                node_receiver,
-            }))
-        }
-        node.inner.initialize(&mut service_list).await?;
-        node.inner.spawn_all(service_list).await?;
-        Ok(())
-    }
-}
-
 impl RuskNode {
+    pub fn new(inner: node::Node<Kadcast<255>, Backend, Rusk>) -> Self {
+        Self { inner }
+    }
+
+    pub fn inner(&self) -> &node::Node<Kadcast<255>, Backend, Rusk> {
+        &self.inner
+    }
+
     pub fn db(&self) -> Arc<tokio::sync::RwLock<Backend>> {
         self.inner.database() as Arc<tokio::sync::RwLock<Backend>>
     }

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -68,6 +68,8 @@ impl Rusk {
         event_sender: broadcast::Sender<RuesEvent>,
     ) -> Result<Self> {
         let dir = dir.as_ref();
+        info!("Using state from {dir:?}");
+
         let commit_id_path = to_rusk_state_id_path(dir);
 
         let base_commit_bytes = fs::read(commit_id_path)?;


### PR DESCRIPTION
This PR aims to embed the HTTP server instantiation inside the rusk builder.

This is required in order to test the whole "binary" inside the rust test suite, and without rely on external testbed