### PR TITLE
rusk-wallet: Split `prove` and `propagate`

### DIFF
--- a/rusk-wallet/src/clients.rs
+++ b/rusk-wallet/src/clients.rs
@@ -154,13 +154,9 @@ impl State {
         sync_db(&self.client, &self.cache(), &self.store, self.status).await
     }
 
-    /// Requests that a node prove the given transaction and later propagates it
-    /// Skips writing the proof for non phoenix transactions
-    pub async fn prove_and_propagate(
-        &self,
-        tx: Transaction,
-    ) -> Result<Transaction, Error> {
-        let status = self.status;
+    /// Requests that a node prove the given shielded transaction.
+    /// Returns the transaction unchanged for unshielded transaction.
+    pub async fn prove(&self, tx: Transaction) -> Result<Transaction, Error> {
         let prover = &self.prover;
         let mut tx = tx;
 
@@ -182,6 +178,15 @@ impl State {
             status("Proving sucesss!");
         }
 
+        Ok(tx)
+    }
+
+    /// Propagate a transaction to a node.
+    pub async fn propagate(
+        &self,
+        tx: Transaction,
+    ) -> Result<Transaction, Error> {
+        let status = self.status;
         let tx_bytes = tx.to_var_bytes();
 
         status("Attempt to preverify tx...");

--- a/rusk-wallet/src/wallet.rs
+++ b/rusk-wallet/src/wallet.rs
@@ -474,7 +474,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         sender_sk.zeroize();
 
-        state.prove_and_propagate(tx).await
+        state.propagate(tx).await
     }
 
     /// Executes a generic contract call, paying gas with a shielded address.
@@ -528,7 +528,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         sender_sk.zeroize();
 
-        state.prove_and_propagate(tx).await
+        let tx = state.prove(tx).await?;
+        state.propagate(tx).await
     }
 
     /// Transfers funds between shielded addresses.
@@ -586,7 +587,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         sender_sk.zeroize();
 
-        state.prove_and_propagate(tx).await
+        let tx = state.prove(tx).await?;
+        state.propagate(tx).await
     }
 
     /// Transfers funds between public accounts.
@@ -629,7 +631,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         sender_sk.zeroize();
 
-        state.prove_and_propagate(tx).await
+        state.propagate(tx).await
     }
 
     /// Stakes Dusk using shielded notes.
@@ -683,7 +685,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         sender_sk.zeroize();
         stake_sk.zeroize();
 
-        state.prove_and_propagate(stake).await
+        let stake = state.prove(stake).await?;
+        state.propagate(stake).await
     }
 
     /// Stakes Dusk using a public account.
@@ -732,7 +735,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         stake_sk.zeroize();
 
-        state.prove_and_propagate(stake).await
+        state.propagate(stake).await
     }
 
     /// Obtains stake information for a given address.
@@ -790,7 +793,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         sender_sk.zeroize();
         stake_sk.zeroize();
 
-        state.prove_and_propagate(unstake).await
+        let unstake = state.prove(unstake).await?;
+        state.propagate(unstake).await
     }
 
     /// Unstakes Dusk onto a public account.
@@ -832,7 +836,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         stake_sk.zeroize();
 
-        state.prove_and_propagate(unstake).await
+        state.propagate(unstake).await
     }
 
     /// Withdraws accumulated staking to a shielded address.
@@ -874,7 +878,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         sender_sk.zeroize();
         stake_sk.zeroize();
 
-        state.prove_and_propagate(withdraw).await
+        let withdraw = state.prove(withdraw).await?;
+        state.propagate(withdraw).await
     }
 
     /// Converts Dusk from a shielded address to a public account.
@@ -913,7 +918,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         phoenix_sk.zeroize();
         moonlight_sk.zeroize();
 
-        state.prove_and_propagate(convert).await
+        let convert = state.prove(convert).await?;
+        state.propagate(convert).await
     }
 
     /// Converts Dusk from a public account to a shielded address.
@@ -948,7 +954,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         phoenix_sk.zeroize();
         moonlight_sk.zeroize();
 
-        state.prove_and_propagate(convert).await
+        state.propagate(convert).await
     }
 
     /// Withdraws accumulated staking reward to a public account.
@@ -976,7 +982,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         sender_sk.zeroize();
 
-        state.prove_and_propagate(withdraw).await
+        state.propagate(withdraw).await
     }
 
     /// Deploys a contract using a public account to pay gas.
@@ -1010,7 +1016,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         sender_sk.zeroize();
 
-        state.prove_and_propagate(deploy).await
+        state.propagate(deploy).await
     }
 
     /// Deploys a contract using shielded notes to pay gas.
@@ -1050,7 +1056,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         sender_sk.zeroize();
 
-        state.prove_and_propagate(deploy).await
+        let deploy = state.prove(deploy).await?;
+        state.propagate(deploy).await
     }
 
     /// Returns BLS key-pair for provisioner nodes


### PR DESCRIPTION
Resolves #2708