### PR TITLE
Improve message propagation and tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ dusk-merkle = "=0.5.3"
 dusk-plonk = { version = "=0.20.0", default-features = false }
 dusk-poseidon = "=0.40.0"
 jubjub-schnorr = { version = "=0.5.0", default-features = false }
-kadcast = "=0.7.0-rc.5"
+kadcast = "=0.7.0-rc.7"
 phoenix-circuits = { version = "=0.4.0", default-features = false }
 phoenix-core = { version = "=0.32.0", default-features = false }
 piecrust = "=0.24.0"

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -402,11 +402,7 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
                     );
                 }
 
-                self.future_msgs.lock().await.put_msg(
-                    msg.header.round,
-                    msg.get_step(),
-                    msg,
-                );
+                self.future_msgs.lock().await.put_msg(msg);
 
                 return None;
             }

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -491,6 +491,7 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
                         msg_step = msg.get_step(),
                         msg_round = msg.header.round,
                         msg_topic = ?msg.topic(),
+                        ray_id = msg.ray_id()
                     );
 
                     self.outbound.try_send(msg.clone());

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -414,7 +414,7 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
         let msg_topic = msg.topic();
         let msg_iter = msg.header.iteration;
         let msg_step = msg.get_step();
-        let msg_round = msg.header.round;
+        let msg_height = msg.header.round;
         trace!("collecting msg {msg:#?}");
 
         let collected = phase
@@ -431,7 +431,7 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
             Ok(HandleMsgOutput::Pending) => None,
             Err(err) => {
                 let event = "failed collect";
-                error!(event, ?err, ?msg_topic, msg_iter, msg_step, msg_round,);
+                error!(event, ?err, ?msg_topic, msg_iter, msg_step, msg_height,);
                 None
             }
         }
@@ -493,7 +493,8 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
                         event = "republish",
                         src = "future_msgs",
                         msg_step = msg.get_step(),
-                        msg_round = msg.header.round,
+                        msg_iter = msg.get_iteration(),
+                        msg_height = msg.get_height(),
                         msg_topic = ?msg.topic(),
                         ray_id = msg.ray_id()
                     );

--- a/consensus/src/iteration_ctx.rs
+++ b/consensus/src/iteration_ctx.rs
@@ -184,6 +184,14 @@ impl<DB: Database> IterationCtx<DB> {
                 next_cfg.step = next_prop_step;
 
                 let next_generator = Committee::new(provisioners, &next_cfg);
+                
+                debug!(
+                  event = "committee_generated",
+                  step = next_cfg.step,
+                  config = ?next_cfg,
+                  members = format!("{}", &next_generator)
+                );
+                
                 self.committees.insert(next_prop_step, next_generator);
             }
         }

--- a/consensus/src/iteration_ctx.rs
+++ b/consensus/src/iteration_ctx.rs
@@ -184,14 +184,14 @@ impl<DB: Database> IterationCtx<DB> {
                 next_cfg.step = next_prop_step;
 
                 let next_generator = Committee::new(provisioners, &next_cfg);
-                
+
                 debug!(
                   event = "committee_generated",
                   step = next_cfg.step,
                   config = ?next_cfg,
                   members = format!("{}", &next_generator)
                 );
-                
+
                 self.committees.insert(next_prop_step, next_generator);
             }
         }

--- a/consensus/src/msg_handler.rs
+++ b/consensus/src/msg_handler.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use node_data::bls::PublicKeyBytes;
 use node_data::message::{Message, Status};
 use node_data::StepName;
-use tracing::{debug, trace, warn};
+use tracing::{debug, warn};
 
 /// Indicates whether an output value is available for current step execution
 /// (Step is Ready) or needs to collect data (Step is Pending)
@@ -45,13 +45,12 @@ pub trait MsgHandler {
     ) -> Result<(), ConsensusError> {
         let signer = msg.get_signer().ok_or(ConsensusError::InvalidMsgType)?;
         debug!(
-            event = "msg received",
+            event = "validating msg",
             signer = signer.to_bs58(),
             topic = ?msg.topic(),
             step = msg.get_step(),
+            ray_id = msg.ray_id(),
         );
-
-        trace!(event = "msg received", msg = format!("{:#?}", msg),);
 
         // We don't verify the tip here, otherwise future round messages will be
         // discarded and not put into the queue

--- a/consensus/src/proposal/step.rs
+++ b/consensus/src/proposal/step.rs
@@ -127,6 +127,6 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
     }
 
     pub fn name(&self) -> &'static str {
-        "sel"
+        "proposal"
     }
 }

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -115,7 +115,8 @@ impl MsgHandler for RatificationHandler {
                     from = p.sign_info().signer.to_bs58(),
                     vote = ?p.vote,
                     msg_step = p.get_step(),
-                    msg_round = p.header().round,
+                    msg_iter = p.header().iteration,
+                    msg_height = p.header().round,
                 );
                 ConsensusError::InvalidVote(p.vote)
             })?;
@@ -179,7 +180,8 @@ impl MsgHandler for RatificationHandler {
                     from = p.sign_info().signer.to_bs58(),
                     vote = ?p.vote,
                     msg_step = p.get_step(),
-                    msg_round = p.header().round,
+                    msg_iter = p.header().iteration,
+                    msg_height = p.header().round,
                 );
             }
         };

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -152,7 +152,8 @@ impl MsgHandler for ValidationHandler {
                     from = p.sign_info().signer.to_bs58(),
                     vote = ?p.vote,
                     msg_step = p.get_step(),
-                    msg_round = p.header().round,
+                    msg_iter = p.header().iteration,
+                    msg_height = p.header().round,
                 );
                 ConsensusError::InvalidVote(p.vote)
             })?;
@@ -226,7 +227,8 @@ impl MsgHandler for ValidationHandler {
                     from = p.sign_info().signer.to_bs58(),
                     vote = ?p.vote,
                     msg_step = p.get_step(),
-                    msg_round = p.header().round,
+                    msg_iter = p.header().iteration,
+                    msg_height = p.header().round,
                 );
             }
         }

--- a/node-data/src/ledger.rs
+++ b/node-data/src/ledger.rs
@@ -31,10 +31,10 @@ use std::io::{self, Read, Write};
 use fake::{Dummy, Fake, Faker};
 
 /// Encode a byte array into a shortened HEX representation.
-pub fn to_str<const N: usize>(bytes: &[u8; N]) -> String {
+pub fn to_str(bytes: &[u8]) -> String {
     const OFFSET: usize = 16;
     let hex = hex::encode(bytes);
-    if N <= OFFSET {
+    if bytes.len() <= OFFSET {
         return hex;
     }
 

--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -147,7 +147,7 @@ impl Message {
             _ => StepName::Proposal.to_step(self.header.iteration),
         }
     }
-    
+
     pub fn get_iteration(&self) -> u8 {
         self.header.iteration
     }

--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -152,6 +152,13 @@ impl Message {
         &self.version
     }
 
+    pub fn ray_id(&self) -> &str {
+        self.metadata
+            .as_ref()
+            .map(|m| m.ray_id.as_str())
+            .unwrap_or_default()
+    }
+
     pub fn with_version(mut self, v: Version) -> Self {
         self.version = v;
         self
@@ -164,6 +171,7 @@ impl Message {
 pub struct Metadata {
     pub height: u8,
     pub src_addr: SocketAddr,
+    pub ray_id: String,
 }
 
 impl Serializable for Message {

--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -147,6 +147,14 @@ impl Message {
             _ => StepName::Proposal.to_step(self.header.iteration),
         }
     }
+    
+    pub fn get_iteration(&self) -> u8 {
+        self.header.iteration
+    }
+
+    pub fn get_height(&self) -> u64 {
+        self.header.round
+    }
 
     pub fn version(&self) -> &Version {
         &self.version

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -147,7 +147,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
                 },
                 // Handles any inbound wire.
                 // Component should either process it or re-route it to the next upper layer
-                recv =  self.inbound.recv() => {
+                recv = self.inbound.recv() => {
                     let msg = recv?;
                     match msg.payload {
                         Payload::Block(blk) => {

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -16,7 +16,7 @@ use dusk_consensus::operations::{
 use dusk_consensus::queue::MsgRegistry;
 use dusk_consensus::user::provisioners::ContextProvisioners;
 use node_data::bls::PublicKeyBytes;
-use node_data::ledger::{Block, Fault, Hash, Header};
+use node_data::ledger::{to_str, Block, Fault, Hash, Header};
 use node_data::message::AsyncQueue;
 
 use tokio::sync::{oneshot, Mutex, RwLock};
@@ -201,7 +201,14 @@ impl<DB: database::DB> CandidateDB<DB> {
 #[async_trait]
 impl<DB: database::DB> dusk_consensus::commons::Database for CandidateDB<DB> {
     async fn store_candidate_block(&mut self, b: Block) {
-        tracing::debug!("store candidate block: {:?}", b);
+        let iter = b.header().iteration;
+        let height = b.header().height;
+        let hash = to_str(&b.header().hash);
+        let prev_hash = to_str(&b.header().prev_block_hash);
+        debug!(
+            event = "store candidate block",
+            height, iter, hash, prev_hash
+        );
         let _ = self
             .db
             .read()

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -13,6 +13,7 @@ use async_trait::async_trait;
 use kadcast::config::Config;
 use kadcast::{MessageInfo, Peer};
 use metrics::counter;
+use node_data::ledger::to_str;
 use node_data::message::payload::{GetResource, Inv, Nonce};
 use node_data::message::{AsyncQueue, Metadata, PROTOCOL_VERSION};
 use node_data::{get_current_timestamp, Serializable};
@@ -65,7 +66,7 @@ impl<const N: usize> kadcast::NetworkListen for Listener<N> {
                 counter!(format!("dusk_inbound_{:?}_count", msg.topic()))
                     .increment(1);
 
-                let ray_id = hex::encode(md.ray_id());
+                let ray_id = to_str(md.ray_id());
                 debug!(
                     event = "msg received",
                     src = ?md.src(),

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -17,7 +17,7 @@ use node_data::message::payload::{GetResource, Inv, Nonce};
 use node_data::message::{AsyncQueue, Metadata, PROTOCOL_VERSION};
 use node_data::{get_current_timestamp, Serializable};
 use tokio::sync::RwLock;
-use tracing::{error, info, trace};
+use tracing::{debug, error, info, trace};
 
 /// Number of alive peers randomly selected which a `flood_request` is sent to
 const REDUNDANCY_PEER_COUNT: usize = 8;
@@ -65,10 +65,20 @@ impl<const N: usize> kadcast::NetworkListen for Listener<N> {
                 counter!(format!("dusk_inbound_{:?}_count", msg.topic()))
                     .increment(1);
 
+                let ray_id = hex::encode(md.ray_id());
+                debug!(
+                    event = "msg received",
+                    topic = ?msg.topic(),
+                    src = ?md.src(),
+                    height = md.height(),
+                    ray_id
+                );
+
                 // Update Transport Data
                 msg.metadata = Some(Metadata {
                     height: md.height(),
                     src_addr: md.src(),
+                    ray_id,
                 });
 
                 // Allow upper layers to fast-discard a message before queueing


### PR DESCRIPTION
- Improve logs related to messages
- Repropagate past-iteration messages in the current round
- Repropagate future messages if signed by eligible provisioners
- Repropagate Candidate messages before the Proposal delay