### PR TITLE
node: Update sqlx to workspace version

### DIFF
--- a/node/.sqlx/query-14e22bec4a8a50d407955a5db5fdf66138a9e1a0f14967134e3f2370d12d3173.json
+++ b/node/.sqlx/query-14e22bec4a8a50d407955a5db5fdf66138a9e1a0f14967134e3f2370d12d3173.json
@@ -6,7 +6,7 @@
       {
         "name": "block_height",
         "ordinal": 0,
-        "type_info": "Int64"
+        "type_info": "Integer"
       }
     ],
     "parameters": {

--- a/node/.sqlx/query-615a87effc582024c4b36d63d0ac5a9a0a4b1e6e7385e715a50025bff7509fdf.json
+++ b/node/.sqlx/query-615a87effc582024c4b36d63d0ac5a9a0a4b1e6e7385e715a50025bff7509fdf.json
@@ -6,7 +6,7 @@
       {
         "name": "block_height",
         "ordinal": 0,
-        "type_info": "Int64"
+        "type_info": "Integer"
       },
       {
         "name": "json_contract_events",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -35,7 +35,12 @@ metrics-exporter-prometheus = { workspace = true }
 memory-stats = { workspace = true }
 
 # archive feature dependencies
-sqlx = { version = "=0.7.4", features = [ "runtime-tokio", "tls-native-tls", "sqlite", "migrate"], optional = true }
+sqlx = { workspace = true, features = [
+    "runtime-tokio",
+    "tls-native-tls",
+    "sqlite",
+    "migrate",
+], optional = true }
 serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, features = ["hex"], optional = true }
 


### PR DESCRIPTION
Resolves #2497 

The upgrade from sqlx 0.7 to 0.8 only changed a query type for us from `Int64` to `Integer`.