### PR TITLE
rusk: fix HTTP preverification

### DIFF
--- a/node/src/database.rs
+++ b/node/src/database.rs
@@ -51,6 +51,10 @@ pub trait DB: Send + Sync + 'static {
     where
         F: for<'a> FnOnce(&Self::P<'a>) -> Result<T>;
 
+    fn update_dry_run<F, T>(&self, dry_run: bool, f: F) -> Result<T>
+    where
+        F: for<'a> FnOnce(&Self::P<'a>) -> Result<T>;
+
     fn close(&mut self);
 }
 
@@ -183,6 +187,7 @@ pub trait Persist:
 
     fn clear_database(&self) -> Result<()>;
     fn commit(self) -> Result<()>;
+    fn rollback(self) -> Result<()>;
 }
 
 pub fn into_array<const N: usize>(value: &[u8]) -> [u8; N] {

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -131,7 +131,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
                             Payload::Transaction(tx) => {
                                 let accept = self.accept_tx(&db, &vm, tx);
                                 if let Err(e) = accept.await {
-                                    error!("{}", e);
+                                    error!("Tx {} not accepted: {e}", hex::encode(tx.id()));
                                     continue;
                                 }
 

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -26,7 +26,7 @@ use tracing::{error, info, warn};
 const TOPICS: &[u8] = &[Topics::Tx as u8];
 
 #[derive(Debug, Error)]
-enum TxAcceptanceError {
+pub enum TxAcceptanceError {
     #[error("this transaction exists in the mempool")]
     AlreadyExistsInMempool,
     #[error("this transaction exists in the ledger")]
@@ -129,7 +129,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
                     if let Ok(msg) = msg {
                         match &msg.payload {
                             Payload::Transaction(tx) => {
-                                let accept = self.accept_tx::<DB, VM>(&db, &vm, tx);
+                                let accept = self.accept_tx(&db, &vm, tx);
                                 if let Err(e) = accept.await {
                                     error!("{}", e);
                                     continue;
@@ -161,12 +161,40 @@ impl MempoolSrv {
         vm: &Arc<RwLock<VM>>,
         tx: &Transaction,
     ) -> Result<(), TxAcceptanceError> {
+        let max_mempool_txn_count = self.conf.max_mempool_txn_count;
+
+        let events =
+            MempoolSrv::check_tx(db, vm, tx, false, max_mempool_txn_count)
+                .await?;
+
+        tracing::info!(
+            event = "transaction accepted",
+            hash = hex::encode(tx.id())
+        );
+
+        for tx_event in events {
+            let node_event = tx_event.into();
+            if let Err(e) = self.event_sender.try_send(node_event) {
+                warn!("cannot notify mempool accepted transaction {e}")
+            };
+        }
+
+        Ok(())
+    }
+
+    pub async fn check_tx<'t, DB: database::DB, VM: vm::VMExecution>(
+        db: &Arc<RwLock<DB>>,
+        vm: &Arc<RwLock<VM>>,
+        tx: &'t Transaction,
+        dry_run: bool,
+        max_mempool_txn_count: usize,
+    ) -> Result<Vec<TransactionEvent<'t>>, TxAcceptanceError> {
         let tx_id = tx.id();
 
         // Perform basic checks on the transaction
         db.read().await.view(|view| {
             let count = view.txs_count();
-            if count >= self.conf.max_mempool_txn_count {
+            if count >= max_mempool_txn_count {
                 return Err(TxAcceptanceError::MaxTxnCountExceeded(count));
             }
 
@@ -191,7 +219,7 @@ impl MempoolSrv {
         let mut events = vec![];
 
         // Try to add the transaction to the mempool
-        db.read().await.update(|db| {
+        db.read().await.update_dry_run(dry_run, |db| {
             let spend_ids = tx.to_spend_ids();
 
             // ensure spend_ids do not exist in the mempool
@@ -216,20 +244,7 @@ impl MempoolSrv {
 
             db.add_tx(tx, now)
         })?;
-
-        tracing::info!(
-            event = "transaction accepted",
-            hash = hex::encode(tx_id)
-        );
-
-        for tx_event in events {
-            let node_event = tx_event.into();
-            if let Err(e) = self.event_sender.try_send(node_event) {
-                warn!("cannot notify mempool accepted transaction {e}")
-            };
-        }
-
-        Ok(())
+        Ok(events)
     }
 
     /// Requests full mempool data from N alive peers

--- a/rusk-wallet/src/error.rs
+++ b/rusk-wallet/src/error.rs
@@ -114,7 +114,7 @@ pub enum Error {
     #[error("Cache database corrupted")]
     CacheDatabaseCorrupted,
     /// Prover errors from execution-core
-    #[error("Prover Error")]
+    #[error("Prover Error: {0}")]
     ProverError(String),
     /// Memo provided is too large
     #[error("Memo too large {0}")]

--- a/rusk/src/lib/http/rusk.rs
+++ b/rusk/src/lib/http/rusk.rs
@@ -31,6 +31,9 @@ impl HandleRequest for Rusk {
             // here just for backward compatibility
             return false;
         }
+        if route.2.starts_with("prove_") {
+            return false;
+        }
         matches!(
             route,
             (Target::Contract(_), ..) | (Target::Host(_), "rusk", _)

--- a/rusk/src/lib/http/rusk.rs
+++ b/rusk/src/lib/http/rusk.rs
@@ -25,8 +25,14 @@ const RUSK_FEEDER_HEADER: &str = "Rusk-Feeder";
 #[async_trait]
 impl HandleRequest for Rusk {
     fn can_handle(&self, request: &MessageRequest) -> bool {
+        let route = request.event.to_route();
+        if matches!(route, (Target::Host(_), "rusk", "preverify")) {
+            // moved to chain
+            // here just for backward compatibility
+            return false;
+        }
         matches!(
-            &request.event.to_route(),
+            route,
             (Target::Contract(_), ..) | (Target::Host(_), "rusk", _)
         )
     }
@@ -34,7 +40,6 @@ impl HandleRequest for Rusk {
         #[allow(clippy::match_like_matches_macro)]
         match request.uri.inner() {
             ("contracts", Some(_), _) => true,
-            ("transactions", _, "preverify") => true,
             ("node", _, "provisioners") => true,
             ("node", _, "crs") => true,
             _ => false,
@@ -50,9 +55,6 @@ impl HandleRequest for Rusk {
                 let data = request.data.as_bytes();
                 self.handle_contract_query(contract_id, method, data, feeder)
             }
-            ("transactions", _, "preverify") => {
-                self.handle_preverify(request.data.as_bytes())
-            }
             ("node", _, "provisioners") => self.get_provisioners(),
             ("node", _, "crs") => self.get_crs(),
             _ => Err(anyhow::anyhow!("Unsupported")),
@@ -67,9 +69,6 @@ impl HandleRequest for Rusk {
             (Target::Contract(_), ..) => {
                 let feeder = request.header(RUSK_FEEDER_HEADER).is_some();
                 self.handle_contract_query_legacy(&request.event, feeder)
-            }
-            (Target::Host(_), "rusk", "preverify") => {
-                self.handle_preverify(request.event_data())
             }
             (Target::Host(_), "rusk", "provisioners") => {
                 self.get_provisioners()
@@ -122,13 +121,6 @@ impl Rusk {
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             Ok(ResponseData::new(data))
         }
-    }
-
-    fn handle_preverify(&self, data: &[u8]) -> anyhow::Result<ResponseData> {
-        let tx = execution_core::transfer::Transaction::from_slice(data)
-            .map_err(|e| anyhow::anyhow!("Invalid Data {e:?}"))?;
-        self.preverify(&tx.into())?;
-        Ok(ResponseData::new(DataType::None))
     }
 
     fn get_provisioners(&self) -> anyhow::Result<ResponseData> {


### PR DESCRIPTION
Allow preverification of transactions based on the full mempool acceptance