### PR TITLE
node: add transfer event deserialization

### DIFF
--- a/rusk/src/lib/http/chain/graphql.rs
+++ b/rusk/src/lib/http/chain/graphql.rs
@@ -14,10 +14,13 @@ use tx::*;
 
 use async_graphql::{Context, FieldError, FieldResult, Object};
 use execution_core::{transfer::TRANSFER_CONTRACT, ContractId};
-#[cfg(feature = "archive")]
-use node::archive::{Archive, MoonlightGroup};
 use node::database::rocksdb::Backend;
 use node::database::{Ledger, DB};
+#[cfg(feature = "archive")]
+use {
+    deserialized_archive_data::DeserializedMoonlightGroups,
+    node::archive::{Archive, MoonlightGroup},
+};
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -141,7 +144,7 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         address: String,
-    ) -> OptResult<MoonlightTransactions> {
+    ) -> OptResult<DeserializedMoonlightGroups> {
         full_moonlight_history(ctx, address).await
     }
 

--- a/rusk/src/lib/http/chain/graphql/data.rs
+++ b/rusk/src/lib/http/chain/graphql/data.rs
@@ -337,3 +337,230 @@ pub struct CallData {
     fn_name: String,
     data: String,
 }
+
+/// Interim solution for sending out deserialized event data
+#[cfg(feature = "archive")]
+pub(super) mod deserialized_archive_data {
+    use super::*;
+    use execution_core::stake::STAKE_CONTRACT;
+    use execution_core::transfer::withdraw::WithdrawReceiver;
+    use execution_core::transfer::{
+        ConvertEvent, DepositEvent, MoonlightTransactionEvent, WithdrawEvent,
+        CONVERT_TOPIC, DEPOSIT_TOPIC, MINT_TOPIC, MOONLIGHT_TOPIC,
+        TRANSFER_CONTRACT, WITHDRAW_TOPIC,
+    };
+    use node_data::events::contract::{
+        ContractEvent, TxHash, WrappedContractId,
+    };
+    use serde::ser::SerializeStruct;
+    use serde::{Deserialize, Serialize};
+
+    #[serde_with::serde_as]
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct DeserializedMoonlightGroup {
+        pub events: serde_json::Value,
+        #[serde_as(as = "serde_with::hex::Hex")]
+        pub origin: TxHash,
+        pub block_height: u64,
+    }
+    pub struct DeserializedMoonlightGroups(pub Vec<DeserializedMoonlightGroup>);
+
+    #[Object]
+    impl DeserializedMoonlightGroups {
+        pub async fn json(&self) -> serde_json::Value {
+            serde_json::to_value(&self.0).unwrap_or_default()
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct DeserializedMoonlightTransactionEvent(
+        pub MoonlightTransactionEvent,
+    );
+
+    impl Serialize for DeserializedMoonlightTransactionEvent {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let moonlight_event = &self.0;
+
+            let mut state =
+                serializer.serialize_struct("MoonlightTransactionEvent", 6)?;
+            state.serialize_field(
+                "sender",
+                &bs58::encode(moonlight_event.sender.to_bytes()).into_string(),
+            )?;
+            state.serialize_field(
+                "receiver",
+                &moonlight_event
+                    .receiver
+                    .map(|r| bs58::encode(r.to_bytes()).into_string()),
+            )?;
+            state.serialize_field("value", &moonlight_event.value)?;
+            state
+                .serialize_field("memo", &hex::encode(&moonlight_event.memo))?;
+            state.serialize_field("gas_spent", &moonlight_event.gas_spent)?;
+            state.serialize_field(
+                "refund_info",
+                &moonlight_event.refund_info.map(|(pk, amt)| {
+                    (bs58::encode(pk.to_bytes()).into_string(), amt)
+                }),
+            )?;
+
+            state.end()
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct DeserializedWithdrawEvent(pub WithdrawEvent);
+
+    impl Serialize for DeserializedWithdrawEvent {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let withdraw_event = &self.0;
+            let mut state = serializer.serialize_struct("WithdrawEvent", 3)?;
+            state.serialize_field(
+                "sender",
+                &WrappedContractId(withdraw_event.sender),
+            )?;
+            state.serialize_field(
+                "receiver",
+                &match withdraw_event.receiver {
+                    WithdrawReceiver::Moonlight(pk) => {
+                        bs58::encode(pk.to_bytes()).into_string()
+                    }
+                    WithdrawReceiver::Phoenix(pk) => {
+                        bs58::encode(pk.to_bytes()).into_string()
+                    }
+                },
+            )?;
+            state.serialize_field("value", &withdraw_event.value)?;
+
+            state.end()
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct DeserializedConvertEvent(pub ConvertEvent);
+
+    impl Serialize for DeserializedConvertEvent {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let convert_event = &self.0;
+            let mut state = serializer.serialize_struct("ConvertEvent", 3)?;
+            state.serialize_field(
+                "sender",
+                &convert_event
+                    .sender
+                    .map(|pk| bs58::encode(pk.to_bytes()).into_string()),
+            )?;
+            state.serialize_field(
+                "receiver",
+                &match convert_event.receiver {
+                    WithdrawReceiver::Moonlight(pk) => {
+                        bs58::encode(pk.to_bytes()).into_string()
+                    }
+                    WithdrawReceiver::Phoenix(pk) => {
+                        bs58::encode(pk.to_bytes()).into_string()
+                    }
+                },
+            )?;
+            state.serialize_field("value", &convert_event.value)?;
+            state.end()
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct DeserializedDepositEvent(pub DepositEvent);
+
+    impl Serialize for DeserializedDepositEvent {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let deposit_event = &self.0;
+            let mut state = serializer.serialize_struct("DepositEvent", 3)?;
+            state.serialize_field(
+                "sender",
+                &deposit_event
+                    .sender
+                    .map(|pk| bs58::encode(pk.to_bytes()).into_string()),
+            )?;
+            state.serialize_field(
+                "receiver",
+                &WrappedContractId(deposit_event.receiver),
+            )?;
+            state.serialize_field("value", &deposit_event.value)?;
+
+            state.end()
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize)]
+    pub struct DeserializedContractEvent {
+        pub target: WrappedContractId,
+        pub topic: String,
+        pub data: serde_json::Value,
+    }
+
+    impl From<ContractEvent> for DeserializedContractEvent {
+        fn from(event: ContractEvent) -> Self {
+            let deserialized_data = if event.target.0 == TRANSFER_CONTRACT {
+                match event.topic.as_str() {
+                    MOONLIGHT_TOPIC => rkyv::from_bytes::<
+                        MoonlightTransactionEvent,
+                    >(&event.data)
+                    .map(|e| {
+                        serde_json::to_value(
+                            DeserializedMoonlightTransactionEvent(e),
+                        )
+                    })
+                    .unwrap_or_else(|_| serde_json::to_value(event.data)),
+                    WITHDRAW_TOPIC | MINT_TOPIC => rkyv::from_bytes::<
+                        WithdrawEvent,
+                    >(
+                        &event.data
+                    )
+                    .map(|e| serde_json::to_value(DeserializedWithdrawEvent(e)))
+                    .unwrap_or_else(|_| serde_json::to_value(event.data)),
+                    CONVERT_TOPIC => {
+                        rkyv::from_bytes::<ConvertEvent>(&event.data)
+                            .map(|e| {
+                                serde_json::to_value(DeserializedConvertEvent(
+                                    e,
+                                ))
+                            })
+                            .unwrap_or_else(|_| {
+                                serde_json::to_value(event.data)
+                            })
+                    }
+                    DEPOSIT_TOPIC => {
+                        rkyv::from_bytes::<DepositEvent>(&event.data)
+                            .map(|e| {
+                                serde_json::to_value(DeserializedDepositEvent(
+                                    e,
+                                ))
+                            })
+                            .unwrap_or_else(|_| {
+                                serde_json::to_value(event.data)
+                            })
+                    }
+                    _ => serde_json::to_value(hex::encode(event.data)),
+                }
+            } else {
+                serde_json::to_value(hex::encode(event.data))
+            }
+            .unwrap_or_else(|e| serde_json::Value::String(e.to_string()));
+
+            Self {
+                target: event.target,
+                topic: event.topic,
+                data: deserialized_data,
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related to: #2704

This is an interim solution to provide the moonlight event data in json instead of bytes until execution-core has a feature for that.