### PR TITLE
Use only one `MultisigSignature` in `rusk_abi::verify_bls_multisig`

### DIFF
--- a/contracts/host_fn/src/lib.rs
+++ b/contracts/host_fn/src/lib.rs
@@ -15,7 +15,7 @@ use dusk_bytes::Serializable;
 use execution_core::{
     signatures::{
         bls::{
-            PublicKey as BlsPublicKey, PublicKeyAndSignature,
+            MultisigSignature, PublicKey as BlsPublicKey,
             Signature as BlsSignature,
         },
         schnorr::{
@@ -78,9 +78,10 @@ impl HostFnTest {
     pub fn verify_bls_multisig(
         &self,
         msg: Vec<u8>,
-        kas: Vec<PublicKeyAndSignature>,
+        keys: Vec<BlsPublicKey>,
+        sig: MultisigSignature,
     ) -> bool {
-        rusk_abi::verify_bls_multisig(msg, kas)
+        rusk_abi::verify_bls_multisig(msg, keys, sig)
     }
 
     pub fn chain_id(&self) -> u8 {
@@ -140,8 +141,8 @@ unsafe fn verify_bls(arg_len: u32) -> u32 {
 
 #[no_mangle]
 unsafe fn verify_bls_multisig(arg_len: u32) -> u32 {
-    rusk_abi::wrap_call(arg_len, |(msg, kas)| {
-        STATE.verify_bls_multisig(msg, kas)
+    rusk_abi::wrap_call(arg_len, |(msg, keys, sig)| {
+        STATE.verify_bls_multisig(msg, keys, sig)
     })
 }
 

--- a/execution-core/src/lib.rs
+++ b/execution-core/src/lib.rs
@@ -42,22 +42,6 @@ pub mod signatures {
             Error, MultisigPublicKey, MultisigSignature, PublicKey, SecretKey,
             Signature,
         };
-
-        use bytecheck::CheckBytes;
-        use rkyv::{Archive, Deserialize, Serialize};
-
-        /// A public key and a signature, used to interact with
-        /// [`rusk_abi::verify_bls_multisig`].
-        #[derive(
-            Debug, Clone, PartialEq, Eq, Archive, Serialize, Deserialize,
-        )]
-        #[archive_attr(derive(CheckBytes))]
-        pub struct PublicKeyAndSignature {
-            /// The public key.
-            pub public_key: PublicKey,
-            /// The signature.
-            pub signature: MultisigSignature,
-        }
     }
 
     /// Types for the schnorr-signature scheme operating on the `jubjub` curve.

--- a/rusk-abi/src/abi.rs
+++ b/rusk-abi/src/abi.rs
@@ -10,7 +10,7 @@ use dusk_bytes::Serializable;
 use execution_core::{
     signatures::{
         bls::{
-            PublicKey as BlsPublicKey, PublicKeyAndSignature,
+            MultisigSignature, PublicKey as BlsPublicKey,
             Signature as BlsSignature,
         },
         schnorr::{
@@ -72,9 +72,10 @@ pub fn verify_bls(msg: Vec<u8>, pk: BlsPublicKey, sig: BlsSignature) -> bool {
 /// Verify a BLS signature is valid for the given public key and message
 pub fn verify_bls_multisig(
     msg: Vec<u8>,
-    kas: Vec<PublicKeyAndSignature>,
+    keys: Vec<BlsPublicKey>,
+    sig: MultisigSignature,
 ) -> bool {
-    host_query(Query::VERIFY_BLS_MULTISIG, (msg, kas))
+    host_query(Query::VERIFY_BLS_MULTISIG, (msg, keys, sig))
 }
 
 /// Get the chain ID.

--- a/rusk-abi/src/host.rs
+++ b/rusk-abi/src/host.rs
@@ -18,8 +18,8 @@ use execution_core::{
     plonk::{Proof as PlonkProof, Verifier},
     signatures::{
         bls::{
-            MultisigPublicKey, PublicKey as BlsPublicKey,
-            PublicKeyAndSignature, Signature as BlsSignature,
+            MultisigPublicKey, MultisigSignature, PublicKey as BlsPublicKey,
+            Signature as BlsSignature,
         },
         schnorr::{
             PublicKey as SchnorrPublicKey, Signature as SchnorrSignature,
@@ -164,8 +164,8 @@ fn host_verify_bls(arg_buf: &mut [u8], arg_len: u32) -> u32 {
 }
 
 fn host_verify_bls_multisig(arg_buf: &mut [u8], arg_len: u32) -> u32 {
-    wrap_host_query(arg_buf, arg_len, |(msg, kas)| {
-        verify_bls_multisig(msg, kas)
+    wrap_host_query(arg_buf, arg_len, |(msg, keys, sig)| {
+        verify_bls_multisig(msg, keys, sig)
     })
 }
 
@@ -237,26 +237,16 @@ pub fn verify_bls(msg: Vec<u8>, pk: BlsPublicKey, sig: BlsSignature) -> bool {
 /// Verify a BLS signature is valid for the given public key and message
 pub fn verify_bls_multisig(
     msg: Vec<u8>,
-    keys_and_sigs: Vec<PublicKeyAndSignature>,
+    keys: Vec<BlsPublicKey>,
+    sig: MultisigSignature,
 ) -> bool {
-    let len = keys_and_sigs.len();
+    let len = keys.len();
     if len < 1 {
-        panic!("must have at least one key and signature");
-    }
-
-    let mut keys = Vec::with_capacity(keys_and_sigs.len());
-    let mut sigs = Vec::with_capacity(keys_and_sigs.len());
-
-    for kas in keys_and_sigs {
-        keys.push(kas.public_key);
-        sigs.push(kas.signature);
+        panic!("must have at least one key");
     }
 
     let akey = MultisigPublicKey::aggregate(&keys)
         .expect("aggregation should succeed");
 
-    let mut asig = sigs.pop().unwrap();
-    asig = asig.aggregate(&sigs);
-
-    akey.verify(&asig, &msg).is_ok()
+    akey.verify(&sig, &msg).is_ok()
 }


### PR DESCRIPTION
To save on space for each verification, we only take a single `MultisigSignature` as opposed to as many of them as keys.

While technically not required, using as many signatures as keys for each verification is a bit strange when we can use just one.