### PR TITLE
Disable future quorum propagation

### DIFF
--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -146,21 +146,12 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
                     match msg.payload {
                         Payload::Candidate(_)
                         | Payload::Validation(_)
-                        | Payload::Ratification(_) => {
-                            // Re-route message to the Consensus
-                            let acc = self.acceptor.as_ref().expect("initialize is called");
-                            if let Err(e) = acc.read().await.reroute_msg(msg).await {
-                                warn!("Could not reroute msg to Consensus: {}", e);
-                            }
-                        },
-
-                        Payload::Quorum(ref quorum) => {
-                            debug!(
-                                event = "Quorum received",
-                                src = "wire",
-                                round = msg.header.round,
-                                iter = msg.header.iteration,
-                                vote = ?quorum.vote(),
+                        | Payload::Ratification(_)
+                        | Payload::Quorum(_) => {
+                              debug!(
+                                event = "Consensus message received",
+                                topic = ?msg.topic(),
+                                info = ?msg.header,
                                 metadata = ?msg.metadata,
                             );
 
@@ -173,8 +164,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
 
                         Payload::Block(blk) => {
                             info!(
-                                event = "Block received",
-                                src = "wire",
+                                event = "Block message received",
                                 blk_height = blk.header().height,
                                 blk_hash = to_str(&blk.header().hash),
                                 metadata = ?msg.metadata,

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -429,10 +429,9 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
                     }
 
                     Status::Future => {
-                        //INFO: we currently rebroadcast future Quorums without
-                        // any check
-                        debug!("Rebroadcast Quorum for future round");
-                        broadcast(&self.network, &msg).await;
+                        // We do not rebroadcast future Quorum messages because
+                        // we cannot pre-verify them and we want to avoid
+                        // potential DoS attacks
                     }
                 }
             }


### PR DESCRIPTION
Solves #2171 

REFACTORING:
 - `execute`: merge handling of Quorum with other Consensus messages (avoids duplicated logic)
 - `reroute_msg`:
    - discard non-consensus messages at the beginning
    - check if consensus task is running at the beginning and repropagate all (consensus) messages if not running

BUGFIX:
  - `reroute_msg`: change `msg_round >= tip_height` to `msg_round > tip_height` check to avoid passing to the consensus task messages for the previous round (current round is tip+1)

CHANGES:
  - Do not rebroadcast Quorum messages from the future (unless we are synchronizing)