### PR TITLE
rusk: refactor CLI sub commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,4 @@ COPY --from=build-stage /opt/rusk/target/release/rusk /opt/rusk/
 COPY --from=build-stage /opt/rusk/examples/consensus.keys /opt/rusk/consensus.keys
 COPY --from=build-stage /opt/rusk/examples/genesis.toml /opt/rusk/state.toml
 
-CMD ./rusk recovery-state --init /opt/rusk/state.toml -o /tmp/state; ./rusk -s /tmp/state --consensus-keys-path /opt/rusk/consensus.keys --http-listen-addr 0.0.0.0:8080
+CMD ./rusk recovery state --init /opt/rusk/state.toml -o /tmp/state; ./rusk -s /tmp/state --consensus-keys-path /opt/rusk/consensus.keys --http-listen-addr 0.0.0.0:8080

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Run a single full-node cluster with example state.
 
 ```bash
 # Generate genesis state
-cargo r --release -p rusk -- recovery-state --init examples/genesis.toml -o /tmp/example.state
+cargo r --release -p rusk -- recovery state --init examples/genesis.toml -o /tmp/example.state
 
 # Launch a local ephemeral node
 DUSK_CONSENSUS_KEYS_PASS=password cargo r --release -p rusk -- -s /tmp/example.state

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -318,4 +318,14 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> ChainSrv<N, DB, VM> {
 
         Ok(block)
     }
+
+    pub async fn revert_last_final(&self) -> anyhow::Result<()> {
+        self.acceptor
+            .as_ref()
+            .expect("Chain to be initialized")
+            .read()
+            .await
+            .try_revert(acceptor::RevertTarget::LastFinalizedState)
+            .await
+    }
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -168,6 +168,10 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> Node<N, DB, VM> {
         self.network.clone()
     }
 
+    pub fn vm_handler(&self) -> Arc<RwLock<VM>> {
+        self.vm_handler.clone()
+    }
+
     pub async fn initialize(
         &self,
         services: &mut [Box<dyn LongLivedService<N, DB, VM>>],

--- a/node/testbed.sh
+++ b/node/testbed.sh
@@ -14,7 +14,7 @@ run_node() {
     local NODE_FOLDER="${TEMPD}/node_${ID}"
     local RUSK_STATE_PATH="${NODE_FOLDER}/state"
 
-    RUSK_STATE_PATH="${RUSK_STATE_PATH}" cargo r --release -p rusk -- recovery-state --init "$GENESIS_PATH"
+    RUSK_STATE_PATH="${RUSK_STATE_PATH}" cargo r --release -p rusk -- recovery state --init "$GENESIS_PATH"
     
     echo "Starting node $ID ..."
     RUSK_STATE_PATH="${RUSK_STATE_PATH}" $TOOL_BIN \

--- a/rusk-recovery/config/example.toml
+++ b/rusk-recovery/config/example.toml
@@ -2,7 +2,7 @@
 #
 # The url can be either remote or local (eg: file:///path/state.zip)
 # The content of the file shall be the same format generated 
-# by `rusk recovery-state --output <state.zip>` command
+# by `rusk recovery state --output <state.zip>` command
 # If no base_state is specified a local one will be generated
 base_state = "https://dusk-infra.ams3.digitaloceanspaces.com/keys/genesis.zip"
 

--- a/rusk/Makefile
+++ b/rusk/Makefile
@@ -37,6 +37,11 @@ clippy: ## Run clippy
 		--features chain \
 		--release \
 		-- -D warnings
+	@cargo clippy \
+		--no-default-features \
+		--features archive \
+		--release \
+		-- -D warnings
 	@cargo check --benches --features testwallet
 
 doc: ## Run doc gen
@@ -59,14 +64,14 @@ recovery-keys: ## Build circuit keys
 		--no-default-features \
 		--features recovery-keys \
 		--release \
-		-- recovery-keys
+		-- recovery keys
 
 recovery-state: ## Build network state
 	@cargo r \
 		--no-default-features \
 		--features recovery-state \
 		--release \
-		-- recovery-state \
+		-- recovery state \
 		--init $(INITFILE)
 
 .PHONY: test help clippy build build-bench bench recovery-keys recovery-state rusk

--- a/rusk/src/bin/args.rs
+++ b/rusk/src/bin/args.rs
@@ -4,8 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#[cfg(any(feature = "recovery-state", feature = "recovery-keys"))]
-mod command;
+pub(crate) mod command;
 #[cfg(feature = "recovery-state")]
 mod state;
 
@@ -97,8 +96,7 @@ pub struct Args {
     /// Kadcast network id
     pub kadcast_network_id: Option<u8>,
 
-    #[cfg(any(feature = "recovery-state", feature = "recovery-keys"))]
-    /// Command
+    /// Utility commands
     #[clap(subcommand)]
     pub command: Option<command::Command>,
 }

--- a/rusk/src/bin/args/command.rs
+++ b/rusk/src/bin/args/command.rs
@@ -4,83 +4,22 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use clap::builder::BoolishValueParser;
+#[cfg(any(feature = "recovery-state", feature = "recovery-keys"))]
+pub mod recovery;
+
+#[cfg(feature = "chain")]
+pub mod chain;
+
 use clap::Subcommand;
-use rusk_recovery_tools::Theme;
-use std::io;
-use tracing::info;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(PartialEq, Eq, Hash, Clone, Subcommand, Debug)]
 pub enum Command {
-    #[cfg(feature = "recovery-keys")]
-    RecoveryKeys {
-        /// Keeps untracked keys
-        #[clap(short, long, value_parser = BoolishValueParser::new(), env = "RUSK_KEEP_KEYS")]
-        keep: bool,
+    #[cfg(any(feature = "recovery-state", feature = "recovery-keys"))]
+    #[clap(subcommand)]
+    Recovery(recovery::RecoveryCommand),
 
-        /// URL of the server to download the CRS from
-        #[clap(
-            long,
-            default_value = "https://nodes.dusk.network/trusted-setup",
-            env = "RUSK_CRS_URL"
-        )]
-        crs_url: String,
-    },
-
-    #[cfg(feature = "recovery-state")]
-    RecoveryState {
-        /// Forces a build/download even if the state is in the profile path.
-        #[clap(short = 'f', value_parser = BoolishValueParser::new(), long, env = "RUSK_FORCE_STATE")]
-        force: bool,
-
-        /// Create a state applying the init config specified in this file.
-        #[clap(short, long, value_parser, env = "RUSK_RECOVERY_INPUT")]
-        init: Option<super::PathBuf>,
-
-        /// If specified, the generated state is written on this file instead
-        /// of save the state in the profile path.
-        #[clap(short, long, value_parser, num_args(1))]
-        output: Option<super::PathBuf>,
-    },
-}
-
-impl Command {
-    fn display_env(theme: &Theme) -> io::Result<()> {
-        let profile_dir = rusk_profile::get_rusk_profile_dir()?;
-        let circuits_dir = rusk_profile::get_rusk_circuits_dir()?;
-        let keys_dir = rusk_profile::get_rusk_keys_dir()?;
-        let state_dir = rusk_profile::get_rusk_state_dir()?;
-
-        info!("{} {}", theme.info("PROFILE"), profile_dir.display());
-        info!("{} {}", theme.info("CIRCUITS"), circuits_dir.display());
-        info!("{} {}", theme.info("KEYS"), keys_dir.display());
-        info!("{} {}", theme.info("STATE"), state_dir.display());
-        Ok(())
-    }
-
-    pub fn run(self) -> Result<(), Box<dyn std::error::Error>> {
-        let theme = Theme::default();
-
-        Self::display_env(&theme)?;
-
-        let result = match self {
-            #[cfg(feature = "recovery-state")]
-            Self::RecoveryState {
-                force,
-                init,
-                output,
-            } => super::state::recovery_state(init, force, output),
-            #[cfg(feature = "recovery-keys")]
-            Self::RecoveryKeys { keep, crs_url } => {
-                rusk_recovery_tools::keys::exec(keep, crs_url)
-            }
-        };
-
-        if let Err(e) = &result {
-            tracing::error!("{} {e}", theme.error("Error"));
-        }
-
-        result
-    }
+    #[cfg(feature = "chain")]
+    #[clap(subcommand)]
+    Chain(chain::ChainCommand),
 }

--- a/rusk/src/bin/args/command/chain.rs
+++ b/rusk/src/bin/args/command/chain.rs
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use clap::Subcommand;
+
+#[derive(PartialEq, Eq, Hash, Clone, Subcommand, Debug)]
+pub enum ChainCommand {
+    /// Revert chain state to last final state
+    Revert,
+}

--- a/rusk/src/bin/args/command/recovery.rs
+++ b/rusk/src/bin/args/command/recovery.rs
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use clap::builder::BoolishValueParser;
+use clap::Subcommand;
+use rusk_recovery_tools::Theme;
+use std::io;
+use tracing::info;
+
+#[allow(clippy::large_enum_variant)]
+#[derive(PartialEq, Eq, Hash, Clone, Subcommand, Debug)]
+pub enum RecoveryCommand {
+    #[cfg(feature = "recovery-keys")]
+    /// Check ZK keys and regenerate them if missing
+    Keys {
+        /// Keeps untracked keys
+        #[clap(short, long, value_parser = BoolishValueParser::new(), env = "RUSK_KEEP_KEYS")]
+        keep: bool,
+
+        /// URL of the server to download the CRS from
+        #[clap(
+            long,
+            default_value = "https://nodes.dusk.network/trusted-setup",
+            env = "RUSK_CRS_URL"
+        )]
+        crs_url: String,
+    },
+
+    #[cfg(feature = "recovery-state")]
+    /// Check VM state and create a new one if missing
+    State {
+        /// Forces a build/download even if the state is in the profile path.
+        #[clap(short = 'f', value_parser = BoolishValueParser::new(), long, env = "RUSK_FORCE_STATE")]
+        force: bool,
+
+        /// Create a state applying the init config specified in this file.
+        #[clap(short, long, value_parser, env = "RUSK_RECOVERY_INPUT")]
+        init: Option<std::path::PathBuf>,
+
+        /// If specified, the generated state is written on this file instead
+        /// of save the state in the profile path.
+        #[clap(short, long, value_parser, num_args(1))]
+        output: Option<std::path::PathBuf>,
+    },
+}
+
+impl RecoveryCommand {
+    fn display_env(theme: &Theme) -> io::Result<()> {
+        let profile_dir = rusk_profile::get_rusk_profile_dir()?;
+        let circuits_dir = rusk_profile::get_rusk_circuits_dir()?;
+        let keys_dir = rusk_profile::get_rusk_keys_dir()?;
+        let state_dir = rusk_profile::get_rusk_state_dir()?;
+
+        info!("{} {}", theme.info("PROFILE"), profile_dir.display());
+        info!("{} {}", theme.info("CIRCUITS"), circuits_dir.display());
+        info!("{} {}", theme.info("KEYS"), keys_dir.display());
+        info!("{} {}", theme.info("STATE"), state_dir.display());
+        Ok(())
+    }
+
+    pub fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+        let theme = Theme::default();
+
+        Self::display_env(&theme)?;
+
+        let result = match self {
+            #[cfg(feature = "recovery-state")]
+            Self::State {
+                force,
+                init,
+                output,
+            } => crate::args::state::recovery_state(init, force, output),
+            #[cfg(feature = "recovery-keys")]
+            Self::Keys { keep, crs_url } => {
+                rusk_recovery_tools::keys::exec(keep, crs_url)
+            }
+        };
+
+        if let Err(e) = &result {
+            tracing::error!("{} {e}", theme.error("Error"));
+        }
+
+        result
+    }
+}


### PR DESCRIPTION
- Move `recovery-keys` to `recovery keys`
- Move `recovery-state` to `recovery state`
- Add `chain revert`

This PR is just MVP, future refactor should pass the Command to the right component (to avoid expose any single function needed like I did for the revert)

Additionally, moving the command into distinct subcommand activated by features, will allow us to add commands related to features like:
- `rusk archive compress`
- `rusk wallet unstake`
and so on...