### PR TITLE
Freeze workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,121 @@ members = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+# Workspace internal dependencies
+dusk-consensus = { version = "0.1.1-rc.3", path = "./consensus/" }
+execution-core = { version = "0.1.0", path = "./execution-core/" }
+license-circuits = { version = "0.1.0", path = "./circuits/license/" }
+node = { version = "0.1.0", path = "./node/" }
+node-data = { version = "0.1.0", path = "./node-data/" }
+rusk-abi = { version = "0.13.0-rc.0", path = "./rusk-abi/", default-features = false }
+rusk-profile = { version = "0.6.0", path = "./rusk-profile/" }
+rusk-prover = { version = "0.5.0", path = "./rusk-prover/" }
+rusk-recovery = { version = "0.6.0", path = "./rusk-recovery/" }
+wallet-core = { version = "0.1.0", path = "./wallet-core/" }
+
+# Dusk dependencies outside the workspace
+bls12_381-bls = { version = "=0.4.0", default-features = false }
+dusk-bls12_381 = { version = "=0.13.0", default-features = false }
+dusk-bytes = "=0.1.7"
+dusk-jubjub = { version = "=0.14.1", default-features = false }
+dusk-merkle = "=0.5.3"
+dusk-plonk = { version = "=0.20.0", default-features = false }
+dusk-poseidon = "=0.40.0"
+jubjub-schnorr = { version = "=0.5.0", default-features = false }
+kadcast = "=0.7.0-rc.5"
+phoenix-circuits = { version = "=0.4.0", default-features = false }
+phoenix-core = { version = "=0.32.0", default-features = false }
+piecrust = "=0.24.0"
+piecrust-uplink = "=0.17.1"
+poseidon-merkle = "=0.7.0"
+zk-citadel = "=0.14.0"
+
+# External dependencies
+aes = "=0.7.5"
+anyhow = "=1.0.89"
+ark-bn254 = { version = "=0.4.0", default-features = false }
+ark-groth16 = { version = "=0.4.0", default-features = false }
+ark-relations = { version = "=0.4.0", default-features = false }
+ark-serialize = { version = "=0.4.2", default-features = false }
+async-channel = "=1.9.0"
+async-graphql = "=5.0.10"
+async-trait = "=0.1.83"
+base64 = "=0.22.1"
+blake2b_simd = { version = "=1.0.2", default-features = false }
+blake3 = { version = "=1.5.4", default-features = false }
+block-modes = "=0.8.1"
+bs58 = "=0.4.0"
+bytecheck = { version = "=0.6.12", default-features = false }
+cargo_toml = "=0.15.3"
+chrono = "=0.4.38"
+clap = "=4.4.18"
+console = "=0.12.0"
+criterion = "=0.5.1"
+crossterm = "=0.25.0"
+dirs = "=4.0.0"
+dlmalloc = "=0.2.6"
+fake = "=2.9.2"
+ff = { version = "=0.13.0", default-features = false }
+flate2 = "=1.0.33"
+flume = "=0.10.14"
+futures = "=0.3.30"
+futures-util = "=0.3.30"
+hex = "=0.4.3"
+http-body-util = "=0.1.2"
+http_req = "=0.8.1"
+humantime-serde = "=1.1.1"
+hyper = "=1.4.1"
+hyper-tungstenite = "=0.13.0"
+hyper-util = "=0.1.9"
+konst = "=0.3.9"
+lazy_static = "=1.5.0"
+lru = "=0.12.4"
+memory-stats = "=1.2.0"
+metrics = "=0.22.3"
+metrics-exporter-prometheus = "=0.14.0"
+num-bigint = { version = "=0.4.6", default-features = false }
+once_cell = "=1.19.0"
+open = "=2.1.3"
+parking_lot = "=0.12.3"
+pin-project = "=1.1.5"
+rand = { version = "=0.8.5", default-features = false }
+rand_chacha = { version = "=0.3.1", default-features = false }
+requestty = "=0.5.0"
+reqwest = "=0.12.7"
+ringbuffer = "=0.15.0"
+rkyv = { version = "=0.7.39", default-features = false }
+rocksdb = { version = "=0.22.0", default-features = false }
+rustc_tools_util = "=0.3.0"
+rustls-pemfile = "=2.1.3"
+semver = "=1.0.23"
+serde = "=1.0.210"
+serde_derive = "=1.0.210"
+serde_json = "=1.0.128"
+serde_with = "=3.9.0"
+sha2 = { version = "0.10.8", default-features = false }
+sha3 = "=0.10.8"
+smallvec = "=1.13.2"
+sqlx = "=0.8.2"
+tar = "=0.4.42"
+tempdir = "=0.3.7"
+tempfile = "=3.12.0"
+thiserror = "=1.0.64"
+time-util = "=0.3.4"
+tiny-bip39 = "=0.8.2"
+tokio = "=1.40.0"
+tokio-rustls = "=0.26.0"
+tokio-stream = "=0.1.16"
+tokio-util = "=0.7.12"
+toml = "=0.7.8"
+tracing = "=0.1.40"
+tracing-subscriber = "=0.3.18"
+tungstenite = "=0.21.0"
+url = "=2.5.2"
+version_check = "=0.9.5"
+zeroize = { version = "=1.8.1", default-features = false }
+zip = "=0.5.13"
+
 [profile.dev.build-override]
 opt-level = 3
 debug = false

--- a/circuits/license/Cargo.toml
+++ b/circuits/license/Cargo.toml
@@ -4,13 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dusk-plonk = { version = "0.20", default-features = false, features = ["rkyv-impl", "alloc"] }
-zk-citadel = "0.14"
+dusk-plonk = { workspace = true, features = ["rkyv-impl", "alloc"] }
+zk-citadel = { workspace = true }
 
 [dev-dependencies]
-rand = "0.8"
-rusk-profile = { version = "0.6", path = "../../rusk-profile" }
-execution-core = { version = "0.1.0", path = "../../execution-core" }
-poseidon-merkle = { version = "0.7", features = ["rkyv-impl", "zk", "size_32"] }
-ff = { version = "0.13", default-features = false }
-dusk-poseidon = "0.40"
+rand = { workspace = true, features = ["std_rng"] }
+rusk-profile = { workspace = true }
+execution-core = { workspace = true }
+ff = { workspace = true }
+dusk-poseidon = { workspace = true }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -13,38 +13,26 @@ exclude = [".github/*", ".gitignore", ".env", ".vscode", "Cargo.lock"]
 path = "src/lib.rs"
 
 [dependencies]
-rand_core = { version = "0.6", default-features = false }
-rand = { version = "0.8", default-features = false, features = ["std_rng"] }
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1"
-sha3 = { version = "0.10" }
-num-bigint = { version = "0.4.3", default-features = false }
-hex = { version = "0.4.3" }
-dusk-bytes = "0.1"
-async-channel = "1.7.1"
-async-trait = "0.1"
-anyhow = "1.0"
-node-data = { version = "0.1", path = "../node-data" }
-execution-core = { version = "0.1.0", path = "../execution-core", features = ["parallel"] }
-dusk-merkle = { version = "0.5", features = ["size_32"] }
-thiserror = "1"
-time-util = { version = "0.3", features = ["chrono"] }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
+sha3 = { workspace = true }
+num-bigint = { workspace = true }
+hex = { workspace = true }
+dusk-bytes = { workspace = true }
+async-trait = { workspace = true }
+anyhow = { workspace = true }
+node-data = { workspace = true }
+execution-core = { workspace = true, features = ["parallel"] }
+dusk-merkle = { workspace = true, features = ["size_32"] }
+thiserror = { workspace = true }
+time-util = { workspace = true, features = ["chrono"] }
 
 [dev-dependencies]
-hex-literal = { version = "0.3.4" }
-clap = "2.33.3"
-rustc_tools_util = "0.2"
-kadcast = "0.4.1"
-blake2 = "0.10.5"
-blake3 = "1.3"
-block-modes = "0.8"
-aes = "0.7"
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-base64 = "0.13"
-node-data = { version = "0.1", path = "../node-data", features = ["faker"]}
-criterion = "0.5"
+node-data = { workspace = true, features = ["faker"]}
+criterion = { workspace = true }
+rand = { workspace = true, features = ["std_rng"] }
 
 [[bench]]
 name = "merkle"
 harness = false
+

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -4,7 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-extern crate core;
+#![deny(unused_crate_dependencies)]
+#![deny(unused_extern_crates)]
 
 pub mod commons;
 pub mod consensus;
@@ -31,4 +32,9 @@ mod iteration_ctx;
 pub mod merkle;
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    // Adding benchmark dependencies here to satisfy `unused_crate_dependencies`
+    // lint
+    use criterion as _;
+    use rand as _;
+}

--- a/contracts/alice/Cargo.toml
+++ b/contracts/alice/Cargo.toml
@@ -2,11 +2,10 @@
 name = "alice"
 version = "0.3.0"
 edition = "2021"
-resolver = "2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-execution-core = { version = "0.1.0", path = "../../execution-core" }
-rusk-abi = { version = "0.13.0-rc", path = "../../rusk-abi", features = ["dlmalloc"] }
+execution-core = { workspace = true }
+rusk-abi = { workspace = true, features = ["abi", "dlmalloc"] }

--- a/contracts/bob/Cargo.toml
+++ b/contracts/bob/Cargo.toml
@@ -2,14 +2,13 @@
 name = "bob"
 version = "0.3.0"
 edition = "2021"
-resolver = "2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-execution-core = { version = "0.1.0", path = "../../execution-core" }
-rusk-abi = { version = "0.13.0-rc", path = "../../rusk-abi" }
-rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
-bytecheck = { version = "0.6", default-features = false }
-dusk-bytes = "0.1"
+execution-core = { workspace = true }
+rusk-abi = { workspace = true, features = ["abi", "dlmalloc"] }
+rkyv = { workspace = true, features = ["size_32"] }
+bytecheck = { workspace = true }
+dusk-bytes = { workspace = true }

--- a/contracts/host_fn/Cargo.toml
+++ b/contracts/host_fn/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-execution-core = { version = "0.1.0", path = "../../execution-core" }
-dusk-bytes = "0.1"
-rusk-abi = { version = "0.13.0-rc", path = "../../rusk-abi" }
+execution-core = { workspace = true }
+dusk-bytes = { workspace = true }
+rusk-abi = { workspace = true, features = ["abi", "dlmalloc"]}

--- a/contracts/license/Cargo.toml
+++ b/contracts/license/Cargo.toml
@@ -7,25 +7,22 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-execution-core = { version = "0.1.0", path = "../../execution-core", features = ["zk"] }
-dusk-bytes = "0.1"
-dusk-poseidon = "0.40"
-poseidon-merkle = { version = "0.7", features = ["rkyv-impl", "zk", "size_32"] }
-rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
-bytecheck = { version = "0.6", default-features = false }
+execution-core = { workspace = true, features = ["zk"] }
+dusk-bytes = { workspace = true }
+rkyv = { workspace = true, features = ["size_32"] }
+bytecheck = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-rusk-abi = { version = "0.13.0-rc", path = "../../rusk-abi" }
+rusk-abi = { workspace = true, features = ["abi", "dlmalloc"] }
 
 [dev-dependencies]
-rusk-abi = { version = "0.13.0-rc", path = "../../rusk-abi", default-features = false, features = ["host"] }
-rusk-profile = { version = "0.6", path = "../../rusk-profile"}
-license-circuits = { version = "0.1", path = "../../circuits/license" }
-rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
-hex = "0.4"
-rand = "0.8"
-zk-citadel = "0.14"
-ff = { version = "0.13", default-features = false }
+rusk-abi = { workspace = true, features = ["host"] }
+rusk-profile = { workspace = true }
+license-circuits = { workspace = true }
+rand = { workspace = true }
+zk-citadel = { workspace = true }
+ff = { workspace = true }
+dusk-poseidon = { workspace = true }
 
 [build-dependencies]
-rusk-profile = { version = "0.6", path = "../../rusk-profile"}
+rusk-profile = { workspace = true }

--- a/contracts/license/src/lib.rs
+++ b/contracts/license/src/lib.rs
@@ -7,6 +7,8 @@
 #![cfg_attr(target_family = "wasm", no_std)]
 #![cfg(target_family = "wasm")]
 #![feature(arbitrary_self_types)]
+#![deny(unused_crate_dependencies)]
+#![deny(unused_extern_crates)]
 
 extern crate alloc;
 
@@ -16,9 +18,7 @@ mod license_types;
 #[cfg(target_family = "wasm")]
 mod state;
 
-pub use license_types::{
-    LicenseSession, LicenseSessionId, PoseidonItem, UseLicenseArg,
-};
+pub use license_types::{LicenseSession, LicenseSessionId, UseLicenseArg};
 
 const VD_LICENSE_CIRCUIT: &[u8] = include_bytes!(concat!(
     env!("RUSK_BUILT_KEYS_PATH"),

--- a/contracts/license/src/license_types.rs
+++ b/contracts/license/src/license_types.rs
@@ -11,11 +11,6 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 use execution_core::{plonk::Proof, BlsScalar};
 
-use poseidon_merkle::Item;
-
-#[allow(dead_code)]
-pub type PoseidonItem = Item<()>;
-
 /// Use License Argument.
 #[derive(Debug, Clone, PartialEq, Archive, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]

--- a/contracts/license/src/state.rs
+++ b/contracts/license/src/state.rs
@@ -9,18 +9,16 @@ use core::ops::Range;
 use alloc::vec::Vec;
 
 use dusk_bytes::Serializable;
-use poseidon_merkle::{Opening, Tree};
 
-use execution_core::BlsScalar;
+use execution_core::{
+    license::{LicenseOpening, LicenseTree, LicenseTreeItem},
+    BlsScalar,
+};
 
 use crate::collection::Map;
 use crate::error::Error;
-use crate::license_types::{
-    LicenseSession, LicenseSessionId, PoseidonItem, UseLicenseArg,
-};
+use crate::license_types::{LicenseSession, LicenseSessionId, UseLicenseArg};
 use crate::verifier_data_license_circuit;
-
-const DEPTH: usize = 17; // depth of the Merkle tree
 
 #[derive(Debug, Clone)]
 pub struct RequestEntry {
@@ -38,7 +36,7 @@ pub struct LicenseEntry {
 pub struct LicenseContractState {
     pub sessions: Map<LicenseSessionId, LicenseSession>,
     pub licenses: Map<u64, LicenseEntry>,
-    pub tree: Tree<(), DEPTH>,
+    pub tree: LicenseTree,
 }
 
 #[allow(dead_code)]
@@ -47,7 +45,7 @@ impl LicenseContractState {
         Self {
             sessions: Map::new(),
             licenses: Map::new(),
-            tree: Tree::<(), DEPTH>::new(),
+            tree: LicenseTree::new(),
         }
     }
 
@@ -61,7 +59,7 @@ impl LicenseContractState {
     /// Inserts a license into the collection of licenses.
     /// Method intended to be called by the License Provider.
     pub fn issue_license(&mut self, license: Vec<u8>, hash: BlsScalar) {
-        let item = PoseidonItem { hash, data: () };
+        let item = LicenseTreeItem { hash, data: () };
         let mut pos = self.tree.len();
         while self.tree.contains(pos) {
             pos += 1;
@@ -95,7 +93,7 @@ impl LicenseContractState {
     pub fn get_merkle_opening(
         &mut self,
         position: u64,
-    ) -> Option<Opening<(), DEPTH>> {
+    ) -> Option<LicenseOpening> {
         self.tree.opening(position)
     }
 

--- a/contracts/license/tests/license.rs
+++ b/contracts/license/tests/license.rs
@@ -11,7 +11,6 @@ use std::sync::mpsc;
 
 use dusk_poseidon::{Domain, Hash};
 use ff::Field;
-use poseidon_merkle::Opening;
 use rand::rngs::StdRng;
 use rand::{CryptoRng, RngCore, SeedableRng};
 use rkyv::{check_archived_root, Deserialize, Infallible};
@@ -20,6 +19,7 @@ use zk_citadel::license::{
 };
 
 use execution_core::{
+    license::LicenseOpening,
     plonk::{Compiler, PublicParameters},
     transfer::phoenix::{PublicKey, SecretKey, StealthAddress, ViewKey},
     BlsScalar, ContractId, JubJubAffine, JubJubScalar, GENERATOR_EXTENDED,
@@ -129,7 +129,7 @@ fn compute_citadel_parameters(
     sk: &SecretKey,
     pk_lp: &PublicKey,
     lic: &License,
-    merkle_proof: Opening<(), DEPTH>,
+    merkle_proof: LicenseOpening,
 ) -> (CitadelProverParameters<DEPTH>, SessionCookie) {
     const CHALLENGE: u64 = 20221126u64;
     let c = JubJubScalar::from(CHALLENGE);
@@ -215,7 +215,7 @@ fn license_issue_get_merkle() {
     let (pos, _) = owned_license.unwrap();
 
     let _merkle_opening = session
-        .call::<u64, Opening<(), DEPTH>>(
+        .call::<u64, LicenseOpening>(
             LICENSE_CONTRACT_ID,
             "get_merkle_opening",
             &pos,
@@ -297,7 +297,7 @@ fn multiple_licenses_issue_get_merkle() {
     let (pos, _) = owned_license.unwrap();
 
     let _merkle_opening = session
-        .call::<u64, Opening<(), DEPTH>>(
+        .call::<u64, LicenseOpening>(
             LICENSE_CONTRACT_ID,
             "get_merkle_opening",
             &pos,
@@ -402,7 +402,7 @@ fn use_license_get_session() {
     let (pos, owned_license) = owned_license.unwrap();
 
     let merkle_opening = session
-        .call::<u64, Opening<(), DEPTH>>(
+        .call::<u64, LicenseOpening>(
             LICENSE_CONTRACT_ID,
             "get_merkle_opening",
             &pos,

--- a/contracts/stake/Cargo.toml
+++ b/contracts/stake/Cargo.toml
@@ -7,24 +7,20 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-execution-core = { version = "0.1.0", path = "../../execution-core" }
-dusk-bytes = "0.1"
-rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
+execution-core = { workspace = true }
+dusk-bytes = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-rusk-abi = { version = "0.13.0-rc", path = "../../rusk-abi" }
+rusk-abi = { workspace = true, features = ["abi", "dlmalloc"] }
 
 [dev-dependencies]
-rusk-profile = { version = "0.6", path = "../../rusk-profile" }
-once_cell = { version = "1.9" }
-rusk-abi = { version = "0.13.0-rc", path = "../../rusk-abi", default-features = false, features = ["host"] }
-execution-core = { version = "0.1.0", path = "../../execution-core", features = ["zk"] }
-rusk-prover = { version = "0.5", path = "../../rusk-prover/" }
-rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
-hex = "0.4"
-rand = "0.8"
-ff = { version = "0.13", default-features = false }
-criterion = "0.5"
+rusk-abi = { workspace = true, features = ["host"] }
+execution-core = { workspace = true, features = ["zk"] }
+rusk-prover = { workspace = true }
+rkyv = { workspace = true, features = ["size_32"] }
+rand = { workspace = true }
+ff = { workspace = true }
+criterion = { workspace = true }
 
 [[bench]]
 name = "get_provisioners"

--- a/contracts/stake/src/lib.rs
+++ b/contracts/stake/src/lib.rs
@@ -7,6 +7,8 @@
 #![cfg_attr(target_family = "wasm", no_std)]
 #![cfg(target_family = "wasm")]
 #![feature(arbitrary_self_types)]
+#![deny(unused_crate_dependencies)]
+#![deny(unused_extern_crates)]
 
 extern crate alloc;
 

--- a/contracts/transfer/Cargo.toml
+++ b/contracts/transfer/Cargo.toml
@@ -7,25 +7,20 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-execution-core = { version = "0.1.0", path = "../../execution-core" }
-dusk-bytes = "0.1"
-rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
-ringbuffer = "0.15"
-
+execution-core = { workspace = true }
+ringbuffer = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-rusk-abi = { version = "0.13.0-rc", path = "../../rusk-abi" }
+rusk-abi = { workspace = true, features = ["abi", "dlmalloc"] }
 
 [dev-dependencies]
-rusk-profile = { version = "0.6", path = "../../rusk-profile" }
-once_cell = { version = "1.9" }
-rusk-abi = { version = "0.13.0-rc", path = "../../rusk-abi", default-features = false, features = ["host"] }
-rusk-prover = { version = "0.5", path = "../../rusk-prover/" }
-rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
-bytecheck = { version = "0.6", default-features = false }
-hex = "0.4"
-rand = "0.8"
-ff = { version = "0.13", default-features = false }
+rusk-abi = { workspace = true, features = ["host"] }
+rusk-profile = { workspace = true }
+rusk-prover = { workspace = true }
+rkyv = { workspace = true, features = ["size_32"] }
+rand = { workspace = true }
+ff = { workspace = true }
+dusk-bytes = { workspace = true }
 
 [build-dependencies]
-rusk-profile = { version = "0.6", path = "../../rusk-profile"}
+rusk-profile = { workspace = true }

--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -7,6 +7,8 @@
 #![cfg_attr(target_family = "wasm", no_std)]
 #![cfg(target_family = "wasm")]
 #![feature(arbitrary_self_types)]
+#![deny(unused_crate_dependencies)]
+#![deny(unused_extern_crates)]
 
 extern crate alloc;
 

--- a/execution-core/Cargo.toml
+++ b/execution-core/Cargo.toml
@@ -4,39 +4,37 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dusk-bls12_381 = { version = "0.13", default-features = false, features = ["rkyv-impl"] }
-dusk-jubjub = { version = "0.14", default-features = false, features = ["rkyv-impl"] }
-dusk-poseidon = "0.40"
-bls12_381-bls = { version = "0.4", default-features = false, features = ["rkyv-impl"] }
-jubjub-schnorr = { version = "0.5", default-features = false, features = ["rkyv-impl"] }
-phoenix-core = { version = "0.32", default-features = false, features = ["rkyv-impl", "alloc"] }
-phoenix-circuits = { version = "0.4", default-features = false }
-poseidon-merkle = { version = "0.7", features = ["rkyv-impl"] }
-piecrust-uplink = { version = "0.17" }
-dusk-bytes = "0.1"
-rkyv = { version = "0.7", default-features = false,  features = ["size_32"] }
-bytecheck = { version = "0.6", default-features = false }
-rand = { version = "0.8", default-features = false }
-ff = { version = "0.13", default-features = false }
+dusk-bls12_381 = { workspace = true, features = ["rkyv-impl"] }
+dusk-jubjub = { workspace = true, features = ["rkyv-impl"] }
+dusk-poseidon = { workspace = true }
+bls12_381-bls = { workspace = true, features = ["rkyv-impl"] }
+jubjub-schnorr = { workspace = true, features = ["rkyv-impl"] }
+phoenix-core = { workspace = true, features = ["rkyv-impl", "alloc"] }
+phoenix-circuits = { workspace = true }
+poseidon-merkle = { workspace = true, features = ["rkyv-impl"] }
+piecrust-uplink = { workspace = true }
+dusk-bytes = { workspace = true }
+rkyv = { workspace = true,  features = ["size_32"] }
+bytecheck = { workspace = true }
+rand = { workspace = true }
+ff = { workspace = true }
 
-# zk-dependencies
+# plonk dependencies
+dusk-plonk = { workspace = true, features = ["rkyv-impl", "alloc"], optional = true }
 
-ark-groth16 = { version = "0.4", default-features = false, features = [], optional = true }
-ark-bn254 = { version = "0.4", default-features = false, features = ["curve"], optional = true }
-ark-relations = { version = "0.4", default-features = false, features = [], optional = true }
-ark-serialize = { version = "0.4", default-features = false, features = [], optional = true }
-
-dusk-plonk = { version = "0.20", default-features = false, features = ["rkyv-impl", "alloc"], optional = true }
+# groth dependencies
+ark-groth16 = { workspace = true, optional = true }
+ark-bn254 = { workspace = true, features = ["curve"], optional = true }
+ark-relations = { workspace = true, optional = true }
+ark-serialize = { workspace = true, optional = true }
 
 [dev-dependencies]
-rand = "0.8"
+rand = { workspace = true, features = ["std", "std_rng"] }
 
 [features]
 parallel = [
     # It enables parallel thread aggregation of BlsPublicKey
     "bls12_381-bls/parallel", 
-    # It enables parallel feature for ark-groth16
-    "ark-groth16/parallel"
 ]
 
 # Enables all zero-knowledge proof system libraries supported

--- a/execution-core/src/lib.rs
+++ b/execution-core/src/lib.rs
@@ -12,6 +12,8 @@
 #![deny(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 #![feature(const_fn_floating_point_arithmetic)]
+#![cfg_attr(not(target_family = "wasm"), deny(unused_crate_dependencies))]
+#![deny(unused_extern_crates)]
 
 extern crate alloc;
 

--- a/execution-core/src/license.rs
+++ b/execution-core/src/license.rs
@@ -10,3 +10,16 @@ use crate::{reserved, ContractId};
 
 /// ID of the genesis license contract
 pub const LICENSE_CONTRACT: ContractId = reserved(0x3);
+
+/// The depth of the merkle tree of licenses stored in the license-contract.
+pub const LICENSE_TREE_DEPTH: usize = 17;
+/// The arity of the merkle tree of licenses stored in the
+/// license-contract.
+pub use poseidon_merkle::ARITY as LICENSE_TREE_ARITY;
+/// The merkle tree of licenses stored in the license-contract.
+pub type LicenseTree = poseidon_merkle::Tree<(), LICENSE_TREE_DEPTH>;
+/// The merkle opening for a license-hash in the merkle tree of licenses.
+pub type LicenseOpening = poseidon_merkle::Opening<(), LICENSE_TREE_DEPTH>;
+/// the tree item for the merkle-tree of licenses stored in the
+/// license-contract.
+pub type LicenseTreeItem = poseidon_merkle::Item<()>;

--- a/node-data/Cargo.toml
+++ b/node-data/Cargo.toml
@@ -4,34 +4,31 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dusk-bytes = "^0.1"
-sha3 = "0.10"
-sha2 = "0.10"
-fake = { version = "2.5", features = ['derive'], optional = true }
-rand = { version = "0.8", optional = true }
-hex = { version = "0.4", optional = true }
-execution-core = { version = "0.1.0", path = "../execution-core" }
+dusk-bytes = { workspace = true }
+sha3 = { workspace = true }
+sha2 = { workspace = true }
+rand = { workspace = true, features = ["std_rng"] }
+hex = { workspace = true }
+execution-core = { workspace = true }
 
-rand_core = { version = "0.6", default-features = false }
-block-modes = "0.8"
-aes = "0.7"
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_with = { version = "3.1", features = ["hex"] }
-base64 = "0.13"
-async-channel = "1.7"
-chrono = "0.4"
-bs58 = { version = "0.4" }
-tracing = "0.1"
-anyhow = "1"
-thiserror = "1"
+block-modes = { workspace = true }
+aes = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true, features = ["hex"] }
+base64 = { workspace = true }
+async-channel = { workspace = true }
+chrono = { workspace = true }
+bs58 = { workspace = true }
+tracing = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
 
+# faker feature dependencies
+fake = { workspace = true, features = ['derive'], optional = true }
 
 [dev-dependencies]
-fake = { version = "2.5", features = ['derive'] }
-rand = "0.8"
-hex = "0.4"
+fake = { workspace = true, features = ['derive'] }
 
 [features]
-default = ["dep:rand", "dep:hex"]
-faker = ["dep:fake", "dep:rand", "dep:hex"]
+faker = ["dep:fake"]

--- a/node-data/src/bls.rs
+++ b/node-data/src/bls.rs
@@ -5,12 +5,13 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use aes::Aes256;
+use base64::{engine::general_purpose::STANDARD as BASE64_ENGINE, Engine};
 use block_modes::block_padding::Pkcs7;
 use block_modes::{BlockMode, BlockModeError, Cbc};
 use dusk_bytes::{DeserializableSlice, Serializable};
 
 use rand::rngs::StdRng;
-use rand_core::SeedableRng;
+use rand::SeedableRng;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
@@ -193,14 +194,16 @@ fn read_from_file(
     let keys: BlsKeyPair = serde_json::from_slice(&bytes)
         .map_err(|e| anyhow::anyhow!("keys files should contain json {e}"))?;
 
-    let sk_bytes = base64::decode(keys.secret_key_bls)
+    let sk_bytes = BASE64_ENGINE
+        .decode(keys.secret_key_bls)
         .map_err(|e| anyhow::anyhow!("sk should be base64 {e}"))?;
 
     let sk = BlsSecretKey::from_slice(&sk_bytes)
         .map_err(|e| anyhow::anyhow!("sk should be valid {e:?}"))?;
 
     let pk = BlsPublicKey::from_slice(
-        &base64::decode(keys.public_key_bls)
+        &BASE64_ENGINE
+            .decode(keys.public_key_bls)
             .map_err(|e| anyhow::anyhow!("pk should be base64 {e}"))?[..],
     )
     .map_err(|e| anyhow::anyhow!("pk should be valid {e:?}"))?;

--- a/node-data/src/events/transactions.rs
+++ b/node-data/src/events/transactions.rs
@@ -56,9 +56,9 @@ impl EventSource for TransactionEvent<'_> {
         hex::encode(hash)
     }
 }
+use base64::{engine::general_purpose::STANDARD as BASE64_ENGINE, Engine};
 use dusk_bytes::Serializable;
 use execution_core::transfer::Transaction as ProtocolTransaction;
-
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 
 impl Serialize for Transaction {
@@ -132,7 +132,7 @@ impl Serialize for Transaction {
             let mut call = HashMap::new();
             call.insert("contract", hex::encode(c.contract));
             call.insert("fn_name", c.fn_name.to_string());
-            call.insert("fn_args", base64::encode(&c.fn_args));
+            call.insert("fn_args", BASE64_ENGINE.encode(&c.fn_args));
             call
         });
         state.serialize_field("call", &call)?;

--- a/node-data/src/lib.rs
+++ b/node-data/src/lib.rs
@@ -4,6 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![deny(unused_crate_dependencies)]
+#![deny(unused_extern_crates)]
+
 pub mod archive;
 pub mod bls;
 pub mod encoding;

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,45 +9,43 @@ keywords = ["dusk", "cryptocurrency", "blockchain", "node"]
 license = "MPL-2.0"
 
 [dependencies]
-tracing = "0.1"
-hex = "0.4"
-dusk-consensus = { version = "0.1.1-rc.3", path = "../consensus" }
-kadcast = "0.7.0-rc.5"
-sha3 = { version = "0.10" }
-anyhow = "1.0"
-async-trait = "0.1"
-tokio = { version = "1", features = ["full"] }
-async-channel = "1.7"
+tracing = { workspace = true }
+hex = { workspace = true }
+dusk-consensus = { workspace = true }
+kadcast = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+async-channel = { workspace = true }
 
-rkyv = "0.7"
+rkyv = { workspace = true }
 
-rocksdb_lib = { package = "rocksdb", version = "0.22", default-features = false }
-dusk-bytes = "^0.1"
-node-data = { version = "0.1", path = "../node-data" }
-execution-core = { version = "0.1.0", path = "../execution-core" }
-blake2 = "0.10.5"
-console-subscriber = { version = "0.1.8", optional = true }
-smallvec = "1.10.0"
+rocksdb = { workspace = true }
+dusk-bytes = { workspace = true }
+node-data = { workspace = true }
+execution-core = { workspace = true }
+smallvec = { workspace = true }
 
-serde = "1.0"
-humantime-serde = "1"
-thiserror = "1"
-metrics = "0.22"
-metrics-exporter-prometheus = "0.14"
-memory-stats = "1.0"
-sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-native-tls", "sqlite", "migrate"], optional = true }
-serde_json = { version = "1.0", optional = true }
+serde = { workspace = true }
+humantime-serde = { workspace = true }
+thiserror = { workspace = true }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+memory-stats = { workspace = true }
+
+# archive feature dependencies
+sqlx = { version = "=0.7.4", features = [ "runtime-tokio", "tls-native-tls", "sqlite", "migrate"], optional = true }
+serde_json = { workspace = true, optional = true }
 
 [dev-dependencies]
-fake = { version = "2.5", features = ['derive'] }
-node-data = { version = "0.1", path = "../node-data", features = ["faker"] }
-rand = "0.8"
-rand_core = "0.6"
-tempdir = "0.3"
-criterion = { version = "0.5", features = ["async_futures"] }
+fake = { workspace = true, features = ['derive'] }
+node-data = { workspace = true, features = ["faker"] }
+rand = { workspace = true }
+tempdir = { workspace = true }
+criterion = { workspace = true, features = ["async_futures"] }
 
 [features]
-with_telemetry = ["dep:console-subscriber"]
+with_telemetry = []
 archive = ["dep:sqlx", "dep:serde_json"]
 
 [[bench]]

--- a/node/src/database/rocksdb.rs
+++ b/node/src/database/rocksdb.rs
@@ -17,7 +17,7 @@ use node_data::Serializable;
 
 use crate::database::Mempool;
 
-use rocksdb_lib::{
+use rocksdb::{
     AsColumnFamilyRef, BlockBasedOptions, ColumnFamily, ColumnFamilyDescriptor,
     DBAccess, DBRawIteratorWithThreadMode, IteratorMode, LogLevel,
     OptimisticTransactionDB, OptimisticTransactionOptions, Options,
@@ -212,7 +212,7 @@ impl DB for Backend {
 
         Self {
             rocksdb: Arc::new(
-                rocksdb_lib::OptimisticTransactionDB::open_cf_descriptors(
+                OptimisticTransactionDB::open_cf_descriptors(
                     &blocks_cf_opts,
                     path,
                     cfs,
@@ -254,7 +254,7 @@ impl DB for Backend {
 }
 
 pub struct DBTransaction<'db, DB: DBAccess> {
-    inner: rocksdb_lib::Transaction<'db, DB>,
+    inner: Transaction<'db, DB>,
     /// cumulative size of transaction footprint
     cumulative_inner_size: RefCell<usize>,
 
@@ -894,7 +894,7 @@ impl<DB: DBAccess, M: Mempool> Iterator for MemPoolIterator<'_, DB, M> {
 }
 
 pub struct MemPoolFeeIterator<'db, DB: DBAccess> {
-    iter: DBRawIteratorWithThreadMode<'db, rocksdb_lib::Transaction<'db, DB>>,
+    iter: DBRawIteratorWithThreadMode<'db, Transaction<'db, DB>>,
 }
 
 impl<'db, DB: DBAccess> MemPoolFeeIterator<'db, DB> {
@@ -1543,11 +1543,11 @@ mod tests {
         let path = t.get_path();
         let opts = Options::default();
 
-        let vec = rocksdb_lib::DB::list_cf(&opts, &path).unwrap();
+        let vec = rocksdb::DB::list_cf(&opts, &path).unwrap();
         assert!(!vec.is_empty());
 
         // Ensure no block fields leak after its deletion
-        let db = rocksdb_lib::DB::open_cf(&opts, &path, vec.clone()).unwrap();
+        let db = rocksdb::DB::open_cf(&opts, &path, vec.clone()).unwrap();
         vec.into_iter()
             .map(|cf_name| {
                 if cf_name == CF_METADATA {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![deny(unused_crate_dependencies)]
+#![deny(unused_extern_crates)]
 #![feature(lazy_cell)]
 
 #[cfg(feature = "archive")]
@@ -243,4 +245,8 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> Node<N, DB, VM> {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    // need to add the benchmark dep here so that the
+    // `unused_crate_dependencies` lint is satisfied
+    use criterion as _;
+}

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -9,27 +9,23 @@ license = "MPL-2.0"
 exclude = [".github/workflows/ci.yml", ".gitignore"]
 
 [dependencies]
-blake2b_simd = { version = "1", default-features = false }
+dusk-bytes = { workspace = true }
+execution-core = { workspace = true, features = ["zk"] }
 
-dusk-poseidon = "0.39"
-dusk-bytes = "0.1"
-bytecheck = { version = "0.6", default-features = false }
+# abi feature dependency
+piecrust-uplink = { workspace = true, features = ["abi"], optional = true }
 
-piecrust-uplink = { version = "0.17" }
-piecrust = { version = "0.24", optional = true }
-
-execution-core = { version = "0.1.0", path = "../execution-core", features = ["zk"] }
-
-# These are patches since these crates don't seem to like semver.
-rkyv = { version = "=0.7.39", default-features = false, features = ["size_32"] }
-
-lru = { version = "0.12", optional = true }
+# host feature dependencies
+piecrust = { workspace = true, optional = true }
+lru = { workspace = true, optional = true }
+blake2b_simd = { workspace = true, optional = true }
+dusk-poseidon = { workspace = true, optional = true }
+rkyv = { workspace = true, features = ["size_32"], optional = true }
 
 [dev-dependencies]
-rand = "0.8"
-once_cell = "1.15"
-ff = "0.13"
-hex = "0.4"
+rand = { workspace = true, features = ["getrandom"] }
+once_cell = { workspace = true }
+ff = { workspace = true }
 
 [features]
 # By default, we include the contract writing features.
@@ -37,13 +33,13 @@ default = ["abi", "dlmalloc"]
 
 # These are the features available for when one wishes to use `rusk-abi` as a
 # contract.
-abi = ["piecrust-uplink/abi"]
+abi = ["piecrust-uplink"]
 debug = ["abi", "piecrust-uplink/debug"]
 dlmalloc = ["piecrust-uplink/dlmalloc"]
 
 # These are the features available for when one wishes to use `rusk-abi` as a
 # host.
-host = ["piecrust", "lru", "execution-core/parallel"]
+host = ["piecrust", "lru", "execution-core/parallel", "blake2b_simd", "dusk-poseidon", "rkyv"]
 host_debug = ["piecrust/debug", "lru"]
 
 [[test]]

--- a/rusk-abi/src/lib.rs
+++ b/rusk-abi/src/lib.rs
@@ -15,6 +15,8 @@
 #![cfg_attr(not(feature = "host"), no_std)]
 #![deny(missing_docs)]
 #![deny(clippy::all)]
+#![cfg_attr(not(target_family = "wasm"), deny(unused_crate_dependencies))]
+#![deny(unused_extern_crates)]
 
 #[cfg(all(feature = "host", feature = "abi"))]
 compile_error!("features \"host\" and \"abi\" are mutually exclusive");
@@ -64,17 +66,19 @@ pub use piecrust::{
     PageOpening, Session, VM,
 };
 
+#[cfg(any(feature = "host", feature = "abi"))]
 enum Metadata {}
 
-#[allow(dead_code)]
+#[cfg(any(feature = "host", feature = "abi"))]
 impl Metadata {
     pub const CHAIN_ID: &'static str = "chain_id";
     pub const BLOCK_HEIGHT: &'static str = "block_height";
 }
 
+#[cfg(any(feature = "host", feature = "abi"))]
 enum Query {}
 
-#[allow(dead_code)]
+#[cfg(any(feature = "host", feature = "abi"))]
 impl Query {
     pub const HASH: &'static str = "hash";
     pub const POSEIDON_HASH: &'static str = "poseidon_hash";
@@ -83,4 +87,13 @@ impl Query {
     pub const VERIFY_SCHNORR: &'static str = "verify_schnorr";
     pub const VERIFY_BLS: &'static str = "verify_bls";
     pub const VERIFY_BLS_MULTISIG: &'static str = "verify_bls_multisig";
+}
+
+#[cfg(test)]
+mod tests {
+    // rust doesn't allow for optional dev-dependencies so we need to add this
+    // work-around to satisfy the `unused_crate_dependencies` lint
+    use ff as _;
+    use once_cell as _;
+    use rand as _;
 }

--- a/rusk-abi/tests/lib.rs
+++ b/rusk-abi/tests/lib.rs
@@ -5,7 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 #![deny(clippy::all)]
-#![cfg(feature = "host")]
 
 use std::sync::OnceLock;
 

--- a/rusk-profile/Cargo.toml
+++ b/rusk-profile/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 autobins = false
 
 [dependencies]
-dirs = "4.0"
-tracing = "0.1"
-hex = "0.4"
-sha2 = "0.10"
-blake3 = "1.3"
-toml = "0.7"
-serde = { version = "1", features = ["derive"] }
-console = "0.12"
-version_check = "0.9"
+dirs = { workspace = true }
+tracing = { workspace = true }
+hex = { workspace = true }
+sha2 = { workspace = true }
+blake3 = { workspace = true }
+toml = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+console = { workspace = true }
+version_check = { workspace = true }

--- a/rusk-profile/src/lib.rs
+++ b/rusk-profile/src/lib.rs
@@ -4,6 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![deny(unused_crate_dependencies)]
+#![deny(unused_extern_crates)]
+
 use dirs::home_dir;
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};

--- a/rusk-prover/Cargo.toml
+++ b/rusk-prover/Cargo.toml
@@ -5,16 +5,15 @@ edition = "2021"
 autobins = false
 
 [dependencies]
-dusk-bytes = "0.1"
-once_cell = { version = "1.9" }
-rand = { version = "0.8", default-features = false, features = ["getrandom"] }
-dusk-plonk = { version = "0.20", default-features = false, features = ["rkyv-impl", "alloc"] }
-rusk-profile = { version = "0.6", path = "../rusk-profile" }
-execution-core = { version = "0.1.0", path = "../execution-core", features = ["zk"] }
+dusk-bytes = { workspace = true }
+once_cell = { workspace = true }
+rand = { workspace = true, features = ["getrandom"] }
+dusk-plonk = { workspace = true, features = ["rkyv-impl", "alloc"] }
+rusk-profile = { workspace = true }
+execution-core = { workspace = true, features = ["zk"] }
 
 [dev-dependencies]
-hex = "0.4"
-rand = "0.8"
+hex = { workspace = true }
 
 [features]
 no_random = []

--- a/rusk-prover/src/lib.rs
+++ b/rusk-prover/src/lib.rs
@@ -5,6 +5,8 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![deny(unused_crate_dependencies)]
+#![deny(unused_extern_crates)]
 
 extern crate alloc;
 #[cfg(feature = "std")]

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -11,34 +11,65 @@ path = "src/lib.rs"
 
 
 [dependencies]
-dusk-bytes = "0.1"
-dusk-plonk = { version = "0.20", features = ["rkyv-impl"] }
-hex = "0.4"
-rand = "0.8"
-once_cell = "1.13"
-ff = { version = "0.13", default-features = false }
-tracing = { version = "0.1", features = ["log"] }
-http_req = "0.8"
-zip = "0.5"
-url = "2.3"
-flate2 = "1"
-tar = "0.4"
-cargo_toml = "0.15"
-reqwest = "0.12"
-tokio = { version = "1", features = ["full"] }
-lazy_static = "1.5"
+rusk-profile = { workspace = true }
 
-license-circuits = { version = "0.1", path = "../circuits/license" }
+# stake and keys feature dependency
+execution-core = { workspace = true, features = ["zk", "std"], optional = true }
+once_cell = { workspace = true, optional = true }
+tracing = { workspace = true, features = ["log"], optional = true }
 
-rusk-profile = { version = "0.6", path = "../rusk-profile" }
-rusk-abi = { version = "0.13.0-rc", path = "../rusk-abi", default-features = false, features = ["host"] }
-execution-core = { version = "0.1.0", path = "../execution-core", features = ["zk", "std"] }
+# state feature dependencies
+serde_derive = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+toml = { workspace = true, optional = true }
+bs58 = { workspace = true, optional = true }
+dusk-bytes = { workspace = true, optional = true }
+ff = { workspace = true, optional = true }
+flate2 = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
+http_req = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
+rusk-abi = { workspace = true, features = ["host"], optional = true }
+tar = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
+zip = { workspace = true, optional = true }
 
-serde_derive = { version = "1", optional = true }
-serde = { version = "1", optional = true }
-toml = { version = "0.5", optional = true }
-bs58 = { version = "0.4", optional = true }
+# keys feature dependencies
+cargo_toml = { workspace = true, optional = true }
+dusk-plonk = { workspace = true, features = ["rkyv-impl"], optional = true }
+lazy_static = { workspace = true, optional = true }
+license-circuits = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["full"], optional = true }
 
 [features]
-state = ["serde_derive", "serde", "toml", "bs58"]
-keys = []
+state = [
+    "execution-core",
+    "once_cell",
+    "tracing",
+    "serde_derive",
+    "serde",
+    "toml",
+    "bs58",
+    "dusk-bytes",
+    "ff",
+    "flate2",
+    "hex",
+    "http_req",
+    "rand",
+    "rusk-abi",
+    "tar",
+    "url",
+    "zip",
+]
+keys = [
+    "execution-core",
+    "once_cell",
+    "tracing",
+    "cargo_toml",
+    "dusk-plonk",
+    "lazy_static",
+    "license-circuits",
+    "reqwest",
+    "tokio",
+]

--- a/rusk-recovery/src/keys.rs
+++ b/rusk-recovery/src/keys.rs
@@ -5,10 +5,8 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::Theme;
-use execution_core::{
-    plonk::{Compiler, PublicParameters},
-    transfer::phoenix::TRANSCRIPT_LABEL,
-};
+use dusk_plonk::prelude::{Compiler, PublicParameters};
+use execution_core::transfer::phoenix::TRANSCRIPT_LABEL;
 use once_cell::sync::Lazy;
 use std::{
     io,

--- a/rusk-recovery/src/lib.rs
+++ b/rusk-recovery/src/lib.rs
@@ -4,6 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![deny(unused_crate_dependencies)]
+#![deny(unused_extern_crates)]
+
 #[cfg(feature = "keys")]
 pub mod keys;
 #[cfg(feature = "state")]

--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -15,50 +15,47 @@ name = "rusk-wallet"
 path = "src/bin/main.rs"
 
 [dependencies]
-clap = { version = "3.1", features = ["derive", "env"] }
-thiserror = "1.0"
-anyhow = "1.0"
-tokio = { version = "1.15", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-url = { version = "2", features = ["serde"] }
-async-trait = "0.1"
-block-modes = "0.8"
-serde_json = "1.0"
-hex = "0.4"
-tiny-bip39 = "0.8"
-crossterm = "0.23"
-rand_core = "0.6"
-requestty = "0.5.0"
-futures = "0.3"
-base64 = "0.13"
-crypto = "0.3"
-blake3 = "1.3"
-sha2 = "0.10.7"
-toml = "0.5"
-open = "2.1"
-dirs = "4.0"
-bs58 = "0.4"
-rand = "0.8"
-aes = "0.7"
-rocksdb = "0.22"
-flume = "0.10.14"
-reqwest = { version = "0.11", features = ["stream"] }
-dusk-bytes = "0.1"
+clap = { version = "=3.2.25", features = ["derive", "env"] }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+url = { workspace = true, features = ["serde"] }
+block-modes = { workspace = true }
+serde_json = { workspace = true }
+hex = { workspace = true }
+tiny-bip39 = { workspace = true }
+crossterm = { workspace = true }
+requestty = { workspace = true }
+futures = { workspace = true }
+base64 = { workspace = true }
+blake3 = { workspace = true }
+sha2 = { workspace = true }
+toml = { workspace = true }
+open = { workspace = true }
+dirs = { workspace = true }
+bs58 = { workspace = true }
+rand = { workspace = true, features = ["std", "std_rng", "getrandom"] }
+aes = { workspace = true }
+rocksdb = { workspace = true }
+flume = { workspace = true }
+reqwest = { workspace = true, features = ["stream"] }
+dusk-bytes = { workspace = true }
 
-zeroize = { version = "1", default-features = false, features = ["derive"] }
-wallet-core = { path = "../wallet-core" }
-execution-core = { path = "../execution-core" }
+zeroize = { workspace = true, features = ["derive"] }
+wallet-core = { workspace = true }
+execution-core = { workspace = true }
 
-tracing = "0.1"
-tracing-subscriber = { version = "0.3.0", features = [
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = [
     "fmt",
     "env-filter",
     "json",
 ] }
 
-rkyv = { version = "=0.7.39", default-features = false }
+rkyv = { workspace = true }
 
-konst = "0.3"
+konst = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.2"
+tempfile = { workspace = true }

--- a/rusk-wallet/src/error.rs
+++ b/rusk-wallet/src/error.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use rand_core::Error as RngError;
+use rand::Error as RngError;
 use std::io;
 use std::str::Utf8Error;
 

--- a/rusk-wallet/src/wallet.rs
+++ b/rusk-wallet/src/wallet.rs
@@ -11,33 +11,17 @@ pub mod gas;
 pub use address::Address;
 pub use file::{SecureWalletFile, WalletPath};
 
+use std::fmt::Debug;
+use std::fs;
+use std::path::{Path, PathBuf};
+
 use bip39::{Language, Mnemonic, Seed};
 use dusk_bytes::Serializable;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-
 use rues::RuesHttpClient;
 use serde::Serialize;
-use std::fmt::Debug;
-use std::fs;
-use std::path::{Path, PathBuf};
-use wallet_core::transaction::{
-    moonlight_deployment, moonlight_stake_reward, phoenix_deployment,
-};
-
-use wallet_core::{
-    phoenix_balance,
-    prelude::keys::{
-        derive_bls_pk, derive_bls_sk, derive_phoenix_pk, derive_phoenix_sk,
-        derive_phoenix_vk,
-    },
-    transaction::{
-        moonlight, moonlight_stake, moonlight_to_phoenix, moonlight_unstake,
-        phoenix, phoenix_stake, phoenix_stake_reward, phoenix_to_moonlight,
-        phoenix_unstake,
-    },
-    BalanceInfo,
-};
+use zeroize::Zeroize;
 
 use execution_core::{
     signatures::bls::{PublicKey as BlsPublicKey, SecretKey as BlsSecretKey},
@@ -46,11 +30,22 @@ use execution_core::{
         Transaction,
     },
 };
-
-use zeroize::Zeroize;
+use wallet_core::{
+    phoenix_balance,
+    prelude::keys::{
+        derive_bls_pk, derive_bls_sk, derive_phoenix_pk, derive_phoenix_sk,
+        derive_phoenix_vk,
+    },
+    transaction::{
+        moonlight, moonlight_deployment, moonlight_stake,
+        moonlight_stake_reward, moonlight_to_phoenix, moonlight_unstake,
+        phoenix, phoenix_deployment, phoenix_stake, phoenix_stake_reward,
+        phoenix_to_moonlight, phoenix_unstake,
+    },
+    BalanceInfo,
+};
 
 use super::*;
-
 use crate::{
     clients::{Prover, State},
     crypto::encrypt,
@@ -62,7 +57,6 @@ use crate::{
     store::LocalStore,
     Error, RuskHttpClient,
 };
-
 use gas::Gas;
 
 /// The interface to the Dusk Network
@@ -1189,10 +1183,11 @@ struct BlsKeyPair {
 }
 
 mod base64 {
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
     use serde::{Serialize, Serializer};
 
     pub fn serialize<S: Serializer>(v: &[u8], s: S) -> Result<S::Ok, S::Error> {
-        let base64 = base64::encode(v);
+        let base64 = BASE64.encode(v);
         String::serialize(&base64, s)
     }
 }

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -13,83 +13,82 @@ name = "rusk"
 path = "src/bin/main.rs"
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "fs", "macros"] }
-futures-util = "0.3"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3.0", features = [
+tokio = { workspace = true, features = ["rt-multi-thread", "fs", "macros"] }
+futures-util = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = [
     "fmt",
     "env-filter",
     "json",
 ] }
-clap = { version = "=4.4", features = ["env", "string", "derive"] }
-semver = "1.0"
-anyhow = "1.0"
-rustc_tools_util = "0.3"
-rand = "0.8"
-toml = "0.5"
-serde = "1"
-serde_json = "1"
-serde_with = { version = "3.1", features = ["hex"] }
-humantime-serde = "1"
-bs58 = "0.4"
-base64 = "0.22"
-hex = "0.4"
-parking_lot = "0.12"
-rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
-bytecheck = { version = "0.6", default-features = false }
-dirs = "4"
-blake3 = "1"
-blake2b_simd = { version = "1", default-features = false }
+clap = { workspace = true, features = ["env", "string", "derive"] }
+semver = { workspace = true }
+anyhow = { workspace = true }
+rustc_tools_util = { workspace = true }
+rand = { workspace = true }
+toml = "=0.5.11"
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true, features = ["hex"] }
+humantime-serde = { workspace = true }
+bs58 = { workspace = true }
+base64 = { workspace = true }
+hex = { workspace = true }
+parking_lot = { workspace = true }
+rkyv = { workspace = true, features = ["size_32"] }
+bytecheck = { workspace = true }
+dirs = { workspace = true }
+blake3 = { workspace = true }
+blake2b_simd = { workspace = true }
 
-sha3 = "0.10"
-dusk-bytes = "0.1"
-kadcast = "0.7.0-rc.5"
-pin-project = "1"
-tungstenite = "0.21"
-hyper-tungstenite = "0.13"
-hyper = { version = "1", features = ["server", "http1", "http2"] }
-hyper-util = { version = "0.1", features = ["server", "http1", "http2"] }
-http-body-util = "0.1"
+sha3 = { workspace = true }
+dusk-bytes = { workspace = true }
+kadcast = { workspace = true }
+pin-project = { workspace = true }
+tungstenite = { workspace = true }
+hyper-tungstenite = { workspace = true }
+hyper = { workspace = true, features = ["server", "http1", "http2"] }
+hyper-util = { workspace = true, features = ["server", "http1", "http2"] }
+http-body-util = { workspace = true }
 
-tokio-stream = { version = "0.1", features = ["sync"] }
-tokio-util = { version = "0.7", features = ["rt"] }
-tokio-rustls = "0.25"
-rustls-pemfile = "2"
-async-trait = "0.1"
+tokio-stream = { workspace = true, features = ["sync"] }
+tokio-util = { workspace = true, features = ["rt"] }
+tokio-rustls = { workspace = true }
+rustls-pemfile = { workspace = true }
+async-trait = { workspace = true }
 
-execution-core = { version = "0.1.0", path = "../execution-core", features = ["zk"] }
-rusk-profile = { version = "0.6", path = "../rusk-profile" }
-rusk-abi = { version = "0.13.0-rc", path = "../rusk-abi", default-features = false, features = ["host"] }
-rusk-prover = { version = "0.5", path = "../rusk-prover", features = ["std"], optional = true }
+execution-core = { workspace = true, features = ["zk"] }
+rusk-profile = { workspace = true }
+rusk-abi = { workspace = true, features = ["host"] }
+rusk-prover = { workspace = true, features = ["std"], optional = true }
 
 ## node dependencies
-node = { version = "0.1", path = "../node", optional = true }
-dusk-consensus = { version = "0.1.1-rc.3", path = "../consensus", optional = true }
-node-data = { version = "0.1", path = "../node-data", optional = true }
+node = { workspace = true, optional = true }
+dusk-consensus = { workspace = true, optional = true }
+node-data = { workspace = true, optional = true }
 
 
 ## GraphQL deps
-async-graphql = "5.0"
+async-graphql = { workspace = true }
 
 
 ## Ephemeral dependencies
-tempfile = { version = "3.2", optional = true }
-rusk-recovery = { version = "0.6", path = "../rusk-recovery", optional = true }
+tempfile = { workspace = true, optional = true }
+rusk-recovery = { workspace = true, optional = true }
 
 ## testwallet dependencies
-futures = { version = "0.3", optional = true }
+futures = { workspace = true, optional = true }
 
 [dev-dependencies]
 test-wallet = { version = "0.1.0", path = "../test-wallet" }
-test-context = "0.1"
-reqwest = "0.12"
-rusk-recovery = { version = "0.6", path = "../rusk-recovery", features = ["state"] }
-ff = { version = "0.13", default-features = false }
-rusk-prover = { version = "0.5", path = "../rusk-prover", features = ["no_random"] }
-criterion = "0.5"
+reqwest = { workspace = true }
+rusk-recovery = { workspace = true, features = ["state"] }
+ff = { workspace = true }
+rusk-prover = { workspace = true, features = ["no_random"] }
+criterion = { workspace = true }
 
 [build-dependencies]
-rustc_tools_util = "0.3"
+rustc_tools_util = { workspace = true }
 
 [features]
 default = ["ephemeral", "recovery-state", "recovery-keys", "prover", "chain", "http-wasm"]

--- a/test-wallet/Cargo.toml
+++ b/test-wallet/Cargo.toml
@@ -6,19 +6,17 @@ description = "Test wallet used for Rusk"
 license = "MPL-2.0"
 
 [dependencies]
-rand_core = "^0.6"
-dusk-bytes = "^0.1"
-rkyv = { version = "0.7", default-features = false }
-ff = { version = "0.13", default-features = false }
-zeroize = { version = "1", default-features = false, features = ["derive"] }
+rand = { workspace = true }
+dusk-bytes = { workspace = true }
+rkyv = { workspace = true }
+ff = { workspace = true }
+zeroize = { workspace = true, features = ["derive"] }
 
-# rusk dependencies
-execution-core = { version = "0.1.0", path = "../execution-core" }
-wallet-core = { version = "0.1", path = "../wallet-core/" }
-rusk-prover = { version = "0.5", path = "../rusk-prover/" }
+execution-core = { workspace = true }
+wallet-core = { workspace = true }
+rusk-prover = { workspace = true }
 
 [dev-dependencies]
-rand = "^0.8"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/test-wallet/src/imp.rs
+++ b/test-wallet/src/imp.rs
@@ -12,7 +12,7 @@ use alloc::string::FromUtf8Error;
 use alloc::vec::Vec;
 
 use dusk_bytes::Error as BytesError;
-use rand_core::{CryptoRng, Error as RngError, RngCore};
+use rand::{CryptoRng, Error as RngError, RngCore};
 use rkyv::ser::serializers::{
     AllocScratchError, CompositeSerializerError, SharedSerializeMapError,
 };

--- a/wallet-core/Cargo.toml
+++ b/wallet-core/Cargo.toml
@@ -7,24 +7,21 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-dusk-bytes = "0.1"
-bytecheck = { version = "0.6", default-features = false }
-zeroize = { version = "1", default-features = false, features = ["derive"] }
-rand_chacha = { version = "0.3", default-features = false }
-blake3 = { version = "1", default-features = false }
-sha2 = { version = "0.10", default-features = false }
-rand = { version = "0.8", default-features = false }
-ff = { version = "0.13", default-features = false }
-poseidon-merkle = { version = "0.7", features = ["rkyv-impl"] }
-execution-core = { version = "0.1", path = "../execution-core/" }
-rkyv = { version = "0.7", default-features = false, features = ["alloc"] }
+dusk-bytes = { workspace = true }
+bytecheck = { workspace = true }
+zeroize = { workspace = true, features = ["derive"] }
+rand_chacha = { workspace = true }
+blake3 = { workspace = true }
+sha2 = { workspace = true }
+rand = { workspace = true }
+ff = { workspace = true }
+execution-core = { workspace = true }
+rkyv = { workspace = true, features = ["alloc"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-dlmalloc = { version = "0.2", features = ["global"] }
+dlmalloc = { workspace = true, features = ["global"] }
 
 [dev-dependencies]
-rand = "0.8"
-rkyv = "0.7"
-bytecheck = "0.6"
+rand = { workspace = true, features = ["std_rng"] }
 
 [features]

--- a/wallet-core/src/lib.rs
+++ b/wallet-core/src/lib.rs
@@ -11,6 +11,8 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(clippy::pedantic)]
 #![feature(try_trait_v2)]
+#![cfg_attr(not(target_family = "wasm"), deny(unused_crate_dependencies))]
+#![deny(unused_extern_crates)]
 
 #[cfg(target_family = "wasm")]
 #[global_allocator]


### PR DESCRIPTION
**Workspace internal dependencies**
These dependencies are not frozen to their patches-releases since they are all part of the same workspace which patch-freezes all 3rd-party dependencies anyway.
```rust
dusk-consensus = { version = "0.1.1-rc.3", path = "./consensus/" }
execution-core = { version = "0.1.0", path = "./execution-core/" }
license-circuits = { version = "0.1.0", path = "./circuits/license/" }
node = { version = "0.1.0", path = "./node/" }
node-data = { version = "0.1.0", path = "./node-data/" }
rusk-abi = { version = "0.13.0-rc.0", path = "./rusk-abi/", default-features = false }
rusk-profile = { version = "0.6.0", path = "./rusk-profile/" }
rusk-prover = { version = "0.5.0", path = "./rusk-prover/" }
rusk-recovery = { version = "0.6.0", path = "./rusk-recovery/" }
wallet-core = { version = "0.1.0", path = "./wallet-core/"
```

**Dusk dependencies outside the workspace**
These dependencies are managed by Dusk but still need to be patch-frozen if they themselves don't patch-freeze 3rd-party dependencies.
```rust
bls12_381-bls = { version = "=0.4.0", default-features = false }
dusk-bls12_381 = { version = "=0.13.0", default-features = false }
dusk-bytes = "=0.1.7"
dusk-jubjub = { version = "=0.14.1", default-features = false }
dusk-merkle = "=0.5.3"
dusk-plonk = { version = "=0.20.0", default-features = false }
dusk-poseidon = "=0.40.0"
jubjub-schnorr = { version = "=0.5.0", default-features = false }
kadcast = "=0.7.0-rc.5"
phoenix-circuits = { version = "=0.4.0", default-features = false }
phoenix-core = { version = "=0.32.0", default-features = false }
piecrust = "=0.24.0"
piecrust-uplink = "=0.17.1"
poseidon-merkle = "=0.7.0"
zk-citadel = "=0.14.0"
```

**External dependencies**
These dependencies need to be patch-frozen across the entire workspace since a vulnerability can be introduced by a patch-release.
```rust
aes = "=0.7.5"
anyhow = "=1.0.89"
ark-bn254 = { version = "=0.4.0", default-features = false }
ark-groth16 = { version = "=0.4.0", default-features = false }
ark-relations = { version = "=0.4.0", default-features = false }
ark-serialize = { version = "=0.4.2", default-features = false }
async-channel = "=1.9.0"
async-graphql = "=5.0.10"
async-trait = "=0.1.83"
base64 = "=0.22.1"
blake2b_simd = { version = "=1.0.2", default-features = false }
blake3 = { version = "=1.5.4", default-features = false }
block-modes = "=0.8.1"
bs58 = "=0.4.0"
bytecheck = { version = "=0.6.12", default-features = false }
cargo_toml = "=0.15.3"
chrono = "=0.4.38"
clap = "=4.4.18"
console = "=0.12.0"
criterion = "=0.5.1"
crossterm = "=0.25.0"
dirs = "=4.0.0"
dlmalloc = "=0.2.6"
fake = "=2.9.2"
ff = { version = "=0.13.0", default-features = false }
flate2 = "=1.0.33"
flume = "=0.10.14"
futures = "=0.3.30"
futures-util = "=0.3.30"
hex = "=0.4.3"
http-body-util = "=0.1.2"
http_req = "=0.8.1"
humantime-serde = "=1.1.1"
hyper = "=1.4.1"
hyper-tungstenite = "=0.13.0"
hyper-util = "=0.1.9"
konst = "=0.3.9"
lazy_static = "=1.5.0"
lru = "=0.12.4"
memory-stats = "=1.2.0"
metrics = "=0.22.3"
metrics-exporter-prometheus = "=0.14.0"
num-bigint = { version = "=0.4.6", default-features = false }
once_cell = "=1.19.0"
open = "=2.1.3"
parking_lot = "=0.12.3"
pin-project = "=1.1.5"
rand = { version = "=0.8.5", default-features = false }
rand_chacha = { version = "=0.3.1", default-features = false }
requestty = "=0.5.0"
reqwest = "=0.12.7"
ringbuffer = "=0.15.0"
rkyv = { version = "=0.7.39", default-features = false }
rocksdb = { version = "=0.22.0", default-features = false }
rustc_tools_util = "=0.3.0"
rustls-pemfile = "=2.1.3"
semver = "=1.0.23"
serde = "=1.0.210"
serde_derive = "=1.0.210"
serde_json = "=1.0.128"
serde_with = "=3.9.0"
sha2 = { version = "0.10.8", default-features = false }
sha3 = "=0.10.8"
smallvec = "=1.13.2"
sqlx = "=0.8.2"
tar = "=0.4.42"
tempdir = "=0.3.7"
tempfile = "=3.12.0"
thiserror = "=1.0.64"
time-util = "=0.3.4"
tiny-bip39 = "=0.8.2"
tokio = "=1.40.0"
tokio-rustls = "=0.26.0"
tokio-stream = "=0.1.16"
tokio-util = "=0.7.12"
toml = "=0.7.8"
tracing = "=0.1.40"
tracing-subscriber = "=0.3.18"
tungstenite = "=0.21.0"
url = "=2.5.2"
version_check = "=0.9.5"
zeroize = { version = "=1.8.1", default-features = false }
zip = "=0.5.13"
```

This PR also adds lints to detect unused dependencies to all workspace members that define a library only (as opposed to those that define both a library and binary like `rusk` and `rusk-wallet`). The lints give false positive when used for crates that define both.