### PR TITLE
wallet-core: Always create transparent notes if the transfer-value is 0

### DIFF
--- a/execution-core/src/transfer/phoenix.rs
+++ b/execution-core/src/transfer/phoenix.rs
@@ -119,7 +119,7 @@ impl Transaction {
         inputs: Vec<(Note, NoteOpening)>,
         root: BlsScalar,
         transfer_value: u64,
-        obfuscated_transaction: bool,
+        obfuscate_transfer_note: bool,
         deposit: u64,
         gas_limit: u64,
         gas_price: u64,
@@ -167,7 +167,7 @@ impl Transaction {
         }
 
         // Generate output notes:
-        let transfer_value_blinder = if obfuscated_transaction {
+        let transfer_value_blinder = if obfuscate_transfer_note {
             JubJubScalar::random(&mut *rng)
         } else {
             JubJubScalar::zero()
@@ -180,7 +180,7 @@ impl Transaction {
             JubJubScalar::random(&mut *rng),
             JubJubScalar::random(&mut *rng),
         ];
-        let transfer_note = if obfuscated_transaction {
+        let transfer_note = if obfuscate_transfer_note {
             Note::obfuscated(
                 rng,
                 &sender_pk,

--- a/wallet-core/src/transaction.rs
+++ b/wallet-core/src/transaction.rs
@@ -59,7 +59,7 @@ pub fn phoenix<R: RngCore + CryptoRng, P: Prove>(
     inputs: Vec<(Note, NoteOpening)>,
     root: BlsScalar,
     transfer_value: u64,
-    obfuscated_transaction: bool,
+    is_transfer: bool,
     deposit: u64,
     gas_limit: u64,
     gas_price: u64,
@@ -67,12 +67,12 @@ pub fn phoenix<R: RngCore + CryptoRng, P: Prove>(
     data: Option<impl Into<TransactionData>>,
     prover: &P,
 ) -> Result<Transaction, Error> {
-    // always create a transparent transaction if the transfer-value is 0
-    // this makes it possible for the transfer-contract to filter on those notes
-    // and not add them to the tree
-    let mut obfuscated_transaction = obfuscated_transaction;
+    // always create a transparent transfer-note (the change-note will always be
+    // obfuscated) if the transfer-value is 0 (the transfer-contract doesn't
+    // append transparent notes with value 0 to the tree)
+    let mut obfuscate_transfer_note = is_transfer;
     if transfer_value == 0 {
-        obfuscated_transaction = false;
+        obfuscate_transfer_note = false;
     }
 
     Ok(PhoenixTransaction::new::<R, P>(
@@ -83,7 +83,7 @@ pub fn phoenix<R: RngCore + CryptoRng, P: Prove>(
         inputs,
         root,
         transfer_value,
-        obfuscated_transaction,
+        obfuscate_transfer_note,
         deposit,
         gas_limit,
         gas_price,
@@ -164,7 +164,7 @@ pub fn phoenix_stake<R: RngCore + CryptoRng, P: Prove>(
     let phoenix_refund_pk = PhoenixPublicKey::from(phoenix_sender_sk);
 
     let transfer_value = 0;
-    let obfuscated_transaction = false;
+    let is_transfer = false;
     let deposit = stake_value;
 
     let stake = Stake::new(stake_sk, stake_value, stake_nonce, chain_id);
@@ -179,7 +179,7 @@ pub fn phoenix_stake<R: RngCore + CryptoRng, P: Prove>(
         inputs,
         root,
         transfer_value,
-        obfuscated_transaction,
+        is_transfer,
         deposit,
         gas_limit,
         gas_price,
@@ -258,7 +258,7 @@ pub fn phoenix_stake_reward<R: RngCore + CryptoRng, P: Prove>(
     let phoenix_refund_pk = PhoenixPublicKey::from(phoenix_sender_sk);
 
     let transfer_value = 0;
-    let obfuscated_transaction = false;
+    let is_transfer = false;
     let deposit = 0;
 
     // split the input notes and openings from the nullifiers
@@ -289,7 +289,7 @@ pub fn phoenix_stake_reward<R: RngCore + CryptoRng, P: Prove>(
         inputs,
         root,
         transfer_value,
-        obfuscated_transaction,
+        is_transfer,
         deposit,
         gas_limit,
         gas_price,
@@ -372,7 +372,7 @@ pub fn phoenix_unstake<R: RngCore + CryptoRng, P: Prove>(
     let phoenix_refund_pk = PhoenixPublicKey::from(phoenix_sender_sk);
 
     let transfer_value = 0;
-    let obfuscated_transaction = false;
+    let is_transfer = false;
     let deposit = 0;
 
     // split the input notes and openings from the nullifiers
@@ -403,7 +403,7 @@ pub fn phoenix_unstake<R: RngCore + CryptoRng, P: Prove>(
         inputs,
         root,
         transfer_value,
-        obfuscated_transaction,
+        is_transfer,
         deposit,
         gas_limit,
         gas_price,
@@ -492,7 +492,7 @@ pub fn phoenix_to_moonlight<R: RngCore + CryptoRng, P: Prove>(
     let phoenix_refund_pk = PhoenixPublicKey::from(phoenix_sender_sk);
 
     let transfer_value = 0;
-    let obfuscated_transaction = false;
+    let is_transfer = false;
     // a conversion is a simultaneous deposit to *and* withdrawal from the
     // transfer contract
     let deposit = convert_value;
@@ -524,7 +524,7 @@ pub fn phoenix_to_moonlight<R: RngCore + CryptoRng, P: Prove>(
         inputs,
         root,
         transfer_value,
-        obfuscated_transaction,
+        is_transfer,
         deposit,
         gas_limit,
         gas_price,
@@ -613,7 +613,7 @@ pub fn phoenix_deployment<R: RngCore + CryptoRng, P: Prove>(
     let phoenix_refund_pk = PhoenixPublicKey::from(phoenix_sender_sk);
 
     let transfer_value = 0;
-    let obfuscated_transaction = false;
+    let is_transfer = false;
     let deposit = 0;
 
     // split the input notes and openings from the nullifiers
@@ -645,7 +645,7 @@ pub fn phoenix_deployment<R: RngCore + CryptoRng, P: Prove>(
         inputs,
         root,
         transfer_value,
-        obfuscated_transaction,
+        is_transfer,
         deposit,
         gas_limit,
         gas_price,

--- a/wallet-core/src/transaction.rs
+++ b/wallet-core/src/transaction.rs
@@ -67,6 +67,14 @@ pub fn phoenix<R: RngCore + CryptoRng, P: Prove>(
     data: Option<impl Into<TransactionData>>,
     prover: &P,
 ) -> Result<Transaction, Error> {
+    // always create a transparent transaction if the transfer-value is 0
+    // this makes it possible for the transfer-contract to filter on those notes
+    // and not add them to the tree
+    let mut obfuscated_transaction = obfuscated_transaction;
+    if transfer_value == 0 {
+        obfuscated_transaction = false;
+    }
+
     Ok(PhoenixTransaction::new::<R, P>(
         rng,
         sender_sk,
@@ -484,9 +492,10 @@ pub fn phoenix_to_moonlight<R: RngCore + CryptoRng, P: Prove>(
     let phoenix_refund_pk = PhoenixPublicKey::from(phoenix_sender_sk);
 
     let transfer_value = 0;
-    let obfuscated_transaction = true;
-    let deposit = convert_value; // a convertion is a simultaneous deposit to *and* withdrawal from the
-                                 // transfer contract
+    let obfuscated_transaction = false;
+    // a conversion is a simultaneous deposit to *and* withdrawal from the
+    // transfer contract
+    let deposit = convert_value;
 
     // split the input notes and openings from the nullifiers
     let mut nullifiers = Vec::with_capacity(inputs.len());
@@ -604,7 +613,7 @@ pub fn phoenix_deployment<R: RngCore + CryptoRng, P: Prove>(
     let phoenix_refund_pk = PhoenixPublicKey::from(phoenix_sender_sk);
 
     let transfer_value = 0;
-    let obfuscated_transaction = true;
+    let obfuscated_transaction = false;
     let deposit = 0;
 
     // split the input notes and openings from the nullifiers


### PR DESCRIPTION
Resolves #2689 