### PR TITLE
Facilitate voting in emergency mode

### DIFF
--- a/consensus/src/aggregator.rs
+++ b/consensus/src/aggregator.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::config::EMERGENCY_MODE_ITERATION_THRESHOLD;
+use crate::config::is_emergency_iter;
 use crate::user::cluster::Cluster;
 use crate::user::committee::Committee;
 use dusk_bytes::Serializable;
@@ -85,7 +85,7 @@ impl<V: StepVote> Aggregator<V> {
 
         let iter = v.header().iteration;
 
-        let emergency = iter >= EMERGENCY_MODE_ITERATION_THRESHOLD;
+        let emergency = is_emergency_iter(iter);
 
         let msg_step = v.get_step();
         let vote = v.vote();

--- a/consensus/src/commons.rs
+++ b/consensus/src/commons.rs
@@ -84,7 +84,7 @@ impl RoundUpdate {
 
 #[async_trait::async_trait]
 pub trait Database: Send + Sync {
-    fn store_candidate_block(&mut self, b: Block);
+    async fn store_candidate_block(&mut self, b: Block);
     async fn get_last_iter(&self) -> (Hash, u8);
     async fn store_last_iter(&mut self, data: (Hash, u8));
 }

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -61,6 +61,11 @@ pub fn ratification_extra() -> usize {
     RATIFICATION_COMMITTEE_CREDITS - ratification_quorum()
 }
 
+/// Returns whether the current iteration is an emergency iteration
+pub fn is_emergency_iter(iter: u8) -> bool {
+    iter >= EMERGENCY_MODE_ITERATION_THRESHOLD
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -177,7 +177,8 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
                     if open_consensus_mode {
                         error!("Timeout detected during last step running. This should never happen")
                     } else {
-                        return self.process_timeout_event(phase).await;
+                        self.process_timeout_event(phase).await;
+                        return Ok(Message::empty());
                     }
                 }
             }
@@ -413,7 +414,7 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
     async fn process_timeout_event<C: MsgHandler>(
         &mut self,
         phase: Arc<Mutex<C>>,
-    ) -> Result<Message, ConsensusError> {
+    ) {
         self.iter_ctx.on_timeout_event(self.step_name());
 
         if let Some(msg) = phase
@@ -423,8 +424,6 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
         {
             self.outbound.try_send(msg.clone());
         }
-
-        Ok(Message::empty())
     }
 
     /// Handles all messages stored in future_msgs queue that belongs to the

--- a/consensus/src/msg_handler.rs
+++ b/consensus/src/msg_handler.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::commons::RoundUpdate;
-use crate::config::EMERGENCY_MODE_ITERATION_THRESHOLD;
+use crate::config::is_emergency_iter;
 use crate::errors::ConsensusError;
 use crate::iteration_ctx::RoundCommittees;
 use crate::proposal;
@@ -58,7 +58,7 @@ pub trait MsgHandler {
         let msg_tip = msg.header.prev_block_hash;
         match msg.compare(ru.round, current_iteration, step) {
             Status::Past => {
-                if msg.header.iteration >= EMERGENCY_MODE_ITERATION_THRESHOLD {
+                if is_emergency_iter(msg.header.iteration) {
                     Self::verify_message(
                         msg,
                         ru,
@@ -181,5 +181,10 @@ pub trait MsgHandler {
     ) -> Result<HandleMsgOutput, ConsensusError>;
 
     /// handle_timeout allows each Phase to handle a timeout event.
-    fn handle_timeout(&self) -> Result<HandleMsgOutput, ConsensusError>;
+    /// Returned Message here is sent to outboud queue.
+    fn handle_timeout(
+        &self,
+        ru: &RoundUpdate,
+        curr_iteration: u8,
+    ) -> Option<Message>;
 }

--- a/consensus/src/proposal/block_generator.rs
+++ b/consensus/src/proposal/block_generator.rs
@@ -36,7 +36,7 @@ impl<T: Operations> Generator<T> {
         failed_iterations: IterationsInfo,
     ) -> Result<Message, crate::errors::OperationError> {
         // Sign seed
-        let seed = ru
+        let seed: [u8; 48] = ru
             .secret_key
             .sign_multisig(ru.pubkey_bls.inner(), &ru.seed().inner()[..])
             .to_bytes();

--- a/consensus/src/proposal/handler.rs
+++ b/consensus/src/proposal/handler.rs
@@ -58,7 +58,8 @@ impl<D: Database> MsgHandler for ProposalHandler<D> {
         self.db
             .lock()
             .await
-            .store_candidate_block(p.candidate.clone());
+            .store_candidate_block(p.candidate.clone())
+            .await;
 
         Ok(HandleMsgOutput::Ready(msg))
     }
@@ -82,7 +83,8 @@ impl<D: Database> MsgHandler for ProposalHandler<D> {
         self.db
             .lock()
             .await
-            .store_candidate_block(p.candidate.clone());
+            .store_candidate_block(p.candidate.clone())
+            .await;
 
         Ok(HandleMsgOutput::Pending)
     }

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -188,8 +188,12 @@ impl MsgHandler for RatificationHandler {
     }
 
     /// Handle of an event of step execution timeout
-    fn handle_timeout(&self) -> Result<HandleMsgOutput, ConsensusError> {
-        Ok(HandleMsgOutput::Ready(Message::empty()))
+    fn handle_timeout(
+        &self,
+        _ru: &RoundUpdate,
+        _curr_iteration: u8,
+    ) -> Option<Message> {
+        None
     }
 }
 

--- a/consensus/src/ratification/step.rs
+++ b/consensus/src/ratification/step.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::commons::{Database, RoundUpdate};
-use crate::config::EMERGENCY_MODE_ITERATION_THRESHOLD;
+use crate::config::is_emergency_iter;
 use crate::errors::ConsensusError;
 use crate::execution_ctx::ExecutionCtx;
 use crate::operations::Operations;
@@ -37,9 +37,9 @@ impl RatificationStep {
 
         let msg = Message::from(ratification);
 
-        if result.quorum() == QuorumType::Valid
-            || iteration < EMERGENCY_MODE_ITERATION_THRESHOLD
-        {
+        let is_emergency = is_emergency_iter(iteration);
+
+        if result.quorum() == QuorumType::Valid || !is_emergency {
             // Publish ratification vote
             info!(event = "send_vote", validation_bitset = result.sv().bitset);
 

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -6,6 +6,7 @@
 
 use crate::aggregator::{Aggregator, StepVote};
 use crate::commons::RoundUpdate;
+use crate::config::is_emergency_iter;
 use crate::errors::ConsensusError;
 use crate::msg_handler::{HandleMsgOutput, MsgHandler};
 use crate::step_votes_reg::SafeAttestationInfoRegistry;
@@ -233,7 +234,20 @@ impl MsgHandler for ValidationHandler {
     }
 
     /// Handles of an event of step execution timeout
-    fn handle_timeout(&self) -> Result<HandleMsgOutput, ConsensusError> {
-        Ok(HandleMsgOutput::Ready(Message::empty()))
+    fn handle_timeout(
+        &self,
+        _ru: &RoundUpdate,
+        curr_iteration: u8,
+    ) -> Option<Message> {
+        if is_emergency_iter(curr_iteration) {
+            // While we are in Emergency mode but still the candidate is missing
+            // then we request it
+
+            // TODO: Request ValidationResult by prev_block_hash, iteration
+            // lockup key TODO: Should we also request the candidate
+            // block, if it's still missing?
+        }
+
+        None
     }
 }

--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -1145,7 +1145,7 @@ pub mod payload {
         }
 
         pub fn clone_with_hop_decrement(&self) -> Option<Self> {
-            if self.hops_limit == 1 {
+            if self.hops_limit <= 1 {
                 return None;
             }
             let mut req = self.clone();

--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -1063,7 +1063,12 @@ pub mod payload {
                         inv.add_candidate_from_hash(Self::read_bytes(r)?);
                     }
                     InvType::CandidateFromIteration => {
-                        inv.add_candidate_from_hash(Self::read_bytes(r)?);
+                        let prev_block_hash = Self::read_bytes(r)?;
+                        let iteration = Self::read_u8(r)?;
+                        inv.add_candidate_from_iteration(
+                            prev_block_hash,
+                            iteration,
+                        );
                     }
                 }
             }

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -206,9 +206,14 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
                         };
                     }
 
-                    if let Err(e) = network.read().await.broadcast(&msg).await {
-                        warn!("Unable to re-route message {e}");
+                    if let Payload::GetResource(res) = &msg.payload {
+                        if let Err(e) = network.read().await.flood_request(res.get_inv(), None, 16).await {
+                            warn!("Unable to re-route message {e}");
+                        }
+                    } else if let Err(e) = network.read().await.broadcast(&msg).await {
+                            warn!("Unable to broadcast message {e}");
                     }
+
                 },
                  // Handles heartbeat event
                 _ = sleep_until(heartbeat) => {

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -200,18 +200,13 @@ impl<DB: database::DB> CandidateDB<DB> {
 
 #[async_trait]
 impl<DB: database::DB> dusk_consensus::commons::Database for CandidateDB<DB> {
-    fn store_candidate_block(&mut self, b: Block) {
-        tracing::trace!("store candidate block: {:?}", b);
-        match self.db.try_read() {
-            Ok(db) => {
-                if let Err(e) = db.update(|t| t.store_candidate_block(b)) {
-                    warn!("Unable to store candidate block: {e}");
-                };
-            }
-            Err(e) => {
-                warn!("Cannot acquire lock to store candidate block: {e}");
-            }
-        }
+    async fn store_candidate_block(&mut self, b: Block) {
+        tracing::debug!("store candidate block: {:?}", b);
+        let _ = self
+            .db
+            .read()
+            .await
+            .update(|txn| txn.store_candidate_block(b));
     }
     async fn get_last_iter(&self) -> (Hash, u8) {
         let data = self

--- a/node/src/chain/fsm.rs
+++ b/node/src/chain/fsm.rs
@@ -725,7 +725,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> InSyncImpl<DB, VM, N> {
         let mut inv = Inv::new(1);
         inv.add_block_from_height(height);
         let this_peer = *network.read().await.public_addr();
-        let req = GetResource::new(inv, this_peer, u64::MAX, 1);
+        let req = GetResource::new(inv, Some(this_peer), u64::MAX, 1);
         debug!(event = "request block by height", ?req, ?peer_addr);
 
         if let Err(err) = network

--- a/node/src/chain/header_validation.rs
+++ b/node/src/chain/header_validation.rs
@@ -8,8 +8,7 @@ use crate::database;
 use crate::database::Ledger;
 use dusk_bytes::Serializable;
 use dusk_consensus::config::{
-    EMERGENCY_MODE_ITERATION_THRESHOLD, MINIMUM_BLOCK_TIME,
-    RELAX_ITERATION_THRESHOLD,
+    is_emergency_iter, MINIMUM_BLOCK_TIME, RELAX_ITERATION_THRESHOLD,
 };
 use dusk_consensus::errors::{
     AttestationError, FailedIterationError, HeaderError,
@@ -364,7 +363,7 @@ pub async fn verify_faults<DB: database::DB>(
 ) -> Result<(), InvalidFault> {
     for f in faults {
         let fault_header = f.validate(current_height)?;
-        if fault_header.iteration >= EMERGENCY_MODE_ITERATION_THRESHOLD {
+        if is_emergency_iter(fault_header.iteration) {
             return Err(InvalidFault::EmergencyIteration);
         }
         db.read()

--- a/node/src/database.rs
+++ b/node/src/database.rs
@@ -109,6 +109,14 @@ pub trait Candidate {
         &self,
         hash: &[u8],
     ) -> Result<Option<ledger::Block>>;
+
+    /// Fetches a candidate block by lookup key (prev_block_hash, iteration).
+    fn fetch_candidate_block_by_iteration(
+        &self,
+        prev_block_hash: [u8; 32],
+        iteration: u8,
+    ) -> Result<Option<ledger::Block>>;
+
     fn clear_candidates(&self) -> Result<()>;
 
     fn delete<F>(&self, closure: F) -> Result<()>

--- a/node/src/database/rocksdb.rs
+++ b/node/src/database/rocksdb.rs
@@ -211,6 +211,10 @@ impl DB for Backend {
                 CF_CANDIDATES_HEIGHT,
                 blocks_cf_opts.clone(),
             ),
+            ColumnFamilyDescriptor::new(
+                CF_CANDIDATES_ITERATION,
+                blocks_cf_opts.clone(),
+            ),
             ColumnFamilyDescriptor::new(CF_METADATA, blocks_cf_opts.clone()),
             ColumnFamilyDescriptor::new(CF_MEMPOOL, mp_opts.clone()),
             ColumnFamilyDescriptor::new(CF_MEMPOOL_NULLIFIERS, mp_opts.clone()),

--- a/node/src/databroker.rs
+++ b/node/src/databroker.rs
@@ -12,14 +12,13 @@ use crate::{LongLivedService, Message};
 use anyhow::{anyhow, Result};
 use std::cmp::min;
 
-use node_data::message::payload::{GetResource, InvParam, InvType};
+use node_data::message::payload::{self, GetResource, InvParam, InvType};
+use node_data::message::{AsyncQueue, Payload, Topics};
 use smallvec::SmallVec;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use node_data::message::{payload, AsyncQueue, ConsensusHeader, SignInfo};
-use node_data::message::{Payload, Topics};
 use tokio::sync::{RwLock, Semaphore};
 use tracing::{debug, info, warn};
 
@@ -509,20 +508,7 @@ impl DataBrokerSrv {
                             .ok()
                             .flatten()
                             .map(|candidate| {
-                                let round = candidate.header().height;
-                                let iteration = candidate.header().iteration;
-                                let prev_block_hash =
-                                    candidate.header().prev_block_hash;
-
-                                Message::from(payload::Candidate {
-                                    candidate,
-                                    header: ConsensusHeader {
-                                        prev_block_hash,
-                                        round,
-                                        iteration,
-                                    },
-                                    sign_info: SignInfo::default(), // TODO: Use Block::Signature here
-                                })
+                                Message::from(payload::Candidate { candidate })
                             })
                         } else {
                             None

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -211,7 +211,7 @@ impl<const N: usize> crate::Network for Kadcast<N> {
 
         let msg = GetResource::new(
             msg_inv.clone(),
-            self.public_addr,
+            Some(self.public_addr),
             ttl_as_sec,
             hops_limit,
         );


### PR DESCRIPTION
When a node joins an emergency iteration:

- If Proposal step times out and the provisioner is a committee member of Validation step then the node should request the candidate. If candidate is received then it is handled by `on_emergency_mode` and a vote can be casted.