### PR TITLE
rusk: add makefile dev commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,16 @@ bench: keys wasm  ## Bench Rusk & node
 run: keys state web-wallet ## Run the server
 	$(MAKE) -C ./rusk/ $@
 
+prepare-dev: keys wasm ## Preparation steps for launching a local node for development
+		@cp examples/consensus.keys ~/.dusk/rusk/consensus.keys \
+	&& cargo r --release -p rusk -- recovery state --init examples/genesis.toml -o /tmp/example.state || echo "Example genesis state already exists. Not overriding it"
+
+run-dev: ## Launch a local ephemeral node for development
+	DUSK_CONSENSUS_KEYS_PASS=password cargo r --release -p rusk -- -s /tmp/example.state
+
+run-dev-archive: ## Launch a local ephemeral archive node for development
+	DUSK_CONSENSUS_KEYS_PASS=password cargo r --release --features archive -p rusk  -- -s /tmp/example.state
+
 rusk: keys state web-wallet ## Build rusk binary
 	$(MAKE) -C ./rusk build
 
@@ -88,4 +98,4 @@ COMPILER_VERSION=v0.2.0
 setup-compiler: ## Setup the Dusk Contract Compiler
 	@./scripts/setup-compiler.sh $(COMPILER_VERSION)
 
-.PHONY: all abi keys state wasm allcircuits contracts test bench run help rusk rusk-wallet web-wallet setup-compiler
+.PHONY: all abi keys state wasm allcircuits contracts test bench prepare-dev run run-dev run-dev-archive help rusk rusk-wallet web-wallet setup-compiler


### PR DESCRIPTION
This pull request introduces 3 new Makefile commands in the top most Makefile.

make prepare-dev
make run-dev
make run-dev-archive

This is a mirror of the commands listed in the README to make it easier to run the node without having to type more than 2 commands. To run a node, all you need to do is entering `make prepare-dev` & then either `make run-dev` or `make run-dev-archive`. Once `make prepare-dev` has been run, there is no need to run it again, unless, for example the contracts change.