### PR TITLE
Add `(contract, topic, data)` to bloom

### DIFF
--- a/rusk/src/lib/bloom.rs
+++ b/rusk/src/lib/bloom.rs
@@ -40,13 +40,19 @@ impl Bloom {
     /// Add an event to the bloom.
     #[allow(unused)]
     pub fn add_event(&mut self, event: &Event) {
+        // We add the tuple (contract, topic) to allow for checking if an
+        // event with the given topic was emitted in a given block.
         let mut iuf = self.iuf();
         iuf.update(event.source);
         iuf.update(&event.topic);
-        // We explicitly omit the `data` from the filter, since it can be
-        // obtained by other means. Like this the bloom is just used for
-        // querying if a specific event topic has been emitted by a given
-        // contract in a block. iuf.update(&event.data);
+        iuf.add();
+
+        // We also add the triple (contract, topic, data) to allow for checking
+        // if the full event was emitted in the block.
+        let mut iuf = self.iuf();
+        iuf.update(event.source);
+        iuf.update(&event.topic);
+        iuf.update(&event.data);
         iuf.add();
     }
 


### PR DESCRIPTION
This commit adds the `(contract, topic, data)` triple to the bloom filter present in each block. This allows someone observing a block being emitted to both check for a `(contract, topic)` *and* the `(contract, topic, data)` triple being included the block. This facilitates the following workflow:

- Listener receives a block, and checks for `(contract, topic)`
- If exists, listener asks for full event data
- Listener checks that the `(contract, topic, data)` is also in the block