### PR TITLE
w3sper: Add high-level API to retrieve gas price

### DIFF
--- a/w3sper.js/src/network/components/blocks.js
+++ b/w3sper.js/src/network/components/blocks.js
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+export class Blocks {
+  #scope = null;
+
+  constructor(rues) {
+    this.#scope = rues.scope("blocks");
+  }
+
+  get gasPrice() {
+    // The gas price endpoint returns the current gas price as `number` but it should
+    // be `BigInt` to avoid precision loss.
+    return this.#scope.call["gas-price"]()
+      .then((r) => r.json())
+      .then((data) =>
+        Object.fromEntries(
+          Object.entries(data).map(([key, value]) => [key, BigInt(value)]),
+        ),
+      );
+  }
+
+  get on() {
+    return this.#scope.on;
+  }
+
+  get once() {
+    return this.#scope.once;
+  }
+
+  get call() {
+    return this.#scope.call;
+  }
+
+  withId(id) {
+    return this.#scope.withId(id);
+  }
+}

--- a/w3sper.js/src/network/components/node.js
+++ b/w3sper.js/src/network/components/node.js
@@ -15,23 +15,27 @@ export class Node {
     this.#scope = rues.scope("node");
   }
 
-  async info() {
+  get info() {
     if (this.#info) {
       return this.#info;
     }
 
-    const response = await this.#scope.call.info();
-
-    const data = await response.json();
-
-    const info = Object.fromEntries(
-      Object.entries(data).map(([key, value]) => [snakeToCamel(key), value]),
-    );
-
-    info.chainId = info.chainId ?? 0;
-    this.#info = Object.freeze(info);
-
-    return this.#info;
+    return this.#scope.call
+      .info()
+      .then((r) => r.json())
+      .then((data) =>
+        Object.fromEntries(
+          Object.entries(data).map(([key, value]) => [
+            snakeToCamel(key),
+            value,
+          ]),
+        ),
+      )
+      .then((info) => {
+        info.chainId = info.chainId ?? 0;
+        this.#info = Object.freeze(info);
+        return this.#info;
+      });
   }
 
   crs() {

--- a/w3sper.js/src/network/mod.js
+++ b/w3sper.js/src/network/mod.js
@@ -8,6 +8,7 @@ import * as ProtocolDriver from "../protocol-driver/mod.js";
 
 import { Rues } from "../rues/mod.js";
 import { Node } from "./components/node.js";
+import { Blocks } from "./components/blocks.js";
 import { Transactions } from "./components/transactions.js";
 import { Contracts } from "./components/contracts.js";
 import { Gas } from "./gas.js";
@@ -35,6 +36,7 @@ export class Network {
   constructor(url, options = {}) {
     this.#rues = new Rues(url, options);
     this.node = new Node(this.#rues);
+    this.blocks = new Blocks(this.#rues);
     this.contracts = new Contracts(this.#rues);
     this.transactions = new Transactions(this.#rues);
   }

--- a/w3sper.js/src/transaction.js
+++ b/w3sper.js/src/transaction.js
@@ -75,7 +75,7 @@ export class TransactionBuilder {
     const nullifiers = [...picked.keys()];
 
     // Get the chain id from the network
-    const { chainId } = await network.node.info();
+    const { chainId } = await network.node.info;
 
     // Create the unproven transaction
     let [tx, circuits] = await ProtocolDriver.phoenix({
@@ -111,7 +111,7 @@ export class TransactionBuilder {
     const receiver = this.#to;
 
     // Get the chain id from the network
-    const { chainId } = await network.node.info();
+    const { chainId } = await network.node.info;
 
     // Get the nonce
     let { nonce } = await this.#bookkeeper.balance(sender);

--- a/w3sper.js/tests/network_test.js
+++ b/w3sper.js/tests/network_test.js
@@ -21,7 +21,7 @@ test("Network connection", async () => {
 
   assert.ok(!network.connected);
 
-  assert.equal(Object.keys(await network.node.info()), [
+  assert.equal(Object.keys(await network.node.info), [
     "bootstrappingNodes",
     "chainId",
     "kadcastAddress",
@@ -34,6 +34,19 @@ test("Network block height", async () => {
   const network = await Network.connect("http://localhost:8080/");
 
   assert.ok((await network.blockHeight) > 0);
+
+  await network.disconnect();
+});
+
+test("Network gas price", async () => {
+  const network = await Network.connect("http://localhost:8080/");
+
+  const price = await network.blocks.gasPrice;
+
+  assert.equal(typeof price.average, "bigint");
+  assert.equal(typeof price.max, "bigint");
+  assert.equal(typeof price.median, "bigint");
+  assert.equal(typeof price.min, "bigint");
 
   await network.disconnect();
 });


### PR DESCRIPTION
- Add `blocks` component with `gasPrice` getter
- Change `network.node.info` as a getter instead of a function for consistency

Resolves #2842