### PR TITLE
transfer-contract: Rename functions where a contract sends funds

### DIFF
--- a/contracts/alice/src/lib.rs
+++ b/contracts/alice/src/lib.rs
@@ -35,12 +35,12 @@ mod wasm {
     }
 
     #[no_mangle]
-    unsafe fn transfer_to_contract(arg_len: u32) -> u32 {
-        rusk_abi::wrap_call(arg_len, |arg| STATE.transfer_to_contract(arg))
+    unsafe fn contract_to_contract(arg_len: u32) -> u32 {
+        rusk_abi::wrap_call(arg_len, |arg| STATE.contract_to_contract(arg))
     }
 
     #[no_mangle]
-    unsafe fn transfer_to_account(arg_len: u32) -> u32 {
-        rusk_abi::wrap_call(arg_len, |arg| STATE.transfer_to_account(arg))
+    unsafe fn contract_to_account(arg_len: u32) -> u32 {
+        rusk_abi::wrap_call(arg_len, |arg| STATE.contract_to_account(arg))
     }
 }

--- a/contracts/alice/src/state.rs
+++ b/contracts/alice/src/state.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use execution_core::transfer::{
-    withdraw::Withdraw, TransferToAccount, TransferToContract,
+    withdraw::Withdraw, ContractToAccount, ContractToContract,
     TRANSFER_CONTRACT,
 };
 
@@ -28,19 +28,19 @@ impl Alice {
             .expect("Transparent deposit transaction should succeed");
     }
 
-    pub fn transfer_to_contract(&mut self, transfer: TransferToContract) {
+    pub fn contract_to_contract(&mut self, transfer: ContractToContract) {
         let _: () = rusk_abi::call(
             TRANSFER_CONTRACT,
-            "transfer_to_contract",
+            "contract_to_contract",
             &transfer,
         )
         .expect("Transferring to contract should succeed");
     }
 
-    pub fn transfer_to_account(&mut self, transfer: TransferToAccount) {
+    pub fn contract_to_account(&mut self, transfer: ContractToAccount) {
         rusk_abi::call::<_, ()>(
             TRANSFER_CONTRACT,
-            "transfer_to_account",
+            "contract_to_account",
             &transfer,
         )
         .expect("Transferring to account should succeed");

--- a/contracts/transfer/src/lib.rs
+++ b/contracts/transfer/src/lib.rs
@@ -46,13 +46,13 @@ unsafe fn convert(arg_len: u32) -> u32 {
 }
 
 #[no_mangle]
-unsafe fn transfer_to_contract(arg_len: u32) -> u32 {
-    rusk_abi::wrap_call(arg_len, |arg| STATE.transfer_to_contract(arg))
+unsafe fn contract_to_contract(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |arg| STATE.contract_to_contract(arg))
 }
 
 #[no_mangle]
-unsafe fn transfer_to_account(arg_len: u32) -> u32 {
-    rusk_abi::wrap_call(arg_len, |arg| STATE.transfer_to_account(arg))
+unsafe fn contract_to_account(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |arg| STATE.contract_to_account(arg))
 }
 
 // Queries

--- a/contracts/transfer/src/state.rs
+++ b/contracts/transfer/src/state.rs
@@ -27,13 +27,13 @@ use execution_core::{
         withdraw::{
             Withdraw, WithdrawReceiver, WithdrawReplayToken, WithdrawSignature,
         },
-        ConvertEvent, DepositEvent, MoonlightTransactionEvent,
-        PhoenixTransactionEvent, ReceiveFromContract, Transaction,
-        TransferToAccount, TransferToAccountEvent, TransferToContract,
-        TransferToContractEvent, WithdrawEvent, CONVERT_TOPIC, DEPOSIT_TOPIC,
-        MINT_TOPIC, MOONLIGHT_TOPIC, PANIC_NONCE_NOT_READY, PHOENIX_TOPIC,
-        TRANSFER_CONTRACT, TRANSFER_TO_ACCOUNT_TOPIC,
-        TRANSFER_TO_CONTRACT_TOPIC, WITHDRAW_TOPIC,
+        ContractToAccount, ContractToAccountEvent, ContractToContract,
+        ContractToContractEvent, ConvertEvent, DepositEvent,
+        MoonlightTransactionEvent, PhoenixTransactionEvent,
+        ReceiveFromContract, Transaction, WithdrawEvent,
+        CONTRACT_TO_ACCOUNT_TOPIC, CONTRACT_TO_CONTRACT_TOPIC, CONVERT_TOPIC,
+        DEPOSIT_TOPIC, MINT_TOPIC, MOONLIGHT_TOPIC, PANIC_NONCE_NOT_READY,
+        PHOENIX_TOPIC, TRANSFER_CONTRACT, WITHDRAW_TOPIC,
     },
     BlsScalar, ContractError, ContractId,
 };
@@ -355,7 +355,7 @@ impl TransferState {
     /// it is called by the transfer contract itself), if the call to the
     /// receiving contract fails, or if the sending contract doesn't have enough
     /// funds.
-    pub fn transfer_to_contract(&mut self, transfer: TransferToContract) {
+    pub fn contract_to_contract(&mut self, transfer: ContractToContract) {
         let sender_contract = rusk_abi::caller()
             .expect("A transfer to a contract must happen in the context of a transaction");
 
@@ -389,8 +389,8 @@ impl TransferState {
             .expect("Calling receiver should succeed");
 
         rusk_abi::emit(
-            TRANSFER_TO_CONTRACT_TOPIC,
-            TransferToContractEvent {
+            CONTRACT_TO_CONTRACT_TOPIC,
+            ContractToContractEvent {
                 sender: sender_contract,
                 receiver: transfer.contract,
                 value: transfer.value,
@@ -407,7 +407,7 @@ impl TransferState {
     /// The function will panic if it is not being called by a contract, if it
     /// is called by the transfer contract itself, or if the calling contract
     /// doesn't have enough funds.
-    pub fn transfer_to_account(&mut self, transfer: TransferToAccount) {
+    pub fn contract_to_account(&mut self, transfer: ContractToAccount) {
         let sender_contract = rusk_abi::caller()
             .expect("A transfer to an account must happen in the context of a transaction");
 
@@ -433,8 +433,8 @@ impl TransferState {
         account.balance += transfer.value;
 
         rusk_abi::emit(
-            TRANSFER_TO_ACCOUNT_TOPIC,
-            TransferToAccountEvent {
+            CONTRACT_TO_ACCOUNT_TOPIC,
+            ContractToAccountEvent {
                 sender: sender_contract,
                 receiver: transfer.account,
                 value: transfer.value,

--- a/contracts/transfer/tests/transfer.rs
+++ b/contracts/transfer/tests/transfer.rs
@@ -30,7 +30,7 @@ use execution_core::{
             ViewKey as PhoenixViewKey,
         },
         withdraw::{Withdraw, WithdrawReceiver, WithdrawReplayToken},
-        TransferToAccount, TransferToContract, TRANSFER_CONTRACT,
+        ContractToAccount, ContractToContract, TRANSFER_CONTRACT,
     },
     ContractError, ContractId, JubJubScalar, LUX,
 };
@@ -913,10 +913,10 @@ fn swap_wrong_contract_targeted() {
 }
 
 /// In this test we deposit some Dusk to the Alice contract, and subsequently
-/// proceed to call Alice's `transfer_to_contract` function, targetting Bob as
+/// proceed to call Alice's `contract_to_contract` function, targeting Bob as
 /// the receiver of the transfer.
 #[test]
-fn transfer_to_contract() {
+fn contract_to_contract() {
     const DEPOSIT_VALUE: u64 = MOONLIGHT_GENESIS_VALUE / 2;
     const TRANSFER_VALUE: u64 = DEPOSIT_VALUE / 2;
 
@@ -999,7 +999,7 @@ fn transfer_to_contract() {
     );
     assert_eq!(bob_balance, 0, "Bob must have a balance of zero");
 
-    let transfer = TransferToContract {
+    let transfer = ContractToContract {
         contract: BOB_ID,
         value: TRANSFER_VALUE,
         fn_name: String::from("recv_transfer"),
@@ -1010,7 +1010,7 @@ fn transfer_to_contract() {
         .to_vec();
     let contract_call = Some(ContractCall {
         contract: ALICE_ID,
-        fn_name: String::from("transfer_to_contract"),
+        fn_name: String::from("contract_to_contract"),
         fn_args,
     });
 
@@ -1063,7 +1063,7 @@ fn transfer_to_contract() {
 /// contract, and subsequently call the Alice contract to trigger a transfer
 /// back to the same account.
 #[test]
-fn transfer_to_account() {
+fn contract_to_account() {
     const DEPOSIT_VALUE: u64 = MOONLIGHT_GENESIS_VALUE / 2;
     const TRANSFER_VALUE: u64 = DEPOSIT_VALUE / 2;
 
@@ -1140,7 +1140,7 @@ fn transfer_to_account() {
         "Alice must have the deposit in their balance"
     );
 
-    let transfer = TransferToAccount {
+    let transfer = ContractToAccount {
         account: moonlight_pk,
         value: TRANSFER_VALUE,
     };
@@ -1149,7 +1149,7 @@ fn transfer_to_account() {
         .to_vec();
     let contract_call = Some(ContractCall {
         contract: ALICE_ID,
-        fn_name: String::from("transfer_to_account"),
+        fn_name: String::from("contract_to_account"),
         fn_args,
     });
 
@@ -1197,7 +1197,7 @@ fn transfer_to_account() {
 /// In this test we try to transfer some Dusk from a contract to an account,
 /// when the contract doesn't have sufficient funds.
 #[test]
-fn transfer_to_account_insufficient_funds() {
+fn contract_to_account_insufficient_funds() {
     // Transfer value larger than DEPOSIT
     const DEPOSIT_VALUE: u64 = MOONLIGHT_GENESIS_VALUE / 2;
     const TRANSFER_VALUE: u64 = 2 * DEPOSIT_VALUE;
@@ -1275,7 +1275,7 @@ fn transfer_to_account_insufficient_funds() {
         "Alice must have the deposit in their balance"
     );
 
-    let transfer = TransferToAccount {
+    let transfer = ContractToAccount {
         account: moonlight_pk,
         value: TRANSFER_VALUE,
     };
@@ -1284,7 +1284,7 @@ fn transfer_to_account_insufficient_funds() {
         .to_vec();
     let contract_call = Some(ContractCall {
         contract: ALICE_ID,
-        fn_name: String::from("transfer_to_account"),
+        fn_name: String::from("contract_to_account"),
         fn_args,
     });
 
@@ -1339,7 +1339,7 @@ fn transfer_to_account_insufficient_funds() {
 /// In this test we try to call the function directly - i.e. not initiated by a
 /// contract, but by the transaction itself.
 #[test]
-fn transfer_to_account_direct_call() {
+fn contract_to_account_direct_call() {
     const TRANSFER_VALUE: u64 = MOONLIGHT_GENESIS_VALUE / 2;
 
     let rng = &mut StdRng::seed_from_u64(0xfeeb);
@@ -1362,7 +1362,7 @@ fn transfer_to_account_direct_call() {
         "The depositer account should have the genesis value"
     );
 
-    let transfer = TransferToAccount {
+    let transfer = ContractToAccount {
         account: moonlight_pk,
         value: TRANSFER_VALUE,
     };
@@ -1371,7 +1371,7 @@ fn transfer_to_account_direct_call() {
         .to_vec();
     let contract_call = Some(ContractCall {
         contract: TRANSFER_CONTRACT,
-        fn_name: String::from("transfer_to_account"),
+        fn_name: String::from("contract_to_account"),
         fn_args,
     });
 

--- a/execution-core/src/transfer.rs
+++ b/execution-core/src/transfer.rs
@@ -41,10 +41,10 @@ pub const PANIC_NONCE_NOT_READY: &str = "Nonce not ready to be used yet";
 pub const MOONLIGHT_TOPIC: &str = "moonlight";
 /// Topic for the phoenix transaction event.
 pub const PHOENIX_TOPIC: &str = "phoenix";
-/// Topic for the transfer to contract event.
-pub const TRANSFER_TO_CONTRACT_TOPIC: &str = "transfer_to_contract";
-/// Topic for the transfer to account event.
-pub const TRANSFER_TO_ACCOUNT_TOPIC: &str = "transfer_to_account";
+/// Topic for the contract to contract transaction event.
+pub const CONTRACT_TO_CONTRACT_TOPIC: &str = "contract_to_contract";
+/// Topic for the contract to account transaction event.
+pub const CONTRACT_TO_ACCOUNT_TOPIC: &str = "contract_to_account";
 /// Topic for the withdraw event.
 pub const WITHDRAW_TOPIC: &str = "withdraw";
 /// Topic for the deposit event.

--- a/execution-core/src/transfer.rs
+++ b/execution-core/src/transfer.rs
@@ -355,7 +355,7 @@ impl From<MoonlightTransaction> for Transaction {
 /// its funds to another contract.
 #[derive(Debug, Clone, Archive, PartialEq, Eq, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]
-pub struct TransferToContract {
+pub struct ContractToContract {
     /// Contract to transfer funds to.
     pub contract: ContractId,
     /// Amount to send to the contract.
@@ -383,7 +383,7 @@ pub struct ReceiveFromContract {
 /// its funds to an account.
 #[derive(Debug, Clone, Archive, PartialEq, Eq, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]
-pub struct TransferToAccount {
+pub struct ContractToAccount {
     /// Account to transfer funds to.
     pub account: AccountPublicKey,
     /// Amount to send to the account.
@@ -459,7 +459,7 @@ pub struct DepositEvent {
 /// Event data emitted on a transfer from a contract to a contract.
 #[derive(Debug, Clone, Archive, PartialEq, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]
-pub struct TransferToContractEvent {
+pub struct ContractToContractEvent {
     /// The sender of the funds.
     pub sender: ContractId,
     /// The receiver of the funds.
@@ -471,7 +471,7 @@ pub struct TransferToContractEvent {
 /// Event data emitted on a transfer from a contract to a Moonlight account.
 #[derive(Debug, Clone, Archive, PartialEq, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]
-pub struct TransferToAccountEvent {
+pub struct ContractToAccountEvent {
     /// The sender of the funds.
     pub sender: ContractId,
     /// The receiver of the funds.


### PR DESCRIPTION
Rename:
- `transfer_to_contract` to `contract_to_contract`
- `transfer_to_account` to `contract_to_account`

Note that the `transfer` prefix is not needed since we are in the transfer-contract and hence the `transfer` is name-spaced anyway.