### PR TITLE
Enforce minimum gas limit for transactions

### DIFF
--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -214,6 +214,12 @@ impl MempoolSrv {
             if tx.inner.gas_limit() < min_gas_limit {
                 return Err(TxAcceptanceError::GasLimitTooLow(min_gas_limit));
             }
+        } else {
+            let vm = vm.read().await;
+            let min_gas_limit = vm.min_gas_limit();
+            if tx.inner.gas_limit() < min_gas_limit {
+                return Err(TxAcceptanceError::GasLimitTooLow(min_gas_limit));
+            }
         }
 
         // Perform basic checks on the transaction

--- a/node/src/vm.rs
+++ b/node/src/vm.rs
@@ -77,6 +77,7 @@ pub trait VMExecution: Send + Sync + 'static {
 
     fn gas_per_deploy_byte(&self) -> u64;
     fn min_deployment_gas_price(&self) -> u64;
+    fn min_gas_limit(&self) -> u64;
 }
 
 // Returns gas charge for bytecode deployment.

--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `min_gas_limit` node configuration argument and enforcement [#2597]
 - Add `gen_contract_id` and 32-byte hash for contract deployment [#1884]
 - Add execution of contract deployment [#1882]
 - Add first version of RUES, allowing websocket clients to subscribe for events
@@ -214,6 +215,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add linking between Rusk and Protobuff structs
 - Add build system that generates keys for circuits and caches them.
 
+[#2597]: https://github.com/dusk-network/rusk/issues/2597
 [#2536]: https://github.com/dusk-network/rusk/issues/2536
 [#2207]: https://github.com/dusk-network/rusk/issues/2207
 [#1884]: https://github.com/dusk-network/rusk/issues/1884

--- a/rusk/default.config.toml
+++ b/rusk/default.config.toml
@@ -25,6 +25,7 @@
 # Note: changing the gas per deploy byte parameter is equivalent to forking the chain.
 #gas_per_deploy_byte = 100
 #min_deployment_gas_price = 2000
+#min_gas_limit = 75000
 
 [databroker]
 max_inv_entries = 100

--- a/rusk/src/bin/config/chain.rs
+++ b/rusk/src/bin/config/chain.rs
@@ -32,6 +32,7 @@ pub(crate) struct ChainConfig {
     // forking the chain.
     gas_per_deploy_byte: Option<u64>,
     min_deployment_gas_price: Option<u64>,
+    min_gas_limit: Option<u64>,
     block_gas_limit: Option<u64>,
 
     #[serde(with = "humantime_serde")]
@@ -90,6 +91,10 @@ impl ChainConfig {
 
     pub(crate) fn min_deployment_gas_price(&self) -> Option<u64> {
         self.min_deployment_gas_price
+    }
+
+    pub(crate) fn min_gas_limit(&self) -> Option<u64> {
+        self.min_gas_limit
     }
 
     pub(crate) fn max_queue_size(&self) -> usize {

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -85,6 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_min_deployment_gas_price(
                 config.chain.min_deployment_gas_price(),
             )
+            .with_min_gas_limit(config.chain.min_gas_limit())
             .with_block_gas_limit(config.chain.block_gas_limit());
     };
 

--- a/rusk/src/lib/builder/node.rs
+++ b/rusk/src/lib/builder/node.rs
@@ -43,6 +43,7 @@ pub struct RuskNodeBuilder {
     generation_timeout: Option<Duration>,
     gas_per_deploy_byte: Option<u64>,
     min_deployment_gas_price: Option<u64>,
+    min_gas_limit: Option<u64>,
     block_gas_limit: u64,
     feeder_call_gas: u64,
     state_dir: PathBuf,
@@ -54,6 +55,7 @@ pub struct RuskNodeBuilder {
 
 const DEFAULT_GAS_PER_DEPLOY_BYTE: u64 = 100;
 const DEFAULT_MIN_DEPLOYMENT_GAS_PRICE: u64 = 2000;
+const DEFAULT_MIN_GAS_LIMIT: u64 = 75000;
 
 impl RuskNodeBuilder {
     pub fn with_consensus_keys(mut self, consensus_keys_path: String) -> Self {
@@ -117,6 +119,7 @@ impl RuskNodeBuilder {
         self.generation_timeout = generation_timeout;
         self
     }
+
     pub fn with_gas_per_deploy_byte(
         mut self,
         gas_per_deploy_byte: Option<u64>,
@@ -124,11 +127,17 @@ impl RuskNodeBuilder {
         self.gas_per_deploy_byte = gas_per_deploy_byte;
         self
     }
+
     pub fn with_min_deployment_gas_price(
         mut self,
         min_deployment_gas_price: Option<u64>,
     ) -> Self {
         self.min_deployment_gas_price = min_deployment_gas_price;
+        self
+    }
+
+    pub fn with_min_gas_limit(mut self, min_gas_limit: Option<u64>) -> Self {
+        self.min_gas_limit = min_gas_limit;
         self
     }
 
@@ -176,6 +185,7 @@ impl RuskNodeBuilder {
         let min_deployment_gas_price = self
             .min_deployment_gas_price
             .unwrap_or(DEFAULT_MIN_DEPLOYMENT_GAS_PRICE);
+        let min_gas_limit = self.min_gas_limit.unwrap_or(DEFAULT_MIN_GAS_LIMIT);
 
         let rusk = Rusk::new(
             self.state_dir,
@@ -183,6 +193,7 @@ impl RuskNodeBuilder {
             self.generation_timeout,
             gas_per_deploy_byte,
             min_deployment_gas_price,
+            min_gas_limit,
             self.block_gas_limit,
             self.feeder_call_gas,
             rues_sender.clone(),

--- a/rusk/src/lib/node.rs
+++ b/rusk/src/lib/node.rs
@@ -43,6 +43,7 @@ pub struct Rusk {
     pub(crate) generation_timeout: Option<Duration>,
     pub(crate) gas_per_deploy_byte: u64,
     pub(crate) min_deployment_gas_price: u64,
+    pub(crate) min_gas_limit: u64,
     pub(crate) feeder_gas_limit: u64,
     pub(crate) block_gas_limit: u64,
     pub(crate) event_sender: broadcast::Sender<RuesEvent>,

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -60,6 +60,7 @@ impl Rusk {
         generation_timeout: Option<Duration>,
         gas_per_deploy_byte: u64,
         min_deployment_gas_price: u64,
+        min_gas_limit: u64,
         block_gas_limit: u64,
         feeder_gas_limit: u64,
         event_sender: broadcast::Sender<RuesEvent>,
@@ -99,6 +100,7 @@ impl Rusk {
             generation_timeout,
             gas_per_deploy_byte,
             min_deployment_gas_price,
+            min_gas_limit,
             feeder_gas_limit,
             event_sender,
             #[cfg(feature = "archive")]

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -239,6 +239,10 @@ impl VMExecution for Rusk {
     fn min_deployment_gas_price(&self) -> u64 {
         self.min_deployment_gas_price
     }
+
+    fn min_gas_limit(&self) -> u64 {
+        self.min_gas_limit
+    }
 }
 
 fn has_unique_elements<T>(iter: T) -> bool

--- a/rusk/tests/common/state.rs
+++ b/rusk/tests/common/state.rs
@@ -32,6 +32,7 @@ use tracing::info;
 const CHAIN_ID: u8 = 0xFA;
 pub const DEFAULT_GAS_PER_DEPLOY_BYTE: u64 = 100;
 pub const DEFAULT_MIN_DEPLOYMENT_GAS_PRICE: u64 = 2000;
+pub const DEFAULT_MIN_GAS_LIMIT: u64 = 75000;
 
 // Creates a Rusk initial state in the given directory
 pub fn new_state<P: AsRef<Path>>(
@@ -62,6 +63,7 @@ pub fn new_state_with_chainid<P: AsRef<Path>>(
         None,
         DEFAULT_GAS_PER_DEPLOY_BYTE,
         DEFAULT_MIN_DEPLOYMENT_GAS_PRICE,
+        DEFAULT_MIN_GAS_LIMIT,
         block_gas_limit,
         u64::MAX,
         sender,

--- a/rusk/tests/services/contract_deployment.rs
+++ b/rusk/tests/services/contract_deployment.rs
@@ -24,9 +24,11 @@ use tokio::sync::broadcast;
 use tracing::info;
 
 use crate::common::logger;
-use crate::common::state::DEFAULT_GAS_PER_DEPLOY_BYTE;
 use crate::common::state::DEFAULT_MIN_DEPLOYMENT_GAS_PRICE;
 use crate::common::state::{generator_procedure, ExecuteResult};
+use crate::common::state::{
+    DEFAULT_GAS_PER_DEPLOY_BYTE, DEFAULT_MIN_GAS_LIMIT,
+};
 use crate::common::wallet::{TestStateClient, TestStore};
 
 const BLOCK_HEIGHT: u64 = 1;
@@ -103,6 +105,7 @@ fn initial_state<P: AsRef<Path>>(dir: P, deploy_bob: bool) -> Result<Rusk> {
         None,
         DEFAULT_GAS_PER_DEPLOY_BYTE,
         DEFAULT_MIN_DEPLOYMENT_GAS_PRICE,
+        DEFAULT_MIN_GAS_LIMIT,
         BLOCK_GAS_LIMIT,
         u64::MAX,
         sender,

--- a/rusk/tests/services/owner_calls.rs
+++ b/rusk/tests/services/owner_calls.rs
@@ -31,8 +31,10 @@ use tokio::sync::broadcast;
 use tracing::info;
 
 use crate::common::logger;
-use crate::common::state::DEFAULT_GAS_PER_DEPLOY_BYTE;
 use crate::common::state::DEFAULT_MIN_DEPLOYMENT_GAS_PRICE;
+use crate::common::state::{
+    DEFAULT_GAS_PER_DEPLOY_BYTE, DEFAULT_MIN_GAS_LIMIT,
+};
 use crate::common::wallet::{TestStateClient, TestStore};
 
 const BLOCK_GAS_LIMIT: u64 = 1_000_000_000_000;
@@ -82,6 +84,7 @@ fn initial_state<P: AsRef<Path>>(
         None,
         DEFAULT_GAS_PER_DEPLOY_BYTE,
         DEFAULT_MIN_DEPLOYMENT_GAS_PRICE,
+        DEFAULT_MIN_GAS_LIMIT,
         BLOCK_GAS_LIMIT,
         u64::MAX,
         sender,


### PR DESCRIPTION
Enforce minimum gas limit for transactions in such a way that transactions are not propagated if they do not satisfy the minimum gas limit requirement.

Implements issue #2597


