### PR TITLE
rusk-wallet: Accept string instead of bytes for Memo

### DIFF
--- a/rusk-wallet/src/bin/command.rs
+++ b/rusk-wallet/src/bin/command.rs
@@ -236,7 +236,7 @@ pub(crate) enum Command {
         reward: bool,
     },
 
-    /// Moonlight transaction commands
+    // Moonlight transaction commands
     /// Send DUSK publicly through the network using Moonlight
     MoonlightTransfer {
         /// Moonlight Address from which to send DUSK [default: first address]

--- a/rusk-wallet/src/bin/command.rs
+++ b/rusk-wallet/src/bin/command.rs
@@ -214,7 +214,7 @@ pub(crate) enum Command {
 
         /// memo to attach to the transaction
         #[clap(short, long)]
-        memo: Vec<u8>,
+        memo: String,
 
         /// Max amount of gas for this transaction
         #[clap(short = 'l', long, default_value_t= DEFAULT_STAKE_GAS_LIMIT)]
@@ -236,7 +236,7 @@ pub(crate) enum Command {
         reward: bool,
     },
 
-    // Moonlight transaction commands
+    /// Moonlight transaction commands
     /// Send DUSK publicly through the network using Moonlight
     MoonlightTransfer {
         /// Moonlight Address from which to send DUSK [default: first address]
@@ -373,7 +373,7 @@ pub(crate) enum Command {
 
         /// Memo is additonal info attached to transaction
         #[clap(short, long)]
-        memo: Vec<u8>,
+        memo: String,
 
         /// Max amount of gas for this transaction
         #[clap(short = 'l', long, default_value_t= DEFAULT_LIMIT)]
@@ -831,6 +831,8 @@ impl Command {
 
                 let gas = Gas::new(gas_limit).with_price(gas_price);
 
+                let memo = memo.as_bytes().to_vec();
+
                 let tx = wallet
                     .moonlight_execute(
                         addr,
@@ -856,6 +858,8 @@ impl Command {
                 };
 
                 let gas = Gas::new(gas_limit).with_price(gas_price);
+
+                let memo = memo.as_bytes().to_vec();
 
                 let tx = wallet
                     .phoenix_execute(

--- a/rusk-wallet/src/bin/interactive.rs
+++ b/rusk-wallet/src/bin/interactive.rs
@@ -275,7 +275,7 @@ fn transaction_op_menu_moonlight(
         History => AddrOp::Back,
         Memo => AddrOp::Run(Box::new(Command::MoonlightMemo {
             addr: Some(addr),
-            memo: prompt::request_bytes("memo")?,
+            memo: prompt::request_str("memo")?,
             gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT)?,
             gas_price: prompt::request_gas_price()?,
         })),
@@ -359,7 +359,7 @@ fn transaction_op_menu_phoenix(
         }
         Memo => AddrOp::Run(Box::new(Command::PhoenixMemo {
             addr: Some(addr),
-            memo: prompt::request_bytes("memo")?,
+            memo: prompt::request_str("memo")?,
             gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT)?,
             gas_price: prompt::request_gas_price()?,
         })),


### PR DESCRIPTION
Closes #2524 