### PR TITLE
rusk: add support for configurable HTTP headers

### DIFF
--- a/rusk/default.config.toml
+++ b/rusk/default.config.toml
@@ -8,6 +8,16 @@
 #cert = <path_of_pem>
 #key = <path_of_key>
 
+# The default max cost for feeder calls is the maximum representable. Put in a
+# normal number to change
+#feeder_call_gas = u64::MAX 
+
+#ws_sub_channel_cap = 16,
+#ws_event_channel_cap = 1024,
+
+# Custom headers to put into every HTTP response. By default none are added.
+#headers = [["name1", "value1"], ["name2", "value2"]]
+
 [chain]
 #db_path = '/home/user/.dusk/rusk'
 #consensus_keys_path = '/home/user/.dusk/rusk/consensus.keys'

--- a/rusk/src/bin/config/http.rs
+++ b/rusk/src/bin/config/http.rs
@@ -6,6 +6,7 @@
 
 use std::path::PathBuf;
 
+use hyper::HeaderMap;
 use serde::{Deserialize, Serialize};
 
 use crate::args::Args;
@@ -23,6 +24,8 @@ pub struct HttpConfig {
     pub ws_sub_channel_cap: usize,
     #[serde(default = "default_ws_event_channel_cap")]
     pub ws_event_channel_cap: usize,
+    #[serde(with = "vec_header_map", default = "default_http_headers")]
+    pub headers: HeaderMap,
 }
 
 impl Default for HttpConfig {
@@ -30,6 +33,7 @@ impl Default for HttpConfig {
         Self {
             cert: None,
             key: None,
+            headers: default_http_headers(),
             listen: default_listen(),
             feeder_call_gas: default_feeder_call_gas(),
             listen_address: None,
@@ -55,6 +59,10 @@ const fn default_ws_event_channel_cap() -> usize {
     1024
 }
 
+fn default_http_headers() -> HeaderMap {
+    HeaderMap::new()
+}
+
 impl HttpConfig {
     pub fn listen_addr(&self) -> String {
         self.listen_address
@@ -67,5 +75,116 @@ impl HttpConfig {
         if let Some(http_listen_addr) = &args.http_listen_addr {
             self.listen_address = Some(http_listen_addr.into());
         }
+    }
+}
+
+mod vec_header_map {
+    use super::*;
+
+    use std::fmt;
+
+    use serde::de::{Deserializer, Error as _, SeqAccess, Visitor};
+    use serde::ser::{Error as _, SerializeSeq, Serializer};
+
+    use hyper::header::{HeaderName, HeaderValue};
+
+    pub fn serialize<S>(
+        headers: &HeaderMap,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let tuple_vec_len = headers.len();
+        let mut tuple_vec = Vec::with_capacity(tuple_vec_len);
+
+        for (k, v) in headers {
+            let k_str = k.as_str();
+            let v_str = v.to_str().map_err(S::Error::custom)?;
+
+            tuple_vec.push((k_str, v_str));
+        }
+
+        let mut seq = serializer.serialize_seq(Some(tuple_vec_len))?;
+        for elem in tuple_vec {
+            seq.serialize_element(&elem)?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<HeaderMap, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TupleVecVisitor;
+
+        impl<'de> Visitor<'de> for TupleVecVisitor {
+            type Value = Vec<(&'de str, &'de str)>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a tuple header name and value")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let tuple_vec_len = seq.size_hint().unwrap_or_default();
+                let mut tuple_vec = Vec::with_capacity(tuple_vec_len);
+
+                while let Some(elem) = seq.next_element()? {
+                    tuple_vec.push(elem);
+                }
+
+                Ok(tuple_vec)
+            }
+        }
+
+        let tuple_vec = deserializer.deserialize_seq(TupleVecVisitor)?;
+
+        let mut headers = HeaderMap::with_capacity(tuple_vec.len());
+        for (k, v) in tuple_vec {
+            let name = HeaderName::from_bytes(k.as_bytes())
+                .map_err(D::Error::custom)?;
+            let value = HeaderValue::from_str(v).map_err(D::Error::custom)?;
+            headers.insert(name, value);
+        }
+
+        Ok(headers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyper::http::HeaderValue;
+
+    #[test]
+    fn serialize_config() {
+        let mut config = HttpConfig::default();
+
+        config
+            .headers
+            .insert("name1", HeaderValue::from_str("value1").unwrap());
+        config
+            .headers
+            .insert("name2", HeaderValue::from_str("value2").unwrap());
+
+        let toml = toml::to_string(&config)
+            .expect("serializing configuration should succeed");
+
+        println!("{toml}");
+    }
+
+    #[test]
+    fn deserialize_config() {
+        let config_str = r#"listen = true
+                            feeder_call_gas = 18446744
+                            ws_sub_channel_cap = 16
+                            ws_event_channel_cap = 1024
+                            headers = [["name1", "value1"], ["name2", "value2"]]"#;
+
+        toml::from_str::<HttpConfig>(config_str)
+            .expect("deserializing config should succeed");
     }
 }

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -91,6 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             address: config.http.listen_addr(),
             cert: config.http.cert,
             key: config.http.key,
+            headers: config.http.headers,
             ws_event_channel_cap: config.http.ws_event_channel_cap,
         };
         node_builder = node_builder.with_http(http_builder)

--- a/rusk/src/lib/builder/http_only.rs
+++ b/rusk/src/lib/builder/http_only.rs
@@ -44,6 +44,7 @@ impl RuskHttpBuilder {
                     rues_receiver,
                     http.ws_event_channel_cap,
                     http.address,
+                    http.headers,
                     cert_and_key,
                 )
                 .await?,

--- a/rusk/src/lib/builder/node.rs
+++ b/rusk/src/lib/builder/node.rs
@@ -225,6 +225,7 @@ impl RuskNodeBuilder {
                     rues_receiver,
                     http.ws_event_channel_cap,
                     http.address,
+                    http.headers,
                     cert_and_key,
                 )
                 .await?,


### PR DESCRIPTION
This commit adds support for using `rusk`'s TOML configuration file to specify headers to be sent as a response to *every* HTTP response.

It is useful for any number of possible scenarios, such as setting CORS for a specific site, providing IDs to nodes in larger infrastructure, etc...

Resolves: #2454