### PR TITLE
Update transfer events

### DIFF
--- a/contracts/transfer/src/transitory.rs
+++ b/contracts/transfer/src/transitory.rs
@@ -92,7 +92,7 @@ pub fn put_transaction(tx: impl Into<Transaction>) {
     unsafe {
         let tx = tx.into();
 
-        let sender = tx.from_account().copied();
+        let sender = tx.moonlight_sender().copied();
         let value = tx.deposit();
 
         let mut deposit = Deposit::None;

--- a/execution-core/tests/serialization.rs
+++ b/execution-core/tests/serialization.rs
@@ -134,9 +134,8 @@ fn new_moonlight_tx<R: RngCore + CryptoRng>(
     rng: &mut R,
     data: Option<TransactionData>,
 ) -> Transaction {
-    let from_sk = AccountSecretKey::random(rng);
-    let to_account =
-        Some(AccountPublicKey::from(&AccountSecretKey::random(rng)));
+    let sender_sk = AccountSecretKey::random(rng);
+    let receiver = Some(AccountPublicKey::from(&AccountSecretKey::random(rng)));
 
     let value: u64 = rng.gen();
     let deposit: u64 = rng.gen();
@@ -145,7 +144,7 @@ fn new_moonlight_tx<R: RngCore + CryptoRng>(
     let nonce: u64 = rng.gen();
 
     Transaction::moonlight(
-        &from_sk, to_account, value, deposit, gas_limit, gas_price, nonce,
+        &sender_sk, receiver, value, deposit, gas_limit, gas_price, nonce,
         CHAIN_ID, data,
     )
     .expect("transaction generation should work")

--- a/node-data/src/events/transactions.rs
+++ b/node-data/src/events/transactions.rs
@@ -84,12 +84,12 @@ impl Serialize for Transaction {
             ProtocolTransaction::Moonlight(m) => {
                 state.serialize_field("type", "moonlight")?;
 
-                let from = m.from_account();
+                let from = m.sender();
                 let from = bs58::encode(from.to_bytes()).into_string();
                 state.serialize_field("from", &from)?;
 
                 let to = m
-                    .to_account()
+                    .receiver()
                     .map(|to| bs58::encode(to.to_bytes()).into_string());
                 state.serialize_field("to", &to)?;
 
@@ -120,7 +120,7 @@ impl Serialize for Transaction {
                     bs58::encode(stealth_address.to_bytes()).into_string(),
                 );
             }
-            if let Some(sender) = tx.sender() {
+            if let Some(sender) = tx.moonlight_sender() {
                 fee.insert("sender", hex::encode(sender.to_bytes()));
             }
             fee

--- a/node-data/src/ledger/transaction.rs
+++ b/node-data/src/ledger/transaction.rs
@@ -92,7 +92,7 @@ impl Transaction {
                 .map(|n| SpendingId::Nullifier(n.to_bytes()))
                 .collect(),
             ProtocolTransaction::Moonlight(m) => {
-                vec![SpendingId::AccountNonce(*m.from_account(), m.nonce())]
+                vec![SpendingId::AccountNonce(*m.sender(), m.nonce())]
             }
         }
     }

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -143,10 +143,9 @@ impl VMExecution for Rusk {
                 }
             }
             ProtocolTransaction::Moonlight(tx) => {
-                let account_data =
-                    self.account(tx.from_account()).map_err(|e| {
-                        anyhow::anyhow!("Cannot check account: {e}")
-                    })?;
+                let account_data = self.account(tx.sender()).map_err(|e| {
+                    anyhow::anyhow!("Cannot check account: {e}")
+                })?;
 
                 let max_value =
                     tx.value() + tx.deposit() + tx.gas_limit() * tx.gas_price();
@@ -158,7 +157,7 @@ impl VMExecution for Rusk {
 
                 if tx.nonce() <= account_data.nonce {
                     let err = crate::Error::RepeatingNonce(
-                        (*tx.from_account()).into(),
+                        (*tx.sender()).into(),
                         tx.nonce(),
                     );
                     return Err(anyhow::anyhow!("Invalid tx: {err}"));

--- a/rusk/src/lib/verifier.rs
+++ b/rusk/src/lib/verifier.rs
@@ -59,7 +59,7 @@ pub fn verify_proof(tx: &PhoenixTransaction) -> Result<bool> {
 pub fn verify_signature(tx: &MoonlightTransaction) -> Result<bool> {
     Ok(rusk_abi::verify_bls(
         tx.signature_message(),
-        *tx.from_account(),
+        *tx.sender(),
         *tx.signature(),
     ))
 }


### PR DESCRIPTION
Changes:
- Use consts for event topics in transfer contract events, so that we can also use that const imported elsewhere to match on topics.
- Renamed "from" & "to" to "sender" & "receiver" for `MoonlightTransactionEvent` and related logic, so that it is consistently called sender/receiver in every context.
- Standardized the field order to sender, receiver, value in all transfer event structs.
- Changed "CONVERT" to "convert" in the self.mint_withdrawal call as it is also lower case for "mint" & "withdraw" calls.

The new sender, receiver, value ordering of fields (as `MoonlightTransactionEvent` already had with from, to, value) made the most sense to me, but I have no hard opinion on it. If there is a problem with it, I can change it back.