### PR TITLE
Make archive available in graphql

### DIFF
--- a/rusk/src/lib/builder/node.rs
+++ b/rusk/src/lib/builder/node.rs
@@ -182,13 +182,20 @@ impl RuskNodeBuilder {
         .map_err(|e| anyhow::anyhow!("Cannot instantiate VM {e}"))?;
         info!("Rusk VM loaded");
 
+        #[cfg(feature = "archive")]
+        let archive = Archive::create_or_open(self.db_path.clone()).await;
+
         let node = {
             let db = rocksdb::Backend::create_or_open(
                 self.db_path.clone(),
                 self.db_options.clone(),
             );
             let net = Kadcast::new(self.kadcast.clone())?;
-            RuskNode::new(Node::new(net, db, rusk.clone()))
+            RuskNode::new(
+                Node::new(net, db, rusk.clone()),
+                #[cfg(feature = "archive")]
+                archive.clone(),
+            )
         };
 
         let mut chain_srv = ChainSrv::new(
@@ -254,7 +261,7 @@ impl RuskNodeBuilder {
         #[cfg(feature = "archive")]
         service_list.push(Box::new(ArchivistSrv {
             archive_receiver,
-            archivist: Archive::create_or_open(self.db_path.clone()).await,
+            archivist: archive,
         }));
 
         node.inner().initialize(&mut service_list).await?;

--- a/rusk/src/lib/http/chain.rs
+++ b/rusk/src/lib/http/chain.rs
@@ -143,8 +143,13 @@ impl RuskNode {
     ) -> anyhow::Result<ResponseData> {
         let gql_query = data.as_string();
 
+        #[cfg(feature = "archive")]
         let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
-            .data(self.db())
+            .data((self.db(), self.archive()))
+            .finish();
+        #[cfg(not(feature = "archive"))]
+        let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
+            .data((self.db(), ()))
             .finish();
 
         if gql_query.trim().is_empty() {

--- a/rusk/src/lib/http/chain/graphql.rs
+++ b/rusk/src/lib/http/chain/graphql.rs
@@ -14,13 +14,19 @@ use tx::*;
 
 use async_graphql::{Context, FieldError, FieldResult, Object};
 use execution_core::{transfer::TRANSFER_CONTRACT, ContractId};
+#[cfg(feature = "archive")]
+use node::archive::{Archive, MoonlightTxEvents};
 use node::database::rocksdb::Backend;
 use node::database::{Ledger, DB};
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub type DBContext = Arc<RwLock<Backend>>;
+#[cfg(feature = "archive")]
+pub type DBContext = (Arc<RwLock<Backend>>, Archive);
+#[cfg(not(feature = "archive"))]
+pub type DBContext = (Arc<RwLock<Backend>>, ());
+
 pub type OptResult<T> = FieldResult<Option<T>>;
 
 pub struct Query;

--- a/rusk/src/lib/http/chain/graphql/block.rs
+++ b/rusk/src/lib/http/chain/graphql/block.rs
@@ -12,7 +12,7 @@ pub async fn block_by_height(
     ctx: &Context<'_>,
     height: f64,
 ) -> OptResult<Block> {
-    let db = ctx.data::<DBContext>()?;
+    let (db, _) = ctx.data::<DBContext>()?;
     let block_hash = db.read().await.view(|t| {
         if height >= 0f64 {
             t.fetch_block_hash_by_height(height as u64)
@@ -29,7 +29,7 @@ pub async fn block_by_height(
 }
 
 pub async fn last_block(ctx: &Context<'_>) -> FieldResult<Block> {
-    let db = ctx.data::<DBContext>()?;
+    let (db, _) = ctx.data::<DBContext>()?;
     let block = db.read().await.view(|t| {
         let hash = t.op_read(MD_HASH_KEY)?;
         match hash {
@@ -47,7 +47,7 @@ pub async fn block_by_hash(
     ctx: &Context<'_>,
     hash: String,
 ) -> OptResult<Block> {
-    let db = ctx.data::<DBContext>()?;
+    let (db, _) = ctx.data::<DBContext>()?;
     let hash = hex::decode(hash)?;
     let header = db.read().await.view(|t| t.fetch_light_block(&hash))?;
     Ok(header.map(Block::from))
@@ -60,7 +60,7 @@ pub async fn last_blocks(
     if (count < 1) {
         return Err(FieldError::new("count must be positive"));
     }
-    let db = ctx.data::<DBContext>()?;
+    let (db, _) = ctx.data::<DBContext>()?;
     let last_block = last_block(ctx).await?;
     let mut hash_to_search = last_block.header().prev_block_hash;
     let blocks = db.read().await.view(|t| {
@@ -86,7 +86,7 @@ pub async fn blocks_range(
     from: u64,
     to: u64,
 ) -> FieldResult<Vec<Block>> {
-    let db = ctx.data::<DBContext>()?;
+    let (db, _) = ctx.data::<DBContext>()?;
     let mut blocks = db.read().await.view(|t| {
         let mut blocks = vec![];
         let mut hash_to_search = None;

--- a/rusk/src/lib/http/chain/graphql/data.rs
+++ b/rusk/src/lib/http/chain/graphql/data.rs
@@ -72,7 +72,7 @@ impl Block {
         &self,
         ctx: &async_graphql::Context<'_>,
     ) -> FieldResult<Vec<SpentTransaction>> {
-        let db = ctx.data::<super::DBContext>()?.read().await;
+        let db = ctx.data::<super::DBContext>()?.0.read().await;
         let mut ret = vec![];
 
         db.view(|t| {
@@ -189,7 +189,7 @@ impl SpentTransaction {
         &self,
         ctx: &async_graphql::Context<'_>,
     ) -> FieldResult<String> {
-        let db = ctx.data::<super::DBContext>()?.read().await;
+        let db = ctx.data::<super::DBContext>()?.0.read().await;
         let block_height = self.0.block_height;
 
         let block_hash = db.view(|t| {
@@ -209,7 +209,7 @@ impl SpentTransaction {
         &self,
         ctx: &async_graphql::Context<'_>,
     ) -> FieldResult<u64> {
-        let db = ctx.data::<super::DBContext>()?.read().await;
+        let db = ctx.data::<super::DBContext>()?.0.read().await;
         let block_height = self.0.block_height;
 
         let header = db.view(|t| {

--- a/rusk/src/lib/http/chain/graphql/tx.rs
+++ b/rusk/src/lib/http/chain/graphql/tx.rs
@@ -13,7 +13,7 @@ pub async fn tx_by_hash(
     ctx: &Context<'_>,
     hash: String,
 ) -> OptResult<SpentTransaction> {
-    let db = ctx.data::<DBContext>()?;
+    let (db, _) = ctx.data::<DBContext>()?;
     let hash = hex::decode(hash)?;
     let tx = db.read().await.view(|t| t.get_ledger_tx_by_hash(&hash))?;
     Ok(tx.map(SpentTransaction))
@@ -27,7 +27,7 @@ pub async fn last_transactions(
         return Err(FieldError::new("count must be positive"));
     }
 
-    let db = ctx.data::<DBContext>()?;
+    let (db, _) = ctx.data::<DBContext>()?;
     let transactions = db.read().await.view(|t| {
         let mut txs = vec![];
         let mut current_block =
@@ -59,7 +59,7 @@ pub async fn last_transactions(
 pub async fn mempool<'a>(
     ctx: &Context<'_>,
 ) -> FieldResult<Vec<Transaction<'a>>> {
-    let db = ctx.data::<DBContext>()?;
+    let (db, _) = ctx.data::<DBContext>()?;
     let transactions = db.read().await.view(|t| {
         let txs = t.get_txs_sorted_by_fee()?.map(|t| t.into()).collect();
         Ok::<_, async_graphql::Error>(txs)
@@ -71,7 +71,7 @@ pub async fn mempool_by_hash<'a>(
     ctx: &Context<'_>,
     hash: String,
 ) -> OptResult<Transaction<'a>> {
-    let db = ctx.data::<DBContext>()?;
+    let (db, _) = ctx.data::<DBContext>()?;
     let hash = &hex::decode(hash)?[..];
     let hash = hash.try_into()?;
     let tx = db.read().await.view(|t| t.get_tx(hash))?;


### PR DESCRIPTION
This PR introduces the Archive to RuskNode & DBContext (if the Archive feature is set). This change allows us to use the archive within the graphql logic to retrieve data from it (by adding functions which can use the ctx to access the archive).