### PR TITLE
rusk: add preliminary archive graphql endpoints

### DIFF
--- a/node/.sqlx/query-dc6d1bfa595b7545e8a1bfdaa68f8b408b2bda1142934f2e36bd81135ab7b5c5.json
+++ b/node/.sqlx/query-dc6d1bfa595b7545e8a1bfdaa68f8b408b2bda1142934f2e36bd81135ab7b5c5.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT json_contract_events FROM archive WHERE finalized = 1 ORDER BY block_height DESC LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "name": "json_contract_events",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "dc6d1bfa595b7545e8a1bfdaa68f8b408b2bda1142934f2e36bd81135ab7b5c5"
+}

--- a/node/README.md
+++ b/node/README.md
@@ -26,3 +26,5 @@ This can be done through:
 1. Set DATABASE_URL or create .env file with ``DATABASE_URL=sqlite:///tmp/temp.sqlite3``
 2. Create a db with ``sqlx database create`` 
 3. Run the migrations with ``sqlx migrate run``
+
+> NB: You need to be in the /node folder of this project for sqlx to detect the migrations folder

--- a/node/src/archive/transformer.rs
+++ b/node/src/archive/transformer.rs
@@ -23,12 +23,21 @@ pub struct MoonlightTxEvents {
     events: Vec<ContractEvent>,
     #[serde_as(as = "serde_with::hex::Hex")]
     origin: TxHash,
+    block_height: u64,
 }
 
 impl MoonlightTxEvents {
     // Private on purpose
-    fn new(events: Vec<ContractEvent>, origin: TxHash) -> Self {
-        Self { events, origin }
+    fn new(
+        events: Vec<ContractEvent>,
+        origin: TxHash,
+        block_height: u64,
+    ) -> Self {
+        Self {
+            events,
+            origin,
+            block_height,
+        }
     }
 
     pub fn events(&self) -> &Vec<ContractEvent> {
@@ -37,6 +46,10 @@ impl MoonlightTxEvents {
 
     pub fn origin(&self) -> &TxHash {
         &self.origin
+    }
+
+    pub fn block_height(&self) -> u64 {
+        self.block_height
     }
 }
 
@@ -49,6 +62,7 @@ type MemoMapping = (Vec<u8>, TxHash);
 /// Returns the address mappings, memo mappings and groups
 pub(super) fn group_by_origins_filter_and_convert(
     block_events: Vec<ContractTxEvent>,
+    block_height: u64,
 ) -> (
     Vec<AddressMapping>,
     Vec<MemoMapping>,
@@ -150,7 +164,11 @@ pub(super) fn group_by_origins_filter_and_convert(
         });
 
         if is_moonlight {
-            moonlight_tx_groups.push(MoonlightTxEvents::new(group, tx_hash));
+            moonlight_tx_groups.push(MoonlightTxEvents::new(
+                group,
+                tx_hash,
+                block_height,
+            ));
         }
     }
 

--- a/rusk/src/lib/http/chain/graphql.rs
+++ b/rusk/src/lib/http/chain/graphql.rs
@@ -137,12 +137,23 @@ impl Query {
     }
 
     #[cfg(feature = "archive")]
-    async fn all_moonlight_txs(
+    async fn full_moonlight_history(
         &self,
         ctx: &Context<'_>,
         address: String,
     ) -> OptResult<MoonlightTransactions> {
         moonlight_tx_by_address(ctx, address).await
+    }
+
+    #[cfg(feature = "archive")]
+    async fn transactions_by_memo(
+        &self,
+        ctx: &Context<'_>,
+        memo: String,
+    ) -> OptResult<MoonlightTransactions> {
+        // convert String to Vec<u8>
+        let memo = memo.into_bytes();
+        moonlight_tx_by_memo(ctx, memo).await
     }
 
     #[cfg(feature = "archive")]

--- a/rusk/src/lib/http/chain/graphql.rs
+++ b/rusk/src/lib/http/chain/graphql.rs
@@ -135,4 +135,27 @@ impl Query {
     ) -> OptResult<Transaction> {
         mempool_by_hash(ctx, hash).await
     }
+
+    #[cfg(feature = "archive")]
+    async fn all_moonlight_txs(
+        &self,
+        ctx: &Context<'_>,
+        address: String,
+    ) -> OptResult<MoonlightTransactions> {
+        moonlight_tx_by_address(ctx, address).await
+    }
+
+    #[cfg(feature = "archive")]
+    async fn block_events(
+        &self,
+        ctx: &Context<'_>,
+        height: Option<i64>,
+        hash: Option<String>,
+    ) -> OptResult<BlockEvents> {
+        match (height, hash) {
+            (Some(height), None) => block_events_by_height(ctx, height).await,
+            (None, Some(hash)) => block_events_by_hash(ctx, hash).await,
+            _ => Err(FieldError::new("Specify height or hash")),
+        }
+    }
 }

--- a/rusk/src/lib/http/chain/graphql/block.rs
+++ b/rusk/src/lib/http/chain/graphql/block.rs
@@ -105,3 +105,38 @@ pub async fn blocks_range(
     blocks.reverse();
     Ok(blocks)
 }
+
+#[cfg(feature = "archive")]
+pub(super) async fn block_events_by_height(
+    ctx: &Context<'_>,
+    height: i64,
+) -> OptResult<BlockEvents> {
+    let (_, archive) = ctx.data::<DBContext>()?;
+    let mut events;
+
+    if height < 0 {
+        events = archive.fetch_json_last_vm_events().await.map_err(|e| {
+            FieldError::new(format!("Cannot fetch events: {}", e))
+        })?;
+    } else {
+        events = archive.fetch_json_vm_events(height).await.map_err(|e| {
+            FieldError::new(format!("Cannot fetch events: {}", e))
+        })?;
+    }
+
+    Ok(Some(BlockEvents(serde_json::from_str(&events)?)))
+}
+
+#[cfg(feature = "archive")]
+pub(super) async fn block_events_by_hash(
+    ctx: &Context<'_>,
+    hash: String,
+) -> OptResult<BlockEvents> {
+    let (_, archive) = ctx.data::<DBContext>()?;
+    let events = archive
+        .fetch_json_vm_events_by_blk_hash(&hash)
+        .await
+        .map_err(|e| FieldError::new(format!("Cannot fetch events: {}", e)))?;
+
+    Ok(Some(BlockEvents(serde_json::from_str(&events)?)))
+}

--- a/rusk/src/lib/http/chain/graphql/data.rs
+++ b/rusk/src/lib/http/chain/graphql/data.rs
@@ -32,6 +32,10 @@ impl Block {
 pub struct Header<'a>(&'a node_data::ledger::Header);
 pub struct SpentTransaction(pub node_data::ledger::SpentTransaction);
 pub struct Transaction<'a>(TransactionData<'a>);
+#[cfg(feature = "archive")]
+pub struct MoonlightTransactions(pub Vec<node::archive::MoonlightTxEvents>);
+#[cfg(feature = "archive")]
+pub struct BlockEvents(pub(super) serde_json::Value);
 
 impl<'a> From<&'a node_data::ledger::Transaction> for Transaction<'a> {
     fn from(value: &'a node_data::ledger::Transaction) -> Self {
@@ -167,6 +171,22 @@ impl Header<'_> {
 
     pub async fn json(&self) -> String {
         serde_json::to_string(self.0).unwrap_or_default()
+    }
+}
+
+#[cfg(feature = "archive")]
+#[Object]
+impl MoonlightTransactions {
+    pub async fn json(&self) -> serde_json::Value {
+        serde_json::to_value(&self.0).unwrap_or_default()
+    }
+}
+
+#[cfg(feature = "archive")]
+#[Object]
+impl BlockEvents {
+    pub async fn json(&self) -> serde_json::Value {
+        self.0.clone()
     }
 }
 

--- a/rusk/src/lib/http/chain/graphql/tx.rs
+++ b/rusk/src/lib/http/chain/graphql/tx.rs
@@ -101,7 +101,25 @@ pub(super) async fn moonlight_tx_by_address(
     let pk = AccountPublicKey::from_bytes(&pk_bytes)
         .map_err(|_| anyhow::anyhow!("Failed to serialize given public key"))?;
 
-    let moonlight_events = archive.get_moonlight_events(pk)?;
+    let moonlight_events = archive.moonlight_txs_by_pk(pk)?;
+
+    if let Some(moonlight_events) = moonlight_events {
+        Ok(Some(MoonlightTransactions(moonlight_events)))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(feature = "archive")]
+pub(super) async fn moonlight_tx_by_memo(
+    ctx: &Context<'_>,
+    memo: Vec<u8>,
+) -> OptResult<MoonlightTransactions> {
+    use dusk_bytes::ParseHexStr;
+
+    let (_, archive) = ctx.data::<DBContext>()?;
+
+    let moonlight_events = archive.moonlight_txs_by_memo(memo)?;
 
     if let Some(moonlight_events) = moonlight_events {
         Ok(Some(MoonlightTransactions(moonlight_events)))

--- a/rusk/src/lib/http/chain/graphql/tx.rs
+++ b/rusk/src/lib/http/chain/graphql/tx.rs
@@ -6,6 +6,12 @@
 
 use node::database::rocksdb::MD_HASH_KEY;
 use node::database::{Mempool, Metadata};
+#[cfg(feature = "archive")]
+use {
+    dusk_bytes::Serializable,
+    execution_core::signatures::bls::PublicKey as AccountPublicKey,
+    node::archive::MoonlightTxEvents,
+};
 
 use super::*;
 
@@ -76,4 +82,30 @@ pub async fn mempool_by_hash<'a>(
     let hash = hash.try_into()?;
     let tx = db.read().await.view(|t| t.get_tx(hash))?;
     Ok(tx.map(|t| t.into()))
+}
+
+#[cfg(feature = "archive")]
+pub(super) async fn moonlight_tx_by_address(
+    ctx: &Context<'_>,
+    address: String,
+) -> OptResult<MoonlightTransactions> {
+    use dusk_bytes::ParseHexStr;
+
+    let (_, archive) = ctx.data::<DBContext>()?;
+    let v = bs58::decode(address).into_vec()?;
+
+    let pk_bytes: [u8; 96] = v
+        .try_into()
+        .map_err(|_| FieldError::new("Invalid public key length"))?;
+
+    let pk = AccountPublicKey::from_bytes(&pk_bytes)
+        .map_err(|_| anyhow::anyhow!("Failed to serialize given public key"))?;
+
+    let moonlight_events = archive.get_moonlight_events(pk)?;
+
+    if let Some(moonlight_events) = moonlight_events {
+        Ok(Some(MoonlightTransactions(moonlight_events)))
+    } else {
+        Ok(None)
+    }
 }


### PR DESCRIPTION
This PR introduces three new GraphQL queries for the node.
The three calls on the /on/graphql/query are:
``query { fullMoonlightHistory(address: "") { json } }``
``query { blockEvents(height: -1) { json } }``
``query { transactionsByMemo(memo: "") { json } }``

The address in the first query takes a base58 encoded moonlight address. For now, the only fields available are "json", which returns all the data from that endpoint.

NB: There are already breaking changes planned for these endpoints. Especially the allMoonlightTxs is an interim solution. 