### PR TITLE
web-wallet: Reinstate the Safari polyfill that was removed by mistake

### DIFF
--- a/web-wallet/src/routes/+layout.js
+++ b/web-wallet/src/routes/+layout.js
@@ -1,6 +1,9 @@
 import "$lib/dusk/polyfill/asyncIterator";
 import "$lib/dusk/polyfill/promiseWithResolvers";
 
+// eslint-disable-next-line import/no-unresolved
+import "web-streams-polyfill/polyfill";
+
 export const csr = true;
 export const prerender = true;
 export const ssr = false;


### PR DESCRIPTION
Resolves #2837