### PR TITLE
node: fix OutOfSync handler

### DIFF
--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -150,7 +150,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
                             self.reroute_acceptor(msg).await;
                         }
                         Payload::Quorum(ref q) => {
-                            fsm.on_quorum(q);
+                            fsm.on_quorum(q).await;
                             self.reroute_acceptor(msg).await;
 
                         }

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -146,21 +146,14 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
                     match msg.payload {
                         Payload::Candidate(_)
                         | Payload::Validation(_)
-                        | Payload::Ratification(_)
-                        | Payload::Quorum(_) => {
-                              debug!(
-                                event = "Consensus message received",
-                                topic = ?msg.topic(),
-                                info = ?msg.header,
-                                metadata = ?msg.metadata,
-                            );
+                        | Payload::Ratification(_) => {
+                            self.reroute_acceptor(msg).await;
+                        }
+                        Payload::Quorum(ref q) => {
+                            fsm.on_quorum(q);
+                            self.reroute_acceptor(msg).await;
 
-                            // Re-route message to the Consensus
-                            let acc = self.acceptor.as_ref().expect("initialize is called");
-                            if let Err(e) = acc.read().await.reroute_msg(msg).await {
-                                warn!("Could not reroute msg to Consensus: {}", e);
-                            }
-                        },
+                        }
 
                         Payload::Block(blk) => {
                             info!(
@@ -317,5 +310,20 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> ChainSrv<N, DB, VM> {
             .await
             .try_revert(acceptor::RevertTarget::LastFinalizedState)
             .await
+    }
+
+    async fn reroute_acceptor(&self, msg: Message) {
+        debug!(
+            event = "Consensus message received",
+            topic = ?msg.topic(),
+            info = ?msg.header,
+            metadata = ?msg.metadata,
+        );
+
+        // Re-route message to the Consensus
+        let acc = self.acceptor.as_ref().expect("initialize is called");
+        if let Err(e) = acc.read().await.reroute_msg(msg).await {
+            warn!("Could not reroute msg to Consensus: {}", e);
+        }
     }
 }

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -150,7 +150,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
                             self.reroute_acceptor(msg).await;
                         }
                         Payload::Quorum(ref q) => {
-                            fsm.on_quorum(q).await;
+                            fsm.on_quorum(q, msg.metadata.as_ref()).await;
                             self.reroute_acceptor(msg).await;
 
                         }

--- a/node/src/chain/fsm.rs
+++ b/node/src/chain/fsm.rs
@@ -168,7 +168,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> SimpleFSM<N, DB, VM> {
                     anyhow::Ok(())
                 }
                 State::OutOfSync(ref mut curr) => {
-                    if curr.on_block_event(blk, metadata).await? {
+                    if curr.on_block_event(blk).await? {
                         // Transition from OutOfSync to InSync state
                         curr.on_exiting().await;
 

--- a/node/src/chain/fsm.rs
+++ b/node/src/chain/fsm.rs
@@ -118,6 +118,12 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> SimpleFSM<N, DB, VM> {
         self.acc.write().await.restart_consensus().await;
     }
 
+    pub fn on_quorum(&mut self, quorum: &Quorum) {
+        if let State::OutOfSync(oos) = &mut self.curr {
+            oos.on_quorum(quorum)
+        }
+    }
+
     /// Handles an event of a block occurrence.
     ///
     /// A block event could originate from either local consensus execution, a

--- a/node/src/chain/fsm.rs
+++ b/node/src/chain/fsm.rs
@@ -118,9 +118,9 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> SimpleFSM<N, DB, VM> {
         self.acc.write().await.restart_consensus().await;
     }
 
-    pub fn on_quorum(&mut self, quorum: &Quorum) {
+    pub async fn on_quorum(&mut self, quorum: &Quorum) {
         if let State::OutOfSync(oos) = &mut self.curr {
-            oos.on_quorum(quorum)
+            oos.on_quorum(quorum).await;
         }
     }
 

--- a/node/src/chain/fsm/outofsync.rs
+++ b/node/src/chain/fsm/outofsync.rs
@@ -177,6 +177,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network>
             attempts: 3,
         }
     }
+
     /// Performed when entering the OutOfSync state
     ///
     /// Handles the logic for entering the out-of-sync state. Sets the target
@@ -204,7 +205,13 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network>
         }
 
         let (from, to) = &self.range;
-        info!(event = "entering out-of-sync", from, to, ?peer_addr);
+        info!(
+            event = "entering",
+            from,
+            to,
+            ?peer_addr,
+            mode = "out_of_sync"
+        );
         for (_, b) in self.pool.clone() {
             let _ = self.on_block_event(&b).await;
         }
@@ -279,7 +286,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network>
                     self.start_time = SystemTime::now();
                     self.range.0 += 1;
                     debug!(
-                        event = "accepting next block",
+                        event = "accepted next block",
                         block_height = height,
                         last_request = self.last_request,
                         mode = "out_of_sync"

--- a/node/src/chain/fsm/outofsync.rs
+++ b/node/src/chain/fsm/outofsync.rs
@@ -229,10 +229,17 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network>
         self.pool.retain(|h, _| h >= &curr_height);
     }
 
-    pub fn on_quorum(&mut self, quorum: &Quorum) {
+    pub async fn on_quorum(&mut self, quorum: &Quorum) {
         let prev_quorum_height = quorum.header.round;
         if self.range.1 < prev_quorum_height {
-            self.range.1 = prev_quorum_height
+            debug!(
+                event = "update sync target due to quorum",
+                prev = self.range.1,
+                new = prev_quorum_height,
+                mode = "out_of_sync"
+            );
+            self.range.1 = prev_quorum_height;
+            self.request_pool_missing_blocks().await;
         }
     }
 

--- a/node/src/chain/fsm/outofsync.rs
+++ b/node/src/chain/fsm/outofsync.rs
@@ -188,7 +188,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network>
         let pool = presync.pool;
         let curr_height = self.acc.read().await.get_curr_height().await;
 
-        self.range = (curr_height + 1, presync.target_height);
+        self.range = (curr_height + 1, presync.remote_height);
 
         // add target_block to the pool
         self.drain_pool().await;


### PR DESCRIPTION
With the current PR the target block for sync is properly derived from the incoming blocks/quorum


below the log for a fresh new start, where the first 100blocks are received after the triggered request during acceptor::spawn, and the next batch is derived from the quorum produced by the living cluster


```
Process started
Wed Oct 23 15:55:26 2024 /opt/dusk/bin/rusk 


{"timestamp":"2024-10-23T15:55:30.875494Z","level":"INFO","event":"entering","from":10,"to":10,"peer_addr":"104.248.89.168:9000","mode":"out_of_sync","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-23T15:55:31.157365Z","level":"DEBUG","event":"sync target reached","height":10,"mode":"out_of_sync","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-23T15:55:31.371270Z","level":"DEBUG","event":"sync target reached","height":11,"mode":"out_of_sync","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-23T15:55:32.136782Z","level":"INFO","event":"entering","from":16,"to":17,"peer_addr":"104.248.89.168:9000","mode":"out_of_sync","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-23T15:55:33.169998Z","level":"DEBUG","event":"sync target reached","height":19,"mode":"out_of_sync","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-23T15:55:45.339140Z","level":"INFO","event":"entering","from":80,"to":80,"peer_addr":"104.248.89.168:9000","mode":"out_of_sync","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-23T15:55:45.545842Z","level":"DEBUG","event":"sync target reached","height":80,"mode":"out_of_sync","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-23T15:55:45.737361Z","level":"DEBUG","event":"sync target reached","height":81,"mode":"out_of_sync","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-23T15:55:46.103555Z","level":"INFO","event":"entering","from":84,"to":100,"peer_addr":"104.248.89.168:9000","mode":"out_of_sync","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-23T15:55:49.605848Z","level":"DEBUG","event":"sync target reached","height":100,"mode":"out_of_sync","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-23T15:55:49.798813Z","level":"INFO","event":"entering","from":102,"to":11472,"peer_addr":"167.71.71.115:9000","mode":"out_of_sync","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-23T16:53:25.796029Z","level":"DEBUG","event":"sync target reached","height":11819,"mode":"out_of_sync","target":"node::chain::fsm::outofsync"}
```




```
Process started
Thu Oct 24 09:00:28 2024 /opt/dusk/bin/rusk


{"timestamp":"2024-10-24T09:00:30.609297Z","level":"INFO","event":"entering","from":2,"to":3,"peer_addr":"134.209.91.82:9000","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-24T09:00:31.138652Z","level":"DEBUG","event":"sync target reached","height":3,"target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-24T09:00:50.585720Z","level":"INFO","event":"entering","from":81,"to":81,"peer_addr":"134.209.91.82:9000","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-24T09:00:50.830959Z","level":"DEBUG","event":"sync target reached","height":81,"target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-24T09:00:51.096366Z","level":"DEBUG","event":"sync target reached","height":82,"target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-24T09:00:55.451861Z","level":"INFO","event":"entering","from":102,"to":17620,"peer_addr":"136.243.49.123:9000","target":"node::chain::fsm::outofsync"}
{"timestamp":"2024-10-24T10:32:03.859508Z","level":"DEBUG","event":"sync target reached","height":18168,"target":"node::chain::fsm::outofsync"}
```