### PR TITLE
rusk-wallet: Add `is_synced()` function call to estimate sync completion

### DIFF
--- a/rusk-wallet/src/clients.rs
+++ b/rusk-wallet/src/clients.rs
@@ -348,6 +348,25 @@ impl State {
         Ok(branch)
     }
 
+    /// Queries the transfer contract for the number of notes.
+    pub async fn fetch_num_notes(&self) -> Result<u64, Error> {
+        let status = self.status;
+        status("Fetching latest note position...");
+
+        let data = self
+            .client
+            .contract_query::<_, _, { u64::SIZE }>(
+                TRANSFER_CONTRACT,
+                "num_notes",
+                &(),
+            )
+            .await?;
+
+        let res: u64 = rkyv::from_bytes(&data).map_err(|_| Error::Rkyv)?;
+
+        Ok(res)
+    }
+
     pub fn close(&mut self) {
         // UNWRAP: its okay to panic here because we're closing the database
         // if there's an error we want an exception to happen

--- a/rusk-wallet/src/wallet.rs
+++ b/rusk-wallet/src/wallet.rs
@@ -1151,6 +1151,15 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         }
     }
 
+    /// Check if the wallet is synced
+    pub async fn is_synced(&mut self) -> Result<bool, Error> {
+        let state = self.state()?;
+        let db_pos = state.cache().last_pos()?.unwrap_or(0);
+        let network_last_pos = state.fetch_num_notes().await? - 1;
+
+        Ok(network_last_pos == db_pos)
+    }
+
     /// Close the wallet and zeroize the seed
     pub fn close(&mut self) {
         self.store.inner_mut().zeroize();


### PR DESCRIPTION
Cherry picks the relevant commits from https://github.com/dusk-network/rusk/pull/2540 with minor changes in the displayed message when the wallet is not synced yet.