### PR TITLE
Change `rusk_abi::verify_bls_multisig` to take multiple keys and signatures

### DIFF
--- a/contracts/host_fn/src/lib.rs
+++ b/contracts/host_fn/src/lib.rs
@@ -14,7 +14,10 @@ use alloc::vec::Vec;
 use dusk_bytes::Serializable;
 use execution_core::{
     signatures::{
-        bls::{PublicKey as BlsPublicKey, Signature as BlsSignature},
+        bls::{
+            PublicKey as BlsPublicKey, PublicKeyAndSignature,
+            Signature as BlsSignature,
+        },
         schnorr::{
             PublicKey as SchnorrPublicKey, Signature as SchnorrSignature,
         },
@@ -72,6 +75,14 @@ impl HostFnTest {
         rusk_abi::verify_bls(msg, pk, sig)
     }
 
+    pub fn verify_bls_multisig(
+        &self,
+        msg: Vec<u8>,
+        kas: Vec<PublicKeyAndSignature>,
+    ) -> bool {
+        rusk_abi::verify_bls_multisig(msg, kas)
+    }
+
     pub fn chain_id(&self) -> u8 {
         rusk_abi::chain_id()
     }
@@ -124,6 +135,13 @@ unsafe fn verify_schnorr(arg_len: u32) -> u32 {
 unsafe fn verify_bls(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |(msg, pk, sig)| {
         STATE.verify_bls(msg, pk, sig)
+    })
+}
+
+#[no_mangle]
+unsafe fn verify_bls_multisig(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |(msg, kas)| {
+        STATE.verify_bls_multisig(msg, kas)
     })
 }
 

--- a/execution-core/src/lib.rs
+++ b/execution-core/src/lib.rs
@@ -42,6 +42,22 @@ pub mod signatures {
             Error, MultisigPublicKey, MultisigSignature, PublicKey, SecretKey,
             Signature,
         };
+
+        use bytecheck::CheckBytes;
+        use rkyv::{Archive, Deserialize, Serialize};
+
+        /// A public key and a signature, used to interact with
+        /// [`rusk_abi::verify_bls_multisig`].
+        #[derive(
+            Debug, Clone, PartialEq, Eq, Archive, Serialize, Deserialize,
+        )]
+        #[archive_attr(derive(CheckBytes))]
+        pub struct PublicKeyAndSignature {
+            /// The public key.
+            pub public_key: PublicKey,
+            /// The signature.
+            pub signature: MultisigSignature,
+        }
     }
 
     /// Types for the schnorr-signature scheme operating on the `jubjub` curve.

--- a/rusk-abi/src/abi.rs
+++ b/rusk-abi/src/abi.rs
@@ -10,7 +10,7 @@ use dusk_bytes::Serializable;
 use execution_core::{
     signatures::{
         bls::{
-            MultisigPublicKey, MultisigSignature, PublicKey as BlsPublicKey,
+            PublicKey as BlsPublicKey, PublicKeyAndSignature,
             Signature as BlsSignature,
         },
         schnorr::{
@@ -72,10 +72,9 @@ pub fn verify_bls(msg: Vec<u8>, pk: BlsPublicKey, sig: BlsSignature) -> bool {
 /// Verify a BLS signature is valid for the given public key and message
 pub fn verify_bls_multisig(
     msg: Vec<u8>,
-    pk: MultisigPublicKey,
-    sig: MultisigSignature,
+    kas: Vec<PublicKeyAndSignature>,
 ) -> bool {
-    host_query(Query::VERIFY_BLS_MULTISIG, (msg, pk, sig))
+    host_query(Query::VERIFY_BLS_MULTISIG, (msg, kas))
 }
 
 /// Get the chain ID.


### PR DESCRIPTION
This PR changes `rusk_abi::verify_bls_multisig` to take multiple public keys and signatures. These then get aggregated in the host function and the aggregations verified against the message.

By introducing this, we effectively allow contracts to implement threshold signature schemes that rely on the aggregation capabilities of the host. For example, the contract could expose `fn pay_to(from: Id, from_keys: Vec<PublicKeyAndSignature>, to: PublicKey)` that only moves funds to the `to` account if the signatures included are valid over some message, and if the number of included keys is sufficient up to some configurable number.