### PR TITLE
consensus: improve log for candidate generation

### DIFF
--- a/consensus/src/proposal/block_generator.rs
+++ b/consensus/src/proposal/block_generator.rs
@@ -62,11 +62,11 @@ impl<T: Operations> Generator<T> {
             dur = format!("{:?}ms", start.elapsed().as_millis()),
         );
 
-        debug!("block: {:?}", &candidate);
-
         let mut candidate = Candidate { candidate };
 
         candidate.sign(&ru.secret_key, ru.pubkey_bls.inner());
+
+        debug!(event = "candidate singed", header = ?candidate.header());
 
         Ok(candidate.into())
     }

--- a/consensus/src/proposal/block_generator.rs
+++ b/consensus/src/proposal/block_generator.rs
@@ -66,7 +66,7 @@ impl<T: Operations> Generator<T> {
 
         candidate.sign(&ru.secret_key, ru.pubkey_bls.inner());
 
-        debug!(event = "candidate singed", header = ?candidate.header());
+        debug!(event = "candidate signed", header = ?candidate.header());
 
         Ok(candidate.into())
     }

--- a/node-data/src/ledger/header.rs
+++ b/node-data/src/ledger/header.rs
@@ -88,6 +88,7 @@ impl std::fmt::Debug for Header {
         f.debug_struct("Header")
             .field("version", &self.version)
             .field("height", &self.height)
+            .field("iteration", &self.iteration)
             .field("timestamp", &timestamp)
             .field("prev_block_hash", &to_str(&self.prev_block_hash))
             .field("seed", &to_str(self.seed.inner()))


### PR DESCRIPTION
- Add `iteration` to header debug 
- Add candidate signature
- Remove txs bytes from log (this actually remove all the deploy data from logs)