### PR TITLE
stake-contract: lower gas expenditure

### DIFF
--- a/contracts/stake/src/state.rs
+++ b/contracts/stake/src/state.rs
@@ -108,10 +108,11 @@ impl StakeState {
         }
 
         let digest = stake.signature_message().to_vec();
-        let pk = keys.multisig_pk().expect("Invalid MultisigPublicKey");
-
-        if !rusk_abi::verify_bls_multisig(digest, pk, signature) {
-            panic!("Invalid signature!");
+        if !rusk_abi::verify_bls(digest.clone(), keys.funds, signature.funds) {
+            panic!("Invalid funds signature!");
+        }
+        if !rusk_abi::verify_bls(digest, keys.account, signature.account) {
+            panic!("Invalid account signature!");
         }
 
         // make call to transfer contract to transfer balance from the user to
@@ -158,11 +159,12 @@ impl StakeState {
         }
 
         // check signature is correct
-        let digest = unstake.signature_message().to_vec();
-        let pk = keys.multisig_pk().expect("Invalid MultisigPublicKey");
-
-        if !rusk_abi::verify_bls_multisig(digest, pk, signature) {
-            panic!("Invalid signature!");
+        let digest = unstake.signature_message();
+        if !rusk_abi::verify_bls(digest.clone(), keys.funds, signature.funds) {
+            panic!("Invalid funds signature!");
+        }
+        if !rusk_abi::verify_bls(digest, keys.account, signature.account) {
+            panic!("Invalid account signature!");
         }
 
         // make call to the transfer contract to withdraw funds from this
@@ -203,10 +205,12 @@ impl StakeState {
         }
 
         // check signature is correct
-        let digest = withdraw.signature_message().to_vec();
-        let pk = keys.multisig_pk().expect("Invalid MultisigPublicKey");
-        if !rusk_abi::verify_bls_multisig(digest, pk, signature) {
-            panic!("Invalid signature!");
+        let digest = withdraw.signature_message();
+        if !rusk_abi::verify_bls(digest.clone(), keys.funds, signature.funds) {
+            panic!("Invalid funds signature!");
+        }
+        if !rusk_abi::verify_bls(digest, keys.account, signature.account) {
+            panic!("Invalid account signature!");
         }
 
         // make call to the transfer contract to withdraw funds from this


### PR DESCRIPTION
The culprit of the gas expenditure was the "in-contract" aggregation of bls public keys.

The following function was consuming more than 540M gas points
```rust
    /// Return the `MultisigPublicKey` associated to this `StakeKeys`
    ///
    /// # Errors
    ///
    /// Look at `MultisigPublicKey::aggregate`
    pub fn multisig_pk(&self) -> Result<BlsMultisigPublicKey, BlsError> {
        BlsMultisigPublicKey::aggregate(&[self.account, self.funds])
    }
```

Removing the BlsMultisig in favor of a (less elegant) DoubleSignature struct resulted in a way less gas spent


| **Operation**                                      | **Gas Cost (before)**                          | **Gas Cost (now)** | **Saving**
|----------------------------------------------------|---------------------------------------|-----------|-----|
| STAKE                                              | 556,720,723                           |    10,351,519       |      98.14%    | 
| WITHDRAW                                           | 586,379,923                           |  40,013,913         |      93.18%    |
| UNSTAKE                                            | 586,441,152                           |     40,072,894      |      93.17%    |


Resolves #2677