### PR TITLE
rusk-wallet: Add stdout_format flag to binary

### DIFF
--- a/rusk-wallet/src/bin/command.rs
+++ b/rusk-wallet/src/bin/command.rs
@@ -696,28 +696,37 @@ impl<'a> RunResult<'a> {
                     "hash": hex
                 })
             }
-            StakeInfo(data, _) => match data.amount {
-                Some(amt) => {
-                    let amount = Dusk::from(amt.value).to_string();
-                    let locked = Dusk::from(amt.locked).to_string();
-                    let faults = data.faults.to_string();
-                    let hard_faults = data.hard_faults.to_string();
-                    let eligibility = amt.eligibility.to_string();
-                    let epoch = (amt.eligibility / EPOCH).to_string();
-                    let rewards = Dusk::from(data.reward).to_string();
+            StakeInfo(data, _) => {
+                let faults = data.faults.to_string();
+                let hard_faults = data.hard_faults.to_string();
+                let rewards = Dusk::from(data.reward).to_string();
 
-                    json!({
-                        "rewards": rewards,
-                        "amount": amount,
-                        "locked": locked,
-                        "eligibility": eligibility,
-                        "epoch": epoch,
-                        "hard_faults": hard_faults,
-                        "faults": faults,
-                    })
+                match data.amount {
+                    Some(amt) => {
+                        let amount = Dusk::from(amt.value).to_string();
+                        let locked = Dusk::from(amt.locked).to_string();
+                        let eligibility = amt.eligibility.to_string();
+                        let epoch = (amt.eligibility / EPOCH).to_string();
+
+                        json!({
+                            "rewards": rewards,
+                            "amount": amount,
+                            "locked": locked,
+                            "eligibility": eligibility,
+                            "epoch": epoch,
+                            "hard_faults": hard_faults,
+                            "faults": faults,
+                        })
+                    }
+                    None => {
+                        json!({
+                            "rewards": rewards,
+                            "faults": faults,
+                            "hard_faults": hard_faults
+                        })
+                    }
                 }
-                None => serde_json::Value::Null,
-            },
+            }
             ExportedKeys(pk, kp) => {
                 let pk = pk.as_os_str();
                 let kp = kp.as_os_str();
@@ -812,8 +821,9 @@ impl<'a> fmt::Display for RunResult<'a> {
                 writeln!(f, "> Hard Slashes: {hard_faults}")?;
                 write!(f, "> Accumulated rewards is: {rewards} DUSK")
             }
-            ContractId(bytes) => {
-                write!(f, "> Contract ID: {}", hex::encode(bytes))
+            ContractId((bytes, nonce)) => {
+                write!(f, "> Contract ID: {}", hex::encode(bytes))?;
+                write!(f, "> Deploy nonce: {}", nonce)
             }
             ExportedKeys(pk, kp) => {
                 let pk = pk.display();

--- a/rusk-wallet/src/bin/interactive.rs
+++ b/rusk-wallet/src/bin/interactive.rs
@@ -18,7 +18,7 @@ use rusk_wallet::{
 };
 
 use crate::{
-    io::{self, prompt},
+    io::{self, prompt, GraphQL},
     settings::Settings,
     Command, GraphQL, RunResult, WalletFile,
 };

--- a/rusk-wallet/src/bin/io/args.rs
+++ b/rusk-wallet/src/bin/io/args.rs
@@ -44,6 +44,11 @@ pub(crate) struct WalletArgs {
     #[arg(long, value_enum, default_value_t = LogFormat::Coloured)]
     pub log_type: LogFormat,
 
+    /// format of the result messages written to stdout after a wallet
+    /// operation
+    #[clap(long, value_enum, default_value_t = LogFormat::Plain)]
+    pub stdout_format: LogFormat,
+
     /// Command
     #[command(subcommand)]
     pub command: Option<Command>,

--- a/rusk-wallet/src/wallet/address.rs
+++ b/rusk-wallet/src/wallet/address.rs
@@ -230,12 +230,8 @@ impl Profile {
     /// format the profile into a json value
     pub fn to_json(&self) -> serde_json::Value {
         json!({
-            "shielded": String::from(&Address::Shielded {
-                addr: self.shielded_addr
-            }),
-            "public": String::from(&Address::Public {
-                addr: self.public_addr
-            }),
+            "shielded": String::from(&Address::Shielded(self.shielded_addr)),
+            "public": String::from(&Address::Public(self.public_addr)),
         })
     }
 }

--- a/rusk-wallet/src/wallet/address.rs
+++ b/rusk-wallet/src/wallet/address.rs
@@ -11,6 +11,7 @@ use super::*;
 use crate::Error;
 
 use dusk_bytes::{DeserializableSlice, Serializable};
+use serde_json::json;
 
 /// Address to perform a transaction with.
 #[derive(Clone, Eq)]
@@ -224,6 +225,18 @@ impl Profile {
         }
 
         index_string
+    }
+
+    /// format the profile into a json value
+    pub fn to_json(&self) -> serde_json::Value {
+        json!({
+            "shielded": String::from(&Address::Shielded {
+                addr: self.shielded_addr
+            }),
+            "public": String::from(&Address::Public {
+                addr: self.public_addr
+            }),
+        })
     }
 }
 


### PR DESCRIPTION
Closes #2664 

- Add stdout_format flag to binary
- Add `to_json` for `RunResult`
- Remove duplicate code in main.rs

Fetch moonlight address

```
cargo r -- -n testnet --password '' --stdout-format json profiles  | jq '.[] | .public'
```

Find stake-info

```
cargo r -- -n testnet --password '' --stdout-format json stake-info
```