### PR TITLE
rusk-wallet: Add balance check validation

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -14,19 +14,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add contract deploy and contract calling [#2402]
 - Add support for RUES [#2401]
 - Add Moonlight stake, unstake and withdraw [#2400]
+- Add balance validation for any given transaction action [#2396]
 - Add Moonlight-Phoenix conversion [#2340]
 - Add Moonlight transactions [#2288]
 
 ### Changed
 
+- Changed default gas limits
 - Split `prove_and_propagate` into `prove` and `propagate` [#2708]
 - Unify `sndr_idx` and `profile_idx` fields in `Command` enum [#2702]
 - Change Rusk wallet name and version information [#2647]
 
 ### Fix
 
+- Fix stake info for inactive stakes with rewards [#2766]
 - Fix Moonlight stake reward withdrawal [#2523]
 
+[#2766]: https://github.com/dusk-network/rusk/issues/2766
 [#2708]: https://github.com/dusk-network/rusk/issues/2708
 [#2702]: https://github.com/dusk-network/rusk/issues/2702
 [#2659]: https://github.com/dusk-network/rusk/issues/2659
@@ -36,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2402]: https://github.com/dusk-network/rusk/issues/2402
 [#2401]: https://github.com/dusk-network/rusk/issues/2401
 [#2400]: https://github.com/dusk-network/rusk/issues/2400
+[#2396]: https://github.com/dusk-network/rusk/issues/2396
 [#2340]: https://github.com/dusk-network/rusk/issues/2340
 [#2288]: https://github.com/dusk-network/rusk/issues/2288
 

--- a/rusk-wallet/src/bin/interactive.rs
+++ b/rusk-wallet/src/bin/interactive.rs
@@ -153,6 +153,7 @@ pub(crate) async fn run_loop(
                     }
                 }
                 ProfileOp::Back => break,
+                ProfileOp::Stay => continue,
             }
         }
     }
@@ -221,6 +222,7 @@ fn menu_profile(wallet: &Wallet<WalletFile>) -> anyhow::Result<ProfileSelect> {
 enum ProfileOp {
     Run(Box<Command>),
     Back,
+    Stay,
 }
 
 /// Allows the user to load a wallet interactively

--- a/rusk-wallet/src/gas.rs
+++ b/rusk-wallet/src/gas.rs
@@ -10,16 +10,19 @@
 use crate::currency::Lux;
 
 /// The minimum gas limit
-pub const MIN_LIMIT: u64 = 50_000_000;
+pub const MIN_LIMIT: u64 = 500_000;
 
 /// The default gas limit for transfer transactions
-pub const DEFAULT_LIMIT_TRANSFER: u64 = 100_000_000;
+pub const DEFAULT_LIMIT_TRANSFER: u64 = 2_000_000;
 
 /// The default gas limit for a contract deployment
 pub const DEFAULT_LIMIT_DEPLOYMENT: u64 = 50_000_000;
 
-/// The default gas limit for staking/contract calls
-pub const DEFAULT_LIMIT_CALL: u64 = 2_900_000_000;
+/// The default gas limit for contract calls
+pub const DEFAULT_LIMIT_CALL: u64 = 2_000_000_000;
+
+/// The default gas limit for stake/unstake/withdraw calls
+pub const DEFAULT_LIMIT_STAKE: u64 = 50_000_000;
 
 /// The default gas price
 pub const DEFAULT_PRICE: Lux = 1;


### PR DESCRIPTION
Check whether transfer, stake, shield and unshield operations are possible with the users given balance. If not, the user will be direct back to the menu of the selected profile.

Resolves #2396