### PR TITLE
rusk-prover: Add debug feature to print the circuit-bytes

### DIFF
--- a/rusk-prover/Cargo.toml
+++ b/rusk-prover/Cargo.toml
@@ -12,6 +12,10 @@ dusk-plonk = { workspace = true, features = ["rkyv-impl", "alloc"] }
 rusk-profile = { workspace = true }
 execution-core = { workspace = true, features = ["zk"] }
 
+# debug dependencies
+hex = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+
 [dev-dependencies]
 hex = { workspace = true }
 
@@ -20,3 +24,4 @@ no_random = []
 std = [
     "dusk-plonk/std"
 ]
+debug = ["hex", "tracing"]

--- a/rusk-prover/src/lib.rs
+++ b/rusk-prover/src/lib.rs
@@ -51,6 +51,12 @@ impl Prove for LocalProver {
         #[cfg(feature = "no_random")]
         let rng = &mut StdRng::seed_from_u64(0xbeef);
 
+        #[cfg(feature = "debug")]
+        tracing::info!(
+            "tx_circuit_vec:\n{}",
+            hex::encode(tx_circuit_vec_bytes)
+        );
+
         let (proof, _pi) = match tx_circuit_vec.input_notes_info.len() {
             1 => TX_CIRCUIT_1_2_PROVER
                 .prove(rng, &create_circuit::<1>(tx_circuit_vec)?)

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -84,7 +84,7 @@ test-wallet = { version = "0.1.0", path = "../test-wallet" }
 reqwest = { workspace = true }
 rusk-recovery = { workspace = true, features = ["state"] }
 ff = { workspace = true }
-rusk-prover = { workspace = true, features = ["no_random"] }
+rusk-prover = { workspace = true, features = ["no_random", "debug"] }
 criterion = { workspace = true }
 
 [build-dependencies]


### PR DESCRIPTION
We need to print the circuit-bytes in the rusk tests to be able to update rusk-prover/test/tx_circuit_vec.hex in case of a change of the circuits.
This functionality was lost with the merge of #2135 specifically with the deletion of [line 149 in rusk/tests/common/wallet.rs](https://github.com/dusk-network/rusk/pull/2135/files#diff-f6f5e387d55a9a47a0c1dcac1842bea467aa86a5b0aba2064acc29d8c9fef62dL149).
