### PR TITLE
rusk-wallet: handle reconnection without restart

### DIFF
--- a/rusk-wallet/src/bin/interactive/command_menu.rs
+++ b/rusk-wallet/src/bin/interactive/command_menu.rs
@@ -37,9 +37,8 @@ pub(crate) fn online(
     phoenix_balance: Dusk,
     moonlight_balance: Dusk,
     settings: &Settings,
-    is_synced: bool,
 ) -> anyhow::Result<ProfileOp> {
-    let mut cmd_menu = Menu::new()
+    let cmd_menu = Menu::new()
         .add(MenuItem::History, "Show Transactions History")
         .add(MenuItem::Transfer, "Transfer Dusk")
         .add(MenuItem::Unshield, "Convert Shielded Dusk to Public Dusk")
@@ -56,20 +55,8 @@ pub(crate) fn online(
         .add(MenuItem::Back, "Back")
         .separator();
 
-    let msg = if !is_synced {
-        cmd_menu = Menu::new()
-            .add(MenuItem::Export, "Export provisioner key-pair")
-            .separator()
-            .add(MenuItem::Back, "Back")
-            .separator();
-
-        "The wallet is still syncing. Please come back to display new information."
-    } else {
-        "What do you like to do?"
-    };
-
     let q = Question::select("theme")
-        .message(msg)
+        .message("What do you like to do?")
         .choices(cmd_menu.clone())
         .build();
 

--- a/rusk-wallet/src/bin/interactive/command_menu.rs
+++ b/rusk-wallet/src/bin/interactive/command_menu.rs
@@ -58,6 +58,7 @@ pub(crate) fn online(
     let q = Question::select("theme")
         .message("What do you like to do?")
         .choices(cmd_menu.clone())
+        .page_size(20)
         .build();
 
     let answer = requestty::prompt_one(q)?;

--- a/rusk-wallet/src/clients.rs
+++ b/rusk-wallet/src/clients.rs
@@ -110,6 +110,10 @@ impl State {
         })
     }
 
+    pub async fn check_connection(&self) -> bool {
+        self.client.check_connection().await.is_ok()
+    }
+
     pub(crate) fn cache(&self) -> Arc<Cache> {
         let state = self.cache.lock().unwrap();
 

--- a/rusk-wallet/src/wallet.rs
+++ b/rusk-wallet/src/wallet.rs
@@ -279,7 +279,11 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
     /// Checks if the wallet has an active connection to the network
     pub async fn is_online(&self) -> bool {
-        self.state.is_some()
+        if let Some(state) = &self.state {
+            state.check_connection().await
+        } else {
+            false
+        }
     }
 
     /// Fetches the notes from the state.
@@ -567,7 +571,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
     }
 
     /// Check if the wallet is synced
-    pub async fn is_synced(&mut self) -> Result<bool, Error> {
+    pub async fn is_synced(&self) -> Result<bool, Error> {
         let state = self.state()?;
         let db_pos = state.cache().last_pos()?.unwrap_or(0);
         let network_last_pos = state.fetch_num_notes().await? - 1;


### PR DESCRIPTION
rusk-wallet starts properly when no connection is available, allowing the users to perform basic operations like keys exporting 
If the connection is back, the wallet automatically restore and let the user to continue operate with it

in the future we can increase the allowed operation to new features like:
- change password
- offline history
- etc...


Additionally, the menu is the same for both synced and unsyced status, letting the user to perform moonlight operation while syncing with phoenix status


Resolves https://github.com/dusk-network/rusk/issues/2655