### PR TITLE
explorer: Provisioners Page Updates

### DIFF
--- a/explorer/src/lib/components/__tests__/__snapshots__/ProvisionersCard.spec.js.snap
+++ b/explorer/src/lib/components/__tests__/__snapshots__/ProvisionersCard.spec.js.snap
@@ -52,14 +52,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <th
               class="table__header-cell"
             >
-              Staked Amount (DUSK)
-            </th>
-            
-             
-            <th
-              class="table__header-cell"
-            >
-              Reclaimable Staked Amount (DUSK)
+              Stake Amount (DUSK)
             </th>
             
              
@@ -67,13 +60,6 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
               class="table__header-cell"
             >
               Slashes
-            </th>
-            
-             
-            <th
-              class="table__header-cell"
-            >
-              Hard Slashes
             </th>
             
              
@@ -103,13 +89,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Reclaimable:
+              </b>
+               
               500,000
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Locked:
+              </b>
+               
               0
             </td>
             
@@ -117,13 +112,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Soft:
+              </b>
+               
               0
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Hard:
+              </b>
+               
               0
             </td>
             
@@ -150,13 +154,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Reclaimable:
+              </b>
+               
               500,000
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Locked:
+              </b>
+               
               0
             </td>
             
@@ -164,13 +177,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Soft:
+              </b>
+               
               0
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Hard:
+              </b>
+               
               0
             </td>
             
@@ -197,13 +219,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Reclaimable:
+              </b>
+               
               4,800
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Locked:
+              </b>
+               
               0
             </td>
             
@@ -211,13 +242,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Soft:
+              </b>
+               
               0
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Hard:
+              </b>
+               
               0
             </td>
             
@@ -244,13 +284,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Reclaimable:
+              </b>
+               
               1,234
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Locked:
+              </b>
+               
               0
             </td>
             
@@ -258,13 +307,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Soft:
+              </b>
+               
               0
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Hard:
+              </b>
+               
               0
             </td>
             
@@ -291,13 +349,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Reclaimable:
+              </b>
+               
               500,000
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Locked:
+              </b>
+               
               0
             </td>
             
@@ -305,13 +372,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Soft:
+              </b>
+               
               0
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Hard:
+              </b>
+               
               0
             </td>
             
@@ -338,13 +414,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Reclaimable:
+              </b>
+               
               4,800
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Locked:
+              </b>
+               
               0
             </td>
             
@@ -352,13 +437,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Soft:
+              </b>
+               
               0
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Hard:
+              </b>
+               
               0
             </td>
             
@@ -385,13 +479,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Reclaimable:
+              </b>
+               
               500,000
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Locked:
+              </b>
+               
               0
             </td>
             
@@ -399,13 +502,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Soft:
+              </b>
+               
               0
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Hard:
+              </b>
+               
               0
             </td>
             
@@ -432,13 +544,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Reclaimable:
+              </b>
+               
               1,000
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Locked:
+              </b>
+               
               0
             </td>
             
@@ -446,13 +567,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Soft:
+              </b>
+               
               0
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Hard:
+              </b>
+               
               0
             </td>
             
@@ -479,13 +609,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Reclaimable:
+              </b>
+               
               500,000
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Locked:
+              </b>
+               
               0
             </td>
             
@@ -493,13 +632,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Soft:
+              </b>
+               
               0
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Hard:
+              </b>
+               
               0
             </td>
             
@@ -526,13 +674,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Reclaimable:
+              </b>
+               
               500,000
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__staked-amount-type-label"
+              >
+                Locked:
+              </b>
+               
               0
             </td>
             
@@ -540,13 +697,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             <td
               class="table__data-cell"
             >
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Soft:
+              </b>
+               
               0
-            </td>
-            
-             
-            <td
-              class="table__data-cell"
-            >
+               
+              <br />
+               
+              <b
+                class="provisioners-table__slash-type-label"
+              >
+                Hard:
+              </b>
+               
               0
             </td>
             

--- a/explorer/src/lib/components/__tests__/__snapshots__/ProvisionersList.spec.js.snap
+++ b/explorer/src/lib/components/__tests__/__snapshots__/ProvisionersList.spec.js.snap
@@ -18,7 +18,11 @@ exports[`Provisioners List > renders the \`ProvisionersList\` component 1`] = `
   <dd
     class="details-list__definition details-list__definition--table"
   >
-    m6dy2gz3jC3ifLpZmdTaZbgcptWxRr...UgMi1uSCne1ti5kgYeNHtW82FWtnpf
+    <span
+      class="provisioners-list__staking-address"
+    >
+      m6dy2gz3jC3ifLpZmdTaZbgcp...uSCne1ti5kgYeNHtW82FWtnpf
+    </span>
   </dd>
    
   <dt
@@ -28,7 +32,25 @@ exports[`Provisioners List > renders the \`ProvisionersList\` component 1`] = `
       class="details-list__term-layout"
     >
        
-      staked amount
+      Locked Stake Amount
+    </div>
+  </dt>
+   
+  <dd
+    class="details-list__definition details-list__definition--table"
+  >
+    0
+     DUSK
+  </dd>
+   
+  <dt
+    class="details-list__term details-list__term--table"
+  >
+    <div
+      class="details-list__term-layout"
+    >
+       
+      Reclaimable Stake Amount
     </div>
   </dt>
    
@@ -46,25 +68,7 @@ exports[`Provisioners List > renders the \`ProvisionersList\` component 1`] = `
       class="details-list__term-layout"
     >
        
-      Reclaimable Staked Amount
-    </div>
-  </dt>
-   
-  <dd
-    class="details-list__definition details-list__definition--table"
-  >
-    0
-     DUSK
-  </dd>
-   
-  <dt
-    class="details-list__term details-list__term--table"
-  >
-    <div
-      class="details-list__term-layout"
-    >
-       
-      slashes
+      Soft Slashes
     </div>
   </dt>
    
@@ -81,7 +85,7 @@ exports[`Provisioners List > renders the \`ProvisionersList\` component 1`] = `
       class="details-list__term-layout"
     >
        
-      hard slashes
+      Hard Slashes
     </div>
   </dt>
    

--- a/explorer/src/lib/components/__tests__/__snapshots__/ProvisionersTable.spec.js.snap
+++ b/explorer/src/lib/components/__tests__/__snapshots__/ProvisionersTable.spec.js.snap
@@ -23,14 +23,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <th
           class="table__header-cell"
         >
-          Staked Amount (DUSK)
-        </th>
-        
-         
-        <th
-          class="table__header-cell"
-        >
-          Reclaimable Staked Amount (DUSK)
+          Stake Amount (DUSK)
         </th>
         
          
@@ -38,13 +31,6 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
           class="table__header-cell"
         >
           Slashes
-        </th>
-        
-         
-        <th
-          class="table__header-cell"
-        >
-          Hard Slashes
         </th>
         
          
@@ -74,13 +60,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Reclaimable:
+          </b>
+           
           500,000
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Locked:
+          </b>
+           
           0
         </td>
         
@@ -88,13 +83,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Soft:
+          </b>
+           
           0
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Hard:
+          </b>
+           
           0
         </td>
         
@@ -121,13 +125,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Reclaimable:
+          </b>
+           
           500,000
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Locked:
+          </b>
+           
           0
         </td>
         
@@ -135,13 +148,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Soft:
+          </b>
+           
           0
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Hard:
+          </b>
+           
           0
         </td>
         
@@ -168,13 +190,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Reclaimable:
+          </b>
+           
           4,800
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Locked:
+          </b>
+           
           0
         </td>
         
@@ -182,13 +213,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Soft:
+          </b>
+           
           0
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Hard:
+          </b>
+           
           0
         </td>
         
@@ -215,13 +255,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Reclaimable:
+          </b>
+           
           1,234
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Locked:
+          </b>
+           
           0
         </td>
         
@@ -229,13 +278,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Soft:
+          </b>
+           
           0
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Hard:
+          </b>
+           
           0
         </td>
         
@@ -262,13 +320,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Reclaimable:
+          </b>
+           
           500,000
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Locked:
+          </b>
+           
           0
         </td>
         
@@ -276,13 +343,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Soft:
+          </b>
+           
           0
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Hard:
+          </b>
+           
           0
         </td>
         
@@ -309,13 +385,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Reclaimable:
+          </b>
+           
           4,800
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Locked:
+          </b>
+           
           0
         </td>
         
@@ -323,13 +408,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Soft:
+          </b>
+           
           0
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Hard:
+          </b>
+           
           0
         </td>
         
@@ -356,13 +450,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Reclaimable:
+          </b>
+           
           500,000
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Locked:
+          </b>
+           
           0
         </td>
         
@@ -370,13 +473,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Soft:
+          </b>
+           
           0
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Hard:
+          </b>
+           
           0
         </td>
         
@@ -403,13 +515,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Reclaimable:
+          </b>
+           
           1,000
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Locked:
+          </b>
+           
           0
         </td>
         
@@ -417,13 +538,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Soft:
+          </b>
+           
           0
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Hard:
+          </b>
+           
           0
         </td>
         
@@ -450,13 +580,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Reclaimable:
+          </b>
+           
           500,000
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Locked:
+          </b>
+           
           0
         </td>
         
@@ -464,13 +603,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Soft:
+          </b>
+           
           0
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Hard:
+          </b>
+           
           0
         </td>
         
@@ -497,13 +645,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Reclaimable:
+          </b>
+           
           500,000
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__staked-amount-type-label"
+          >
+            Locked:
+          </b>
+           
           0
         </td>
         
@@ -511,13 +668,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         <td
           class="table__data-cell"
         >
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Soft:
+          </b>
+           
           0
-        </td>
-        
-         
-        <td
-          class="table__data-cell"
-        >
+           
+          <br />
+           
+          <b
+            class="provisioners-table__slash-type-label"
+          >
+            Hard:
+          </b>
+           
           0
         </td>
         

--- a/explorer/src/lib/components/__tests__/__snapshots__/TransactionsList.spec.js.snap
+++ b/explorer/src/lib/components/__tests__/__snapshots__/TransactionsList.spec.js.snap
@@ -22,7 +22,7 @@ exports[`Transactions List > should render the \`TransactionsList\` component in
       class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
       href="/some-base-path/transactions/transaction?id=4877687c2dbf154248d3ddee9ba0d81e3431f39056f82a46819da041d4ac0e04"
     >
-      4877687c2dbf154248d3ddee9ba0d8...31f39056f82a46819da041d4ac0e04
+      4877687c2dbf154248d3ddee9...056f82a46819da041d4ac0e04
     </a>
   </dd>
    
@@ -155,7 +155,7 @@ exports[`Transactions List > should render the \`TransactionsList\` component in
       class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
       href="/some-base-path/transactions/transaction?id=4877687c2dbf154248d3ddee9ba0d81e3431f39056f82a46819da041d4ac0e04"
     >
-      4877687c2dbf154248d3ddee9ba0d8...31f39056f82a46819da041d4ac0e04
+      4877687c2dbf154248d3ddee9...056f82a46819da041d4ac0e04
     </a>
   </dd>
    

--- a/explorer/src/lib/components/provisioners-list/ProvisionersList.css
+++ b/explorer/src/lib/components/provisioners-list/ProvisionersList.css
@@ -1,0 +1,3 @@
+.provisioners-list__staking-address {
+  text-transform: uppercase;
+}

--- a/explorer/src/lib/components/provisioners-list/ProvisionersList.svelte
+++ b/explorer/src/lib/components/provisioners-list/ProvisionersList.svelte
@@ -7,6 +7,8 @@
   import { calculateAdaptiveCharCount, middleEllipsis } from "$lib/dusk/string";
   import { onMount } from "svelte";
 
+  import "./ProvisionersList.css";
+
   /** @type {HostProvisioner} */
   export let data;
 
@@ -36,34 +38,34 @@
   <ListItem tooltipText={displayTooltips ? "The staking address used" : ""}>
     <svelte:fragment slot="term">staking address</svelte:fragment>
     <svelte:fragment slot="definition"
-      >{middleEllipsis(
-        data.key,
-        calculateAdaptiveCharCount(screenWidth, 320, 1024, 4, 30)
-      )}</svelte:fragment
+      ><span class="provisioners-list__staking-address"
+        >{middleEllipsis(
+          data.key,
+          calculateAdaptiveCharCount(screenWidth, 320, 1024, 4, 25)
+        )}</span
+      ></svelte:fragment
     >
   </ListItem>
 
-  <!-- STAKED AMOUNT -->
-  <ListItem tooltipText={displayTooltips ? "The staked amount" : ""}>
-    <svelte:fragment slot="term">staked amount</svelte:fragment>
+  <!-- LOCKED STAKED AMOUNT -->
+  <ListItem tooltipText={displayTooltips ? "The locked stake amount" : ""}>
+    <svelte:fragment slot="term">Locked Stake Amount</svelte:fragment>
+    <svelte:fragment slot="definition"
+      >{formatter(luxToDusk(data.locked_amt))} DUSK</svelte:fragment
+    >
+  </ListItem>
+
+  <!-- RECLAIMABLE STAKED AMOUNT -->
+  <ListItem tooltipText={displayTooltips ? "The reclaimable stake amount" : ""}>
+    <svelte:fragment slot="term">Reclaimable Stake Amount</svelte:fragment>
     <svelte:fragment slot="definition"
       >{formatter(luxToDusk(data.amount))} DUSK</svelte:fragment
     >
   </ListItem>
 
-  <!-- RECLAIMABLE STAKED AMOUNT -->
-  <ListItem
-    tooltipText={displayTooltips ? "The reclaimable staked amount" : ""}
-  >
-    <svelte:fragment slot="term">Reclaimable Staked Amount</svelte:fragment>
-    <svelte:fragment slot="definition"
-      >{formatter(data.locked_amt)} DUSK</svelte:fragment
-    >
-  </ListItem>
-
   <!-- SLASHES -->
-  <ListItem tooltipText={displayTooltips ? "Slashes" : ""}>
-    <svelte:fragment slot="term">slashes</svelte:fragment>
+  <ListItem tooltipText={displayTooltips ? "Soft slashes" : ""}>
+    <svelte:fragment slot="term">Soft Slashes</svelte:fragment>
     <svelte:fragment slot="definition">
       {formatter(data.faults)}
     </svelte:fragment>
@@ -71,7 +73,7 @@
 
   <!-- HARD SLASHES -->
   <ListItem tooltipText={displayTooltips ? "Hard slashes" : ""}>
-    <svelte:fragment slot="term">hard slashes</svelte:fragment>
+    <svelte:fragment slot="term">Hard Slashes</svelte:fragment>
     <svelte:fragment slot="definition">
       {formatter(data.hard_faults)}
     </svelte:fragment>

--- a/explorer/src/lib/components/provisioners-table/ProvisionersTable.css
+++ b/explorer/src/lib/components/provisioners-table/ProvisionersTable.css
@@ -1,3 +1,4 @@
-.provisioners-table .table__header-cell {
-  text-wrap: wrap;
+.provisioners-table__staked-amount-type-label,
+.provisioners-table__slash-type-label {
+  font-weight: 500;
 }

--- a/explorer/src/lib/components/provisioners-table/ProvisionersTable.svelte
+++ b/explorer/src/lib/components/provisioners-table/ProvisionersTable.svelte
@@ -31,10 +31,8 @@
   <TableHead>
     <TableRow>
       <TableCell type="th">Staking Address</TableCell>
-      <TableCell type="th">Staked Amount (DUSK)</TableCell>
-      <TableCell type="th">Reclaimable Staked Amount (DUSK)</TableCell>
+      <TableCell type="th">Stake Amount (DUSK)</TableCell>
       <TableCell type="th">Slashes</TableCell>
-      <TableCell type="th">Hard Slashes</TableCell>
       <TableCell type="th">Accumulated Reward (DUSK)</TableCell>
     </TableRow>
   </TableHead>
@@ -45,15 +43,21 @@
           {middleEllipsis(provisioner.key, HASH_CHARS_LENGTH)}
         </TableCell>
         <TableCell>
+          <b class="provisioners-table__staked-amount-type-label"
+            >Reclaimable:</b
+          >
           {numberFormatter(luxToDusk(provisioner.amount))}
-        </TableCell>
-        <TableCell>
+          <br />
+          <b class="provisioners-table__staked-amount-type-label">Locked:</b>
           {numberFormatter(luxToDusk(provisioner.locked_amt))}
         </TableCell>
         <TableCell>
+          <b class="provisioners-table__slash-type-label">Soft:</b>
           {numberFormatter(provisioner.faults)}
+          <br />
+          <b class="provisioners-table__slash-type-label">Hard:</b>
+          {numberFormatter(provisioner.hard_faults)}
         </TableCell>
-        <TableCell>{numberFormatter(provisioner.hard_faults)}</TableCell>
         <TableCell>{numberFormatter(luxToDusk(provisioner.reward))}</TableCell>
       </TableRow>
     {/each}

--- a/explorer/src/lib/components/transactions-list/TransactionsList.svelte
+++ b/explorer/src/lib/components/transactions-list/TransactionsList.svelte
@@ -57,7 +57,7 @@
         href={`/transactions/transaction?id=${data.txid}`}
         >{middleEllipsis(
           data.txid,
-          calculateAdaptiveCharCount(screenWidth, 320, 1024, 4, 30)
+          calculateAdaptiveCharCount(screenWidth, 320, 1024, 4, 25)
         )}</AppAnchor
       >
     </svelte:fragment>

--- a/explorer/src/routes/blocks/block/__tests__/__snapshots__/page.spec.js.snap
+++ b/explorer/src/routes/blocks/block/__tests__/__snapshots__/page.spec.js.snap
@@ -1298,7 +1298,7 @@ exports[`Block Details > should render the Transaction section of the Block Deta
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=3a3f6f90a1012ae751b4448bcb8e98def0ba2b18170239bd69fcf8e2e37f0602"
             >
-              3a3f6f90a1012ae751b4448bcb8e98...ba2b18170239bd69fcf8e2e37f0602
+              3a3f6f90a1012ae751b4448bc...8170239bd69fcf8e2e37f0602
             </a>
           </dd>
            
@@ -1561,7 +1561,7 @@ exports[`Block Details > should render the Transaction section of the Block Deta
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=07bfabea1d94c16f2dc3697fa642f6cecea6e81bf76b9644efbb6e2723b76d00"
             >
-              07bfabea1d94c16f2dc3697fa642f6...a6e81bf76b9644efbb6e2723b76d00
+              07bfabea1d94c16f2dc3697fa...bf76b9644efbb6e2723b76d00
             </a>
           </dd>
            

--- a/explorer/src/routes/provisioners/__tests__/__snapshots__/page.spec.js.snap
+++ b/explorer/src/routes/provisioners/__tests__/__snapshots__/page.spec.js.snap
@@ -51,7 +51,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            m6dy2gz3jC3ifLpZmdTaZbgcptWxRr...UgMi1uSCne1ti5kgYeNHtW82FWtnpf
+            <span
+              class="provisioners-list__staking-address"
+            >
+              m6dy2gz3jC3ifLpZmdTaZbgcp...uSCne1ti5kgYeNHtW82FWtnpf
+            </span>
           </dd>
            
           <dt
@@ -61,7 +65,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -79,25 +101,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -114,7 +118,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -160,7 +164,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            m9dVuRgr3CQX5P5Fxh2t68QRhRFBZF...tCP7UmZ9qF734nJJhb2f94r33pFQyz
+            <span
+              class="provisioners-list__staking-address"
+            >
+              m9dVuRgr3CQX5P5Fxh2t68QRh...mZ9qF734nJJhb2f94r33pFQyz
+            </span>
           </dd>
            
           <dt
@@ -170,7 +178,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -188,25 +214,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -223,7 +231,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -269,7 +277,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            mHGvQ9XdjzuGyixBGrMeeC7EdX9QZN...93rPux7H5V95Q3hPxdxHiTfxTvgn7f
+            <span
+              class="provisioners-list__staking-address"
+            >
+              mHGvQ9XdjzuGyixBGrMeeC7Ed...x7H5V95Q3hPxdxHiTfxTvgn7f
+            </span>
           </dd>
            
           <dt
@@ -279,7 +291,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -297,25 +327,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -332,7 +344,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -378,7 +390,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            mLx5HUo5PhsobwgMJhzL9j8TY7TjC1...q16NreXVk4jmfr3CEHqvBrRgEzoka8
+            <span
+              class="provisioners-list__staking-address"
+            >
+              mLx5HUo5PhsobwgMJhzL9j8TY...eXVk4jmfr3CEHqvBrRgEzoka8
+            </span>
           </dd>
            
           <dt
@@ -388,7 +404,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -406,25 +440,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -441,7 +457,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -487,7 +503,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            mTgXDqkyVacn7zCgoJfk7rKMVbvKhx...7cnz5nRE4uXaAhpCPPSjgAseybAsfU
+            <span
+              class="provisioners-list__staking-address"
+            >
+              mTgXDqkyVacn7zCgoJfk7rKMV...nRE4uXaAhpCPPSjgAseybAsfU
+            </span>
           </dd>
            
           <dt
@@ -497,7 +517,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -515,25 +553,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -550,7 +570,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -596,7 +616,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            mUJHMDEBiTUVJU5U76Krb5wwMXK6R7...y5PeqLyLvCCdgUnQ74FDFHNxRNhoAA
+            <span
+              class="provisioners-list__staking-address"
+            >
+              mUJHMDEBiTUVJU5U76Krb5wwM...LyLvCCdgUnQ74FDFHNxRNhoAA
+            </span>
           </dd>
            
           <dt
@@ -606,7 +630,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -624,25 +666,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -659,7 +683,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -705,7 +729,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            mUUpjnXow2LHwm8a65cJsckTeQz55m...kfq8pxrsre7jNbLdDocqSfzQcywzaW
+            <span
+              class="provisioners-list__staking-address"
+            >
+              mUUpjnXow2LHwm8a65cJsckTe...xrsre7jNbLdDocqSfzQcywzaW
+            </span>
           </dd>
            
           <dt
@@ -715,7 +743,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -733,25 +779,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -768,7 +796,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -814,7 +842,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            mWvq9EWD9b8gQw5uD4GnYaV8Wsn86y...p4m7pfsBMoDjbYzTTUxooU7BY2oEDe
+            <span
+              class="provisioners-list__staking-address"
+            >
+              mWvq9EWD9b8gQw5uD4GnYaV8W...fsBMoDjbYzTTUxooU7BY2oEDe
+            </span>
           </dd>
            
           <dt
@@ -824,7 +856,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -842,25 +892,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -877,7 +909,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -923,7 +955,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            mXKJ97xTtrSPzxWHBKPurUpehP1yPy...P3VDzeUPuXjqaC9dp6H7JgkCK2o7x4
+            <span
+              class="provisioners-list__staking-address"
+            >
+              mXKJ97xTtrSPzxWHBKPurUpeh...eUPuXjqaC9dp6H7JgkCK2o7x4
+            </span>
           </dd>
            
           <dt
@@ -933,7 +969,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -951,25 +1005,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -986,7 +1022,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -1032,7 +1068,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            mdXsA3Ee1YDt1aTcvUg7AKpzTKgJBo...qjDfvepuR9FPWCcJQfDwK8VZPimZ2J
+            <span
+              class="provisioners-list__staking-address"
+            >
+              mdXsA3Ee1YDt1aTcvUg7AKpzT...epuR9FPWCcJQfDwK8VZPimZ2J
+            </span>
           </dd>
            
           <dt
@@ -1042,7 +1082,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -1060,25 +1118,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -1095,7 +1135,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -1141,7 +1181,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            mdca2ea2KpRZaW6s6NkYAY29wbprGP...zo7uHBPg8MmRfxyBCUVRji7SxM2zBD
+            <span
+              class="provisioners-list__staking-address"
+            >
+              mdca2ea2KpRZaW6s6NkYAY29w...BPg8MmRfxyBCUVRji7SxM2zBD
+            </span>
           </dd>
            
           <dt
@@ -1151,7 +1195,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -1169,25 +1231,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -1204,7 +1248,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -1250,7 +1294,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            mgmcqkk1VFfsa1ko7ydBjhVuM9WuVF...BZHUcEWDB1wsvV5avoC2xddxLvEDVP
+            <span
+              class="provisioners-list__staking-address"
+            >
+              mgmcqkk1VFfsa1ko7ydBjhVuM...EWDB1wsvV5avoC2xddxLvEDVP
+            </span>
           </dd>
            
           <dt
@@ -1260,7 +1308,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -1278,25 +1344,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -1313,7 +1361,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -1359,7 +1407,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            mvft6AXjR1mDtg1Qo3GzGBKZAvvxY1...sY6HjCeDJ9pKfJLdjayAfrxEyudvx2
+            <span
+              class="provisioners-list__staking-address"
+            >
+              mvft6AXjR1mDtg1Qo3GzGBKZA...CeDJ9pKfJLdjayAfrxEyudvx2
+            </span>
           </dd>
            
           <dt
@@ -1369,7 +1421,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
             </div>
           </dt>
            
@@ -1387,7 +1439,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -1405,7 +1457,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -1422,7 +1474,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -1468,7 +1520,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            mvsVWvCaiHtugFDx1VmDCX5Zeex1u1...zUMDyeWVgrE1CfbGCaYvcdeSzHCUUb
+            <span
+              class="provisioners-list__staking-address"
+            >
+              mvsVWvCaiHtugFDx1VmDCX5Ze...eWVgrE1CfbGCaYvcdeSzHCUUb
+            </span>
           </dd>
            
           <dt
@@ -1478,7 +1534,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -1496,25 +1570,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -1531,7 +1587,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -1577,7 +1633,11 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
           <dd
             class="details-list__definition details-list__definition--table"
           >
-            n2DPucZgNznPCfhRfAS8aHQUktJYZ9...VogBzbDNKwS6GhaRRR9f95PUxRwtD1
+            <span
+              class="provisioners-list__staking-address"
+            >
+              n2DPucZgNznPCfhRfAS8aHQUk...bDNKwS6GhaRRR9f95PUxRwtD1
+            </span>
           </dd>
            
           <dt
@@ -1587,7 +1647,25 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              staked amount
+              Locked Stake Amount
+            </div>
+          </dt>
+           
+          <dd
+            class="details-list__definition details-list__definition--table"
+          >
+            0
+             DUSK
+          </dd>
+           
+          <dt
+            class="details-list__term details-list__term--table"
+          >
+            <div
+              class="details-list__term-layout"
+            >
+               
+              Reclaimable Stake Amount
             </div>
           </dt>
            
@@ -1605,25 +1683,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              Reclaimable Staked Amount
-            </div>
-          </dt>
-           
-          <dd
-            class="details-list__definition details-list__definition--table"
-          >
-            0
-             DUSK
-          </dd>
-           
-          <dt
-            class="details-list__term details-list__term--table"
-          >
-            <div
-              class="details-list__term-layout"
-            >
-               
-              slashes
+              Soft Slashes
             </div>
           </dt>
            
@@ -1640,7 +1700,7 @@ exports[`Provisioners page > should render the Provisioners page with the mobile
               class="details-list__term-layout"
             >
                
-              hard slashes
+              Hard Slashes
             </div>
           </dt>
            
@@ -1774,14 +1834,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <th
                 class="table__header-cell"
               >
-                Staked Amount (DUSK)
-              </th>
-              
-               
-              <th
-                class="table__header-cell"
-              >
-                Reclaimable Staked Amount (DUSK)
+                Stake Amount (DUSK)
               </th>
               
                
@@ -1789,13 +1842,6 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
                 class="table__header-cell"
               >
                 Slashes
-              </th>
-              
-               
-              <th
-                class="table__header-cell"
-              >
-                Hard Slashes
               </th>
               
                
@@ -1825,13 +1871,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 500,000
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -1839,13 +1894,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -1872,13 +1936,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 500,000
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -1886,13 +1959,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -1919,13 +2001,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 4,800
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -1933,13 +2024,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -1966,13 +2066,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 1,234
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -1980,13 +2089,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -2013,13 +2131,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 500,000
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -2027,13 +2154,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -2060,13 +2196,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 4,800
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -2074,13 +2219,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -2107,13 +2261,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 500,000
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -2121,13 +2284,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -2154,13 +2326,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 1,000
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -2168,13 +2349,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -2201,13 +2391,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 500,000
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -2215,13 +2414,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -2248,13 +2456,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 500,000
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -2262,13 +2479,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -2295,13 +2521,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 500,000
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -2309,13 +2544,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -2342,13 +2586,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 500,000
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -2356,13 +2609,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -2389,6 +2651,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
+                0
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -2396,20 +2674,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
-                0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -2436,13 +2716,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 4,550
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -2450,13 +2739,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               
@@ -2483,13 +2781,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Reclaimable:
+                </b>
+                 
                 500,000
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__staked-amount-type-label"
+                >
+                  Locked:
+                </b>
+                 
                 0
               </td>
               
@@ -2497,13 +2804,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               <td
                 class="table__data-cell"
               >
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Soft:
+                </b>
+                 
                 0
-              </td>
-              
-               
-              <td
-                class="table__data-cell"
-              >
+                 
+                <br />
+                 
+                <b
+                  class="provisioners-table__slash-type-label"
+                >
+                  Hard:
+                </b>
+                 
                 0
               </td>
               

--- a/explorer/src/routes/transactions/__tests__/__snapshots__/page.spec.js.snap
+++ b/explorer/src/routes/transactions/__tests__/__snapshots__/page.spec.js.snap
@@ -55,7 +55,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=4a4593a447ae768a20a28c534afd815f1f72965a7442eff71e62833047514552"
             >
-              4a4593a447ae768a20a28c534afd81...72965a7442eff71e62833047514552
+              4a4593a447ae768a20a28c534...a7442eff71e62833047514552
             </a>
           </dd>
            
@@ -219,7 +219,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=47ae464b9cf13bbf6e7307ecd0cc1a978094d7571bc6698c9bc5fe3e5facba66"
             >
-              47ae464b9cf13bbf6e7307ecd0cc1a...94d7571bc6698c9bc5fe3e5facba66
+              47ae464b9cf13bbf6e7307ecd...71bc6698c9bc5fe3e5facba66
             </a>
           </dd>
            
@@ -383,7 +383,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=225dae3745d75fa7bbae7e0294cb9626ff01bb4de697c0be31a3fc176b36ea41"
             >
-              225dae3745d75fa7bbae7e0294cb96...01bb4de697c0be31a3fc176b36ea41
+              225dae3745d75fa7bbae7e029...de697c0be31a3fc176b36ea41
             </a>
           </dd>
            
@@ -547,7 +547,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=03bae6e2e96709ebf41da7ca72353efca792723355332f467c0f32b3849de702"
             >
-              03bae6e2e96709ebf41da7ca72353e...92723355332f467c0f32b3849de702
+              03bae6e2e96709ebf41da7ca7...355332f467c0f32b3849de702
             </a>
           </dd>
            
@@ -711,7 +711,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=ed17ab505ab991e83194183b47b0ea8cd933e096c773767153414603a2b96964"
             >
-              ed17ab505ab991e83194183b47b0ea...33e096c773767153414603a2b96964
+              ed17ab505ab991e83194183b4...6c773767153414603a2b96964
             </a>
           </dd>
            
@@ -875,7 +875,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=cbac233a76cde9fdd129277e7368a2fdd99a5f390c2472e7f316151f4b53666c"
             >
-              cbac233a76cde9fdd129277e7368a2...9a5f390c2472e7f316151f4b53666c
+              cbac233a76cde9fdd129277e7...90c2472e7f316151f4b53666c
             </a>
           </dd>
            
@@ -1039,7 +1039,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=a9abf02f549d21a89390eb18f5e91eeff95c21a4c6740dc30e113f2314152b5d"
             >
-              a9abf02f549d21a89390eb18f5e91e...5c21a4c6740dc30e113f2314152b5d
+              a9abf02f549d21a89390eb18f...4c6740dc30e113f2314152b5d
             </a>
           </dd>
            
@@ -1203,7 +1203,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=a7171542640d6b918928927ee814c147ec2c07c5f7990fe82796520084798b6f"
             >
-              a7171542640d6b918928927ee814c1...2c07c5f7990fe82796520084798b6f
+              a7171542640d6b918928927ee...5f7990fe82796520084798b6f
             </a>
           </dd>
            
@@ -1367,7 +1367,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=a171e5d05bd1e6478a4bcc7db4afd9d2e6430e5c3f94d49ffb71934776765465"
             >
-              a171e5d05bd1e6478a4bcc7db4afd9...430e5c3f94d49ffb71934776765465
+              a171e5d05bd1e6478a4bcc7db...c3f94d49ffb71934776765465
             </a>
           </dd>
            
@@ -1531,7 +1531,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=8fff9d4eb4818bfd66cfaf41b01842f4fd75b0c50605e40fa8b1b1393ee0ac57"
             >
-              8fff9d4eb4818bfd66cfaf41b01842...75b0c50605e40fa8b1b1393ee0ac57
+              8fff9d4eb4818bfd66cfaf41b...50605e40fa8b1b1393ee0ac57
             </a>
           </dd>
            
@@ -1695,7 +1695,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=88c5c5ebedb181bed0927f41b55835b3801d505774efca243ae084caa9175e04"
             >
-              88c5c5ebedb181bed0927f41b55835...1d505774efca243ae084caa9175e04
+              88c5c5ebedb181bed0927f41b...774efca243ae084caa9175e04
             </a>
           </dd>
            
@@ -1859,7 +1859,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=65d9ef520afbe16722f3de439695d31ab3ae807d81ef8e3ebd0fe1f805833c2b"
             >
-              65d9ef520afbe16722f3de439695d3...ae807d81ef8e3ebd0fe1f805833c2b
+              65d9ef520afbe16722f3de439...d81ef8e3ebd0fe1f805833c2b
             </a>
           </dd>
            
@@ -2023,7 +2023,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=5d043c4a9c829891dd40c2c482c0e2b579bbe3e0ab7b2e240e47ab231d8fe112"
             >
-              5d043c4a9c829891dd40c2c482c0e2...bbe3e0ab7b2e240e47ab231d8fe112
+              5d043c4a9c829891dd40c2c48...0ab7b2e240e47ab231d8fe112
             </a>
           </dd>
            
@@ -2187,7 +2187,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=5c5aab71b215e835841aaf173bbfdca9372dd29018ee753d3ffd9eaa88158660"
             >
-              5c5aab71b215e835841aaf173bbfdc...2dd29018ee753d3ffd9eaa88158660
+              5c5aab71b215e835841aaf173...018ee753d3ffd9eaa88158660
             </a>
           </dd>
            
@@ -2351,7 +2351,7 @@ exports[`Transactions page > should render the Transactions page with the mobile
               class="dusk-anchor dusk-anchor--on-surface transaction-details__list-link"
               href="/some-base-path/transactions/transaction?id=53085322f4c84b6a9d17c36996b51a8a05d2207752c733dd454e23f6ee0ca62c"
             >
-              53085322f4c84b6a9d17c36996b51a...d2207752c733dd454e23f6ee0ca62c
+              53085322f4c84b6a9d17c3699...752c733dd454e23f6ee0ca62c
             </a>
           </dd>
            


### PR DESCRIPTION
Resolves #2730

### Visuals:
<img width="1044" alt="Screenshot 2024-10-22 at 15 46 19" src="https://github.com/user-attachments/assets/a64453a8-c2a6-4fed-88d2-d627586bf863">
<img width="622" alt="Screenshot 2024-10-22 at 16 29 06" src="https://github.com/user-attachments/assets/6b7b0fdd-1955-45a0-9264-9505fefda12f">

