### PR TITLE
rusk-wallet: Add `Profile` and fix how addresses are shown

### DIFF
--- a/rusk-wallet/src/clients.rs
+++ b/rusk-wallet/src/clients.rs
@@ -41,7 +41,7 @@ use super::{cache::Cache, *};
 use crate::{
     rusk::{RuskHttpClient, RuskRequest},
     store::LocalStore,
-    Error, MAX_ADDRESSES,
+    Error, MAX_PROFILES,
 };
 
 const TRANSFER_CONTRACT: &str =
@@ -90,7 +90,7 @@ impl State {
         prover: RuskHttpClient,
         store: LocalStore,
     ) -> Result<Self, Error> {
-        let cfs = (0..MAX_ADDRESSES)
+        let cfs = (0..MAX_PROFILES)
             .flat_map(|i| {
                 let pk: PhoenixPublicKey =
                     derive_phoenix_pk(store.get_seed(), i as u8);

--- a/rusk-wallet/src/clients/sync.rs
+++ b/rusk-wallet/src/clients/sync.rs
@@ -21,7 +21,7 @@ pub(crate) async fn sync_db(
     let seed = store.get_seed();
 
     let keys: Vec<(PhoenixSecretKey, PhoenixViewKey, PhoenixPublicKey)> = (0
-        ..MAX_ADDRESSES)
+        ..MAX_PROFILES)
         .map(|i| {
             let i = i as u8;
             (

--- a/rusk-wallet/src/lib.rs
+++ b/rusk-wallet/src/lib.rs
@@ -34,7 +34,9 @@ pub use rusk::{RuskHttpClient, RuskRequest};
 
 pub use error::Error;
 pub use wallet::gas;
-pub use wallet::{Address, DecodedNote, SecureWalletFile, Wallet, WalletPath};
+pub use wallet::{
+    Address, DecodedNote, Profile, SecureWalletFile, Wallet, WalletPath,
+};
 
 use execution_core::{
     dusk, from_dusk,
@@ -55,19 +57,19 @@ pub const MIN_CONVERTIBLE: Dusk = Dusk::new(1);
 /// The length of an epoch in blocks
 pub const EPOCH: u64 = 2160;
 /// Max addresses the wallet can store
-pub const MAX_ADDRESSES: usize = get_max_addresses();
+pub const MAX_PROFILES: usize = get_max_addresses();
 
-const DEFAULT_MAX_ADDRESSES: usize = 2;
+const DEFAULT_MAX_PROFILES: usize = 2;
 
 const fn get_max_addresses() -> usize {
-    match option_env!("WALLET_MAX_ADDR") {
+    match option_env!("WALLET_MAX_PROFILES") {
         Some(v) => match konst::primitive::parse_usize(v) {
             Ok(e) if e > 255 => {
-                panic!("WALLET_MAX_ADDR must be lower or equal to 255")
+                panic!("WALLET_MAX_PROFILES must be lower or equal to 255")
             }
             Ok(e) if e > 0 => e,
-            _ => panic!("Invalid WALLET_MAX_ADDR"),
+            _ => panic!("Invalid WALLET_MAX_PROFILES"),
         },
-        None => DEFAULT_MAX_ADDRESSES,
+        None => DEFAULT_MAX_PROFILES,
     }
 }

--- a/rusk-wallet/src/rusk.rs
+++ b/rusk-wallet/src/rusk.rs
@@ -15,20 +15,20 @@ use crate::Error;
 const REQUIRED_RUSK_VERSION: &str = ">=0.8.0";
 
 #[derive(Debug)]
-/// RuskRequesst according to the rusk event system
+/// RuskRequest according to the rusk event system
 pub struct RuskRequest {
     topic: String,
     data: Vec<u8>,
 }
 
 impl RuskRequest {
-    /// New RuskRequesst from topic and data
+    /// New RuskRequest from topic and data
     pub fn new(topic: &str, data: Vec<u8>) -> Self {
         let topic = topic.to_string();
         Self { data, topic }
     }
 
-    /// Return the binary representation of the RuskRequesst
+    /// Return the binary representation of the RuskRequest
     pub fn to_bytes(&self) -> io::Result<Vec<u8>> {
         let mut buffer = vec![];
         buffer.write_all(&(self.topic.len() as u32).to_le_bytes())?;


### PR DESCRIPTION
Add `Profile` struct that holds a `Shielded` (phoenix) and a `Public` (bls) public-key that can be used for generating transactions and staking operations.

This is in line with the terminology used in w3sper.
