### PR TITLE
node: mempool - reject moonlight txs with non consecutive nonce

### DIFF
--- a/node-data/src/ledger/transaction.rs
+++ b/node-data/src/ledger/transaction.rs
@@ -96,6 +96,15 @@ impl Transaction {
             }
         }
     }
+
+    pub fn next_spending_id(&self) -> Option<SpendingId> {
+        match &self.inner {
+            ProtocolTransaction::Phoenix(_) => None,
+            ProtocolTransaction::Moonlight(m) => {
+                Some(SpendingId::AccountNonce(*m.sender(), m.nonce() + 1))
+            }
+        }
+    }
 }
 
 impl PartialEq<Self> for Transaction {

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -342,7 +342,11 @@ impl<DB: database::DB, VM: vm::VMExecution> Operations for Executor<DB, VM> {
             .map_err(OperationError::InvalidEST)?;
         let _ = db.update(|m| {
             for t in &discarded_txs {
-                let _ = m.delete_tx(t.id());
+                if let Ok(_removed) = m.delete_tx(t.id(), true) {
+                    // TODO: `_removed` entries should be sent to rues to inform
+                    // the subscribers that a transaction has been pruned from
+                    // the mempool
+                }
             }
             Ok(())
         });

--- a/node/src/database.rs
+++ b/node/src/database.rs
@@ -143,7 +143,15 @@ pub trait Mempool {
     fn get_tx_exists(&self, tx_id: [u8; 32]) -> Result<bool>;
 
     /// Deletes a transaction from the mempool.
-    fn delete_tx(&self, tx_id: [u8; 32]) -> Result<bool>;
+    ///
+    /// If `cascade` is true, all dependant transactions are deleted
+    ///
+    /// Return a vector with all the deleted tx_id
+    fn delete_tx(
+        &self,
+        tx_id: [u8; 32],
+        cascade: bool,
+    ) -> Result<Vec<[u8; 32]>>;
 
     /// Get transactions hash from the mempool, searching by spendable ids
     fn get_txs_by_spendable_ids(&self, n: &[SpendingId]) -> HashSet<[u8; 32]>;

--- a/node/src/database/rocksdb.rs
+++ b/node/src/database/rocksdb.rs
@@ -736,8 +736,8 @@ impl<'db, DB: DBAccess> Mempool for DBTransaction<'db, DB> {
         self.put_cf(self.mempool_cf, hash, tx_data)?;
 
         // Add Secondary indexes //
-        for n in tx.inner.nullifiers() {
         // Spending Ids
+        for n in tx.to_spend_ids() {
             let key = n.to_bytes();
             self.put_cf(self.spending_id_cf, key, hash)?;
         }
@@ -780,8 +780,8 @@ impl<'db, DB: DBAccess> Mempool for DBTransaction<'db, DB> {
             self.inner.delete_cf(self.mempool_cf, hash)?;
 
             // Delete Secondary indexes
-            // Delete Nullifiers
-            for n in tx.inner.nullifiers() {
+            // Delete spendingids (nullifiers or nonce)
+            for n in tx.to_spend_ids() {
                 let key = n.to_bytes();
                 self.inner.delete_cf(self.spending_id_cf, key)?;
             }

--- a/node/src/vm.rs
+++ b/node/src/vm.rs
@@ -11,6 +11,7 @@ use dusk_consensus::{
 };
 use execution_core::signatures::bls::PublicKey as BlsPublicKey;
 use execution_core::transfer::data::ContractBytecode;
+use execution_core::transfer::moonlight::AccountData;
 use node_data::ledger::{Block, SpentTransaction, Transaction};
 
 #[derive(Default)]
@@ -45,7 +46,10 @@ pub trait VMExecution: Send + Sync + 'static {
         to_delete: Vec<[u8; 32]>,
     ) -> anyhow::Result<()>;
 
-    fn preverify(&self, tx: &Transaction) -> anyhow::Result<()>;
+    fn preverify(
+        &self,
+        tx: &Transaction,
+    ) -> anyhow::Result<PreverificationResult>;
 
     fn get_provisioners(
         &self,
@@ -77,6 +81,17 @@ pub trait VMExecution: Send + Sync + 'static {
 
     fn gas_per_deploy_byte(&self) -> u64;
     fn min_deployment_gas_price(&self) -> u64;
+}
+
+#[allow(clippy::large_enum_variant)]
+pub enum PreverificationResult {
+    Valid,
+    // Current account state, nonce used by tx
+    FutureNonce {
+        account: BlsPublicKey,
+        state: AccountData,
+        nonce_used: u64,
+    },
 }
 
 // Returns gas charge for bytecode deployment.


### PR DESCRIPTION
Mempool allows moonlight txs if they satisfy one of the following:
- tx.nonce() is equal to state.account.nonce()+1
- tx.nonce() is greater of state.account.nonce()+1 and all the intermediate nonces are in the mempool

Additionally:
- Fixed a bug that was preventing mempool secondary index to be populated with moonlight txs
- Improve mempool pruning to remove dependant transactions for expired or discarded txs

Resolves #2605