### PR TITLE
node: use external timestamp to generate genesis_block

### DIFF
--- a/node/src/chain/genesis.rs
+++ b/node/src/chain/genesis.rs
@@ -7,11 +7,10 @@
 use node_data::ledger::{Block, Header};
 
 /// Generates the genesis state for the chain per specified network type
-pub(crate) fn generate_block(state_hash: [u8; 32]) -> Block {
+pub(crate) fn generate_block(state_hash: [u8; 32], timestamp: u64) -> Block {
     Block::new(
         Header {
-            // Tue Sep 10 2024 20:00:00 GMT+0000
-            timestamp: 1725998400,
+            timestamp,
             state_hash,
             ..Default::default()
         },

--- a/rusk/src/bin/config/chain.rs
+++ b/rusk/src/bin/config/chain.rs
@@ -4,12 +4,18 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::{path::PathBuf, time::Duration};
+use std::{
+    path::PathBuf,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use node::database::DatabaseOptions;
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_BLOCK_GAS_LIMIT: u64 = 5 * 1_000_000_000;
+
+// Tue Sep 10 2024 20:00:00 GMT+0000
+pub const DEFAULT_GENESIS_TIMESTAMP: u64 = 1725998400;
 
 use crate::args::Args;
 
@@ -29,6 +35,9 @@ pub(crate) struct ChainConfig {
     gas_per_deploy_byte: Option<u64>,
     min_deployment_gas_price: Option<u64>,
     block_gas_limit: Option<u64>,
+
+    #[serde(with = "humantime_serde")]
+    genesis_timestamp: Option<SystemTime>,
 }
 
 impl ChainConfig {
@@ -90,5 +99,15 @@ impl ChainConfig {
 
     pub(crate) fn block_gas_limit(&self) -> u64 {
         self.block_gas_limit.unwrap_or(DEFAULT_BLOCK_GAS_LIMIT)
+    }
+
+    pub(crate) fn genesis_timestamp(&self) -> u64 {
+        self.genesis_timestamp
+            .map(|t| {
+                t.duration_since(UNIX_EPOCH)
+                    .map(|n| n.as_secs())
+                    .expect("This is heavy.")
+            })
+            .unwrap_or(DEFAULT_GENESIS_TIMESTAMP)
     }
 }

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -71,6 +71,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_databroker(config.databroker)
             .with_telemetry(config.telemetry.listen_addr())
             .with_chain_queue_size(config.chain.max_queue_size())
+            .with_genesis_timestamp(config.chain.genesis_timestamp())
             .with_mempool(config.mempool.into())
             .with_state_dir(state_dir)
             .with_generation_timeout(config.chain.generation_timeout())


### PR DESCRIPTION
Resolves #2431 

This is a best effort PR

Proper solution would be to move the chain settings from rusk.toml to rusk.settings

Those settings should contain:
- Genesis Timestamp (default to UNIX_EPOCH for tests)
- Genesis Seed (default to [0u8;48] for tests
- ChainId (default to 0 for tests)
- Genesis state root (default ask to VM)

See #2430 