### PR TITLE
wallet-core: Add support for new tx types and improve note handling

### DIFF
--- a/wallet-core/Cargo.toml
+++ b/wallet-core/Cargo.toml
@@ -25,3 +25,4 @@ dlmalloc = { workspace = true, features = ["global"] }
 rand = { workspace = true, features = ["std_rng"] }
 
 [features]
+debug = []

--- a/wallet-core/src/ffi/debug.rs
+++ b/wallet-core/src/ffi/debug.rs
@@ -17,7 +17,7 @@
 //! generating unnecessary debug information, as the WASM host environment is
 //! expected to handle errors by aborting on panic, rather than logging.
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debug"))]
 #[allow(unused_macros)]
 #[macro_use]
 pub mod enabled {
@@ -74,7 +74,7 @@ pub mod enabled {
     }
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(any(debug_assertions, feature = "debug")))]
 #[allow(unused_macros)]
 #[macro_use]
 pub mod disabled {

--- a/wallet-core/src/ffi/error.rs
+++ b/wallet-core/src/ffi/error.rs
@@ -21,6 +21,12 @@ pub enum ErrorCode {
     ArchivingError = 255,
     // Unarchiving (rkyv deserialization) error
     UnarchivingError = 254,
+    // Deserialization (dusk-bytes deserialization) error
+    DeserializationError = 253,
+    // Phoenix Transaction error
+    PhoenixTransactionError = 252,
+    // Moonlight Transaction error
+    MoonlightTransactionError = 251,
     // Success
     Ok = 0,
 }

--- a/wallet-core/src/notes/owned.rs
+++ b/wallet-core/src/notes/owned.rs
@@ -6,6 +6,7 @@
 
 //! Provides functions and types to handle notes' ownership.
 
+use alloc::vec;
 use alloc::vec::Vec;
 
 use bytecheck::CheckBytes;
@@ -95,18 +96,18 @@ impl From<Vec<(BlsScalar, NoteLeaf)>> for NoteList {
 pub fn map(
     keys: impl AsRef<[PhoenixSecretKey]>,
     notes: impl AsRef<[NoteLeaf]>,
-) -> NoteList {
+) -> Vec<NoteList> {
     notes.as_ref().iter().fold(
-        NoteList::default(),
-        |mut notes_map, note_leaf| {
-            for sk in keys.as_ref() {
+        vec![NoteList::default(); keys.as_ref().len()],
+        |mut notes_maps, note_leaf| {
+            for (i, sk) in keys.as_ref().iter().enumerate() {
                 if sk.owns(note_leaf.note.stealth_address()) {
                     let nullifier = note_leaf.note.gen_nullifier(sk);
-                    notes_map.insert(nullifier, note_leaf.clone());
+                    notes_maps[i].insert(nullifier, note_leaf.clone());
                     break;
                 }
             }
-            notes_map
+            notes_maps
         },
     )
 }

--- a/wallet-core/tests/notes.rs
+++ b/wallet-core/tests/notes.rs
@@ -99,25 +99,26 @@ fn test_map_owned() {
     // notes with idx 0, 1 and 4 are owned by owner_1
     let notes_by_1 = map_owned(&owner_1_sks, &note_leaves);
     assert_eq!(notes_by_1.len(), 3);
+
     let note = &note_leaves[0].note;
     let nullifier = note.gen_nullifier(&owner_1_sks[0]);
-    assert_eq!(&notes_by_1[&nullifier].note, note);
+    assert_eq!(&notes_by_1[0][&nullifier].note, note);
     let note = &note_leaves[1].note;
     let nullifier = note.gen_nullifier(&owner_1_sks[1]);
-    assert_eq!(&notes_by_1[&nullifier].note, note);
+    assert_eq!(&notes_by_1[1][&nullifier].note, note);
     let note = &note_leaves[4].note;
     let nullifier = note.gen_nullifier(&owner_1_sks[2]);
-    assert_eq!(&notes_by_1[&nullifier].note, note);
+    assert_eq!(&notes_by_1[2][&nullifier].note, note);
 
     // notes with idx 2 and 3 are owned by owner_2
     let notes_by_2 = map_owned(&owner_2_sks, &note_leaves);
     assert_eq!(notes_by_2.len(), 2);
     let note = &note_leaves[2].note;
     let nullifier = note.gen_nullifier(&owner_2_sks[0]);
-    assert_eq!(&notes_by_2[&nullifier].note, note);
+    assert_eq!(&notes_by_2[0][&nullifier].note, note);
     let note = &note_leaves[3].note;
     let nullifier = note.gen_nullifier(&owner_2_sks[1]);
-    assert_eq!(&notes_by_2[&nullifier].note, note);
+    assert_eq!(&notes_by_2[1][&nullifier].note, note);
 }
 
 #[test]
@@ -131,8 +132,8 @@ fn test_balance() {
 
     // create the notes
     for value in 0..=10 {
-        // we want to test with a mix of transparent and obfuscated notes so we
-        // make every 10th note transparent
+        // we want to test with a mix of transparent and obfuscated notes so
+        // we make every 10th note transparent
         let obfuscated_note = value % 10 != 0;
 
         notes.push(gen_note(&mut rng, obfuscated_note, &owner_pk, value));


### PR DESCRIPTION
- Add `debug` feature to Cargo.toml for debugging in release mode
- Add `derive_bls_sk` in `ffi.rs` to support BLS secret key operations.
- Add new modules for handling `MoonlightTransaction` and refactored note balance calculations.
- Add `display_scalar` in FFI for better formatting of BlsScalar types.
- Add `accounts_into_raw` in FFI to convert account buffers into raw bytes.
- Add `into_proved` in FFI for proving Phoenix transactions with a NoOp prover.
- Add `phoenix` and `moonlight` functions for handling Phoenix and Moonlight transactions.
- Change `map_owned`: now returns a `Vec<NoteList>` for multiple owners.
- Change `pick_notes` to handle bookmarks in a vectorized manner.
- Change error handling by adding new error codes for deserialization, Phoenix, and Moonlight transaction errors.
- Change debug macro logic to allow usage with the new `debug` feature flag.
- Add tests for note mapping and balance calculations, ensuring correct nullifier generation.