### PR TITLE
rusk-wallet: Fix creation of deploy-transaction

### DIFF
--- a/rusk-wallet/Cargo.toml
+++ b/rusk-wallet/Cargo.toml
@@ -41,6 +41,7 @@ rocksdb = { workspace = true }
 flume = { workspace = true }
 reqwest = { workspace = true, features = ["stream"] }
 dusk-bytes = { workspace = true }
+blake2b_simd = { workspace = true }
 
 zeroize = { workspace = true, features = ["derive"] }
 wallet-core = { workspace = true }

--- a/rusk-wallet/src/bin/interactive.rs
+++ b/rusk-wallet/src/bin/interactive.rs
@@ -9,10 +9,10 @@ use requestty::Question;
 use rusk_wallet::{
     currency::Dusk,
     dat::{DatFileVersion, LATEST_VERSION},
-    gas, Address, Error, Wallet, WalletPath, MAX_ADDRESSES,
+    gas::{self},
+    Address, Error, Wallet, WalletPath, MAX_ADDRESSES,
 };
 
-use crate::command::DEFAULT_STAKE_GAS_LIMIT;
 use crate::io;
 use crate::io::prompt::request_auth;
 use crate::io::GraphQL;
@@ -256,7 +256,7 @@ fn transaction_op_menu_moonlight(
             sndr_idx: Some(addr_idx),
             rcvr: prompt::request_rcvr_addr("recipient")?,
             amt: prompt::request_token_amt("transfer", moonlight_bal)?,
-            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT)?,
+            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_TRANSFER)?,
             gas_price: prompt::request_gas_price()?,
         })),
         Memo => AddrOp::Run(Box::new(Command::MoonlightMemo {
@@ -264,23 +264,23 @@ fn transaction_op_menu_moonlight(
             memo: prompt::request_str("memo")?,
             rcvr: prompt::request_rcvr_addr("recipient")?,
             amt: prompt::request_optional_token_amt("transfer", moonlight_bal)?,
-            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT)?,
+            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_TRANSFER)?,
             gas_price: prompt::request_gas_price()?,
         })),
         Stake => AddrOp::Run(Box::new(Command::MoonlightStake {
             addr_idx: Some(addr_idx),
             amt: prompt::request_stake_token_amt(moonlight_bal)?,
-            gas_limit: prompt::request_gas_limit(DEFAULT_STAKE_GAS_LIMIT)?,
+            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
             gas_price: prompt::request_gas_price()?,
         })),
         Unstake => AddrOp::Run(Box::new(Command::MoonlightUnstake {
             addr_idx: Some(addr_idx),
-            gas_limit: prompt::request_gas_limit(DEFAULT_STAKE_GAS_LIMIT)?,
+            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
             gas_price: prompt::request_gas_price()?,
         })),
         Withdraw => AddrOp::Run(Box::new(Command::MoonlightWithdraw {
             addr_idx: Some(addr_idx),
-            gas_limit: prompt::request_gas_limit(DEFAULT_STAKE_GAS_LIMIT)?,
+            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
             gas_price: prompt::request_gas_price()?,
         })),
         ContractDeploy => {
@@ -288,7 +288,10 @@ fn transaction_op_menu_moonlight(
                 addr_idx: Some(addr_idx),
                 code: prompt::request_contract_code()?,
                 init_args: prompt::request_bytes("init arguments")?,
-                gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT)?,
+                deploy_nonce: prompt::request_nonce()?,
+                gas_limit: prompt::request_gas_limit(
+                    gas::DEFAULT_LIMIT_DEPLOYMENT,
+                )?,
                 gas_price: prompt::request_gas_price()?,
             }))
         }
@@ -297,7 +300,7 @@ fn transaction_op_menu_moonlight(
             contract_id: prompt::request_bytes("contract id")?,
             fn_name: prompt::request_str("function name to call")?,
             fn_args: prompt::request_bytes("arguments of calling function")?,
-            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT)?,
+            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
             gas_price: prompt::request_gas_price()?,
         })),
         History => AddrOp::Back,
@@ -340,7 +343,7 @@ fn transaction_op_menu_phoenix(
             sndr_idx: Some(addr_idx),
             rcvr: prompt::request_rcvr_addr("recipient")?,
             amt: prompt::request_token_amt("transfer", phoenix_balance)?,
-            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT)?,
+            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_TRANSFER)?,
             gas_price: prompt::request_gas_price()?,
         })),
         Memo => AddrOp::Run(Box::new(Command::PhoenixMemo {
@@ -351,23 +354,23 @@ fn transaction_op_menu_phoenix(
                 "transfer",
                 phoenix_balance,
             )?,
-            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT)?,
+            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_TRANSFER)?,
             gas_price: prompt::request_gas_price()?,
         })),
         Stake => AddrOp::Run(Box::new(Command::PhoenixStake {
             addr_idx: Some(addr_idx),
             amt: prompt::request_stake_token_amt(phoenix_balance)?,
-            gas_limit: prompt::request_gas_limit(DEFAULT_STAKE_GAS_LIMIT)?,
+            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
             gas_price: prompt::request_gas_price()?,
         })),
         Unstake => AddrOp::Run(Box::new(Command::PhoenixUnstake {
             addr_idx: Some(addr_idx),
-            gas_limit: prompt::request_gas_limit(DEFAULT_STAKE_GAS_LIMIT)?,
+            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
             gas_price: prompt::request_gas_price()?,
         })),
         Withdraw => AddrOp::Run(Box::new(Command::PhoenixWithdraw {
             addr_idx: Some(addr_idx),
-            gas_limit: prompt::request_gas_limit(DEFAULT_STAKE_GAS_LIMIT)?,
+            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
             gas_price: prompt::request_gas_price()?,
         })),
         ContractDeploy => {
@@ -375,7 +378,10 @@ fn transaction_op_menu_phoenix(
                 addr_idx: Some(addr_idx),
                 code: prompt::request_contract_code()?,
                 init_args: prompt::request_bytes("init arguments")?,
-                gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT)?,
+                deploy_nonce: prompt::request_nonce()?,
+                gas_limit: prompt::request_gas_limit(
+                    gas::DEFAULT_LIMIT_DEPLOYMENT,
+                )?,
                 gas_price: prompt::request_gas_price()?,
             }))
         }
@@ -384,7 +390,7 @@ fn transaction_op_menu_phoenix(
             contract_id: prompt::request_bytes("contract id")?,
             fn_name: prompt::request_str("function name to call")?,
             fn_args: prompt::request_bytes("arguments of calling function")?,
-            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT)?,
+            gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
             gas_price: prompt::request_gas_price()?,
         })),
         History => AddrOp::Run(Box::new(Command::PhoenixHistory {
@@ -411,6 +417,8 @@ enum CommandMenuItem {
     // Conversion
     PhoenixToMoonlight,
     MoonlightToPhoenix,
+    // Generate Contract ID.
+    CalculateContractId,
     // Others
     StakeInfo,
     Export,
@@ -448,6 +456,7 @@ fn menu_op(
         .add(CMI::MoonlightTransactions, "Moonlight Transactions")
         .add(CMI::PhoenixToMoonlight, "Convert Phoenix Dusk to Moonlight")
         .add(CMI::MoonlightToPhoenix, "Convert Moonlight Dusk to Phoenix")
+        .add(CMI::CalculateContractId, "Calculate Contract ID")
         .add(CMI::Export, "Export provisioner key-pair")
         .separator()
         .add(CMI::Back, "Back")
@@ -489,7 +498,7 @@ fn menu_op(
             AddrOp::Run(Box::new(Command::MoonlightToPhoenix {
                 addr_idx: Some(addr_idx),
                 amt: prompt::request_token_amt("convert", moonlight_balance)?,
-                gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT)?,
+                gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
                 gas_price: prompt::request_gas_price()?,
             }))
         }
@@ -497,8 +506,15 @@ fn menu_op(
             AddrOp::Run(Box::new(Command::PhoenixToMoonlight {
                 addr_idx: Some(addr_idx),
                 amt: prompt::request_token_amt("convert", phoenix_balance)?,
-                gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT)?,
+                gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
                 gas_price: prompt::request_gas_price()?,
+            }))
+        }
+        CMI::CalculateContractId => {
+            AddrOp::Run(Box::new(Command::CalculateContractId {
+                addr_idx: Some(addr_idx),
+                deploy_nonce: prompt::request_nonce()?,
+                code: prompt::request_contract_code()?,
             }))
         }
         CMI::Export => AddrOp::Run(Box::new(Command::Export {
@@ -831,6 +847,7 @@ fn confirm(cmd: &Command) -> anyhow::Result<bool> {
             addr_idx,
             code,
             init_args,
+            deploy_nonce,
             gas_limit,
             gas_price,
         } => {
@@ -843,6 +860,7 @@ fn confirm(cmd: &Command) -> anyhow::Result<bool> {
             );
             println!("   > Code len = {}", code_len);
             println!("   > Init args = {}", hex::encode(init_args));
+            println!("   > Deploy nonce = {}", deploy_nonce);
             println!("   > Max fee = {} DUSK", Dusk::from(max_fee));
 
             prompt::ask_confirm()
@@ -851,6 +869,7 @@ fn confirm(cmd: &Command) -> anyhow::Result<bool> {
             addr_idx,
             code,
             init_args,
+            deploy_nonce,
             gas_limit,
             gas_price,
         } => {
@@ -863,6 +882,7 @@ fn confirm(cmd: &Command) -> anyhow::Result<bool> {
             );
             println!("   > Code len = {}", code_len);
             println!("   > Init args = {}", hex::encode(init_args));
+            println!("   > Deploy nonce = {}", deploy_nonce);
             println!("   > Max fee = {} DUSK", Dusk::from(max_fee));
             println!("   > ALERT: THIS IS A PUBLIC TRANSACTION");
 

--- a/rusk-wallet/src/bin/io/prompt.rs
+++ b/rusk-wallet/src/bin/io/prompt.rs
@@ -360,6 +360,24 @@ pub(crate) fn request_bytes(name: &str) -> anyhow::Result<Vec<u8>> {
     Ok(bytes)
 }
 
+pub(crate) fn request_nonce() -> anyhow::Result<u64> {
+    let question = requestty::Question::input("Contract Deployment nonce")
+        .message("Introduce a number for nonce")
+        .validate_on_key(|f, _| u64::from_str(f).is_ok())
+        .validate(|f, _| {
+            u64::from_str(f)
+                .is_ok()
+                .then_some(())
+                .ok_or("Invalid number".to_owned())
+        })
+        .build();
+
+    let a = requestty::prompt_one(question)?;
+    let bytes = u64::from_str(a.as_string().expect("answer to be a string"))?;
+
+    Ok(bytes)
+}
+
 /// Request Dusk block explorer to be opened
 pub(crate) fn launch_explorer(url: String) -> Result<()> {
     let q = requestty::Question::confirm("launch")

--- a/rusk-wallet/src/bin/main.rs
+++ b/rusk-wallet/src/bin/main.rs
@@ -334,6 +334,9 @@ async fn exec() -> anyhow::Result<()> {
                     println!("{th}");
                 }
             }
+            RunResult::ContractId(id) => {
+                println!("Contract ID: {:?}", id);
+            }
             RunResult::Settings() => {}
             RunResult::Create() | RunResult::Restore() => {}
         },

--- a/rusk-wallet/src/wallet/gas.rs
+++ b/rusk-wallet/src/wallet/gas.rs
@@ -10,10 +10,16 @@
 use crate::currency::Lux;
 
 /// The minimum gas limit
-pub const MIN_LIMIT: u64 = 350_000_000;
+pub const MIN_LIMIT: u64 = 50_000_000;
 
-/// The default gas limit
-pub const DEFAULT_LIMIT: u64 = 500_000_000;
+/// The default gas limit for transfer transactions
+pub const DEFAULT_LIMIT_TRANSFER: u64 = 100_000_000;
+
+/// The default gas limit for a contract deployment
+pub const DEFAULT_LIMIT_DEPLOYMENT: u64 = 50_000_000;
+
+/// The default gas limit for staking/contract calls
+pub const DEFAULT_LIMIT_CALL: u64 = 2_900_000_000;
 
 /// The default gas price
 pub const DEFAULT_PRICE: Lux = 1;
@@ -71,6 +77,6 @@ impl Gas {
 
 impl Default for Gas {
     fn default() -> Self {
-        Self::new(DEFAULT_LIMIT)
+        Self::new(DEFAULT_LIMIT_TRANSFER)
     }
 }


### PR DESCRIPTION
This pick up the changes to the deploy-transaction creation from #2540 after it has been reverted and separated from the changes made to the syncing (#2558)