### PR TITLE
wallet-core: Fix pick_notes function for selecting the input-notes for a transaction

### DIFF
--- a/rusk-wallet/src/clients.rs
+++ b/rusk-wallet/src/clients.rs
@@ -204,12 +204,11 @@ impl State {
     }
 
     /// Selects up to MAX_INPUT_NOTES unspent input notes from the cache. The
-    /// value of the input notes need to cover the target-value of the
-    /// transaction.
+    /// value of the input notes need to cover the cost of the transaction.
     pub(crate) async fn tx_input_notes(
         &self,
         index: u8,
-        target: u64,
+        tx_cost: u64,
     ) -> Result<Vec<(Note, NoteOpening, BlsScalar)>, Error> {
         let vk = derive_phoenix_vk(self.store().get_seed(), index);
         let mut sk = derive_phoenix_sk(self.store().get_seed(), index);
@@ -226,8 +225,8 @@ impl State {
             })
             .collect();
 
-        // pick up to MAX_INPUT_NOTES input-notes that cover the target value
-        let tx_input_notes = pick_notes(&vk, cached_notes.into(), target);
+        // pick up to MAX_INPUT_NOTES input-notes that cover the tx-cost
+        let tx_input_notes = pick_notes(&vk, cached_notes.into(), tx_cost);
         if tx_input_notes.is_empty() {
             return Err(Error::NotEnoughBalance);
         }

--- a/rusk-wallet/src/clients.rs
+++ b/rusk-wallet/src/clients.rs
@@ -17,7 +17,6 @@ use execution_core::{
     Error as ExecutionCoreError,
 };
 use flume::Receiver;
-use futures::{StreamExt, TryStreamExt};
 use rues::RuesHttpClient;
 use tokio::{
     task::JoinHandle,
@@ -204,8 +203,10 @@ impl State {
         Ok(tx)
     }
 
-    /// Find notes for a view key, starting from the given block height.
-    pub(crate) async fn inputs(
+    /// Selects up to MAX_INPUT_NOTES unspent input notes from the cache. The
+    /// value of the input notes need to cover the target-value of the
+    /// transaction.
+    pub(crate) async fn tx_input_notes(
         &self,
         index: u8,
         target: u64,
@@ -214,37 +215,35 @@ impl State {
         let mut sk = derive_phoenix_sk(self.store().get_seed(), index);
         let pk = derive_phoenix_pk(self.store().get_seed(), index);
 
-        let inputs: Result<Vec<_>, Error> = self
+        // fetch the cached unspent notes
+        let cached_notes: Vec<_> = self
             .cache()
             .notes(&pk)?
             .into_iter()
-            .map(|data| {
-                let note = data.note;
-                let block_height = data.block_height;
-                let nullifier = note.gen_nullifier(&sk);
-                let leaf = NoteLeaf { note, block_height };
-                Ok((nullifier, leaf))
+            .map(|note_leaf| {
+                let nullifier = note_leaf.note.gen_nullifier(&sk);
+                (nullifier, note_leaf)
             })
             .collect();
 
-        let input_notes = pick_notes(&vk, inputs?.into(), target);
+        // pick up to MAX_INPUT_NOTES input-notes that cover the target value
+        let tx_input_notes = pick_notes(&vk, cached_notes.into(), target);
+        if tx_input_notes.is_empty() {
+            return Err(Error::NotEnoughBalance);
+        }
 
-        let inputs = input_notes.iter().map(|(scalar, note)| async {
-            let opening = self.fetch_opening(note.as_ref()).await?;
+        // construct the transaction input
+        let mut tx_input = Vec::<(Note, NoteOpening, BlsScalar)>::new();
+        for (nullifier, note_leaf) in tx_input_notes.iter() {
+            // fetch the openings for the input-notes
+            let opening = self.fetch_opening(note_leaf.as_ref()).await?;
 
-            Ok((note.note.clone(), opening, *scalar))
-        });
-
-        // to not overwhelm the node, we buffer the requests
-        // 10 in line
-        let inputs = futures::stream::iter(inputs)
-            .buffer_unordered(10)
-            .try_collect()
-            .await;
+            tx_input.push((note_leaf.note.clone(), opening, *nullifier));
+        }
 
         sk.zeroize();
 
-        inputs
+        Ok(tx_input)
     }
 
     pub(crate) async fn fetch_account(

--- a/rusk-wallet/src/wallet/transaction.rs
+++ b/rusk-wallet/src/wallet/transaction.rs
@@ -55,10 +55,10 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let refund_pk = self.shielded_key(sender_idx)?;
 
         let inputs = state
-            .inputs(sender_idx, amt + gas.limit * gas.price)
+            .tx_input_notes(sender_idx, amt + gas.limit * gas.price)
             .await?
             .into_iter()
-            .map(|(a, b, _)| (a, b))
+            .map(|(note, opening, _nullifier)| (note, opening))
             .collect();
 
         let root = state.fetch_root().await?;
@@ -153,7 +153,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let receiver_pk = self.shielded_key(sender_idx)?;
 
         let inputs = state
-            .inputs(sender_idx, deposit + gas.limit * gas.price)
+            .tx_input_notes(sender_idx, deposit + gas.limit * gas.price)
             .await?
             .into_iter()
             .map(|(a, b, _)| (a, b))
@@ -265,7 +265,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let nonce = current_stake.map(|s| s.nonce).unwrap_or(0) + 1;
 
         let inputs = state
-            .inputs(profile_idx, amt + gas.limit * gas.price)
+            .tx_input_notes(profile_idx, amt + gas.limit * gas.price)
             .await?
             .into_iter()
             .map(|(a, b, _)| (a, b))
@@ -359,7 +359,9 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             return Err(Error::NotStaked);
         }
 
-        let inputs = state.inputs(profile_idx, gas.limit * gas.price).await?;
+        let inputs = state
+            .tx_input_notes(profile_idx, gas.limit * gas.price)
+            .await?;
 
         let root = state.fetch_root().await?;
         let chain_id = state.fetch_chain_id().await?;
@@ -438,7 +440,9 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let mut sender_sk = self.derive_phoenix_sk(sender_idx);
         let mut stake_sk = self.derive_bls_sk(sender_idx);
 
-        let inputs = state.inputs(sender_idx, gas.limit * gas.price).await?;
+        let inputs = state
+            .tx_input_notes(sender_idx, gas.limit * gas.price)
+            .await?;
 
         let root = state.fetch_root().await?;
         let chain_id = state.fetch_chain_id().await?;
@@ -508,7 +512,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let state = self.state()?;
         let amt = *amt;
         let inputs = state
-            .inputs(profile_idx, amt + gas.limit * gas.price)
+            .tx_input_notes(profile_idx, amt + gas.limit * gas.price)
             .await?;
 
         let root = state.fetch_root().await?;
@@ -587,7 +591,9 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let chain_id = state.fetch_chain_id().await?;
         let root = state.fetch_root().await?;
 
-        let inputs = state.inputs(sender_idx, gas.limit * gas.price).await?;
+        let inputs = state
+            .tx_input_notes(sender_idx, gas.limit * gas.price)
+            .await?;
 
         let mut sender_sk = self.derive_phoenix_sk(sender_idx);
         let owner_pk = self.public_key(sender_idx)?;

--- a/rusk-wallet/src/wallet/transaction.rs
+++ b/rusk-wallet/src/wallet/transaction.rs
@@ -54,8 +54,9 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let mut sender_sk = self.derive_phoenix_sk(sender_idx);
         let refund_pk = self.shielded_key(sender_idx)?;
 
+        let tx_cost = amt + gas.limit * gas.price;
         let inputs = state
-            .tx_input_notes(sender_idx, amt + gas.limit * gas.price)
+            .tx_input_notes(sender_idx, tx_cost)
             .await?
             .into_iter()
             .map(|(note, opening, _nullifier)| (note, opening))
@@ -152,8 +153,9 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         // the same
         let receiver_pk = self.shielded_key(sender_idx)?;
 
+        let tx_cost = deposit + gas.limit * gas.price;
         let inputs = state
-            .tx_input_notes(sender_idx, deposit + gas.limit * gas.price)
+            .tx_input_notes(sender_idx, tx_cost)
             .await?
             .into_iter()
             .map(|(a, b, _)| (a, b))
@@ -264,8 +266,9 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         let nonce = current_stake.map(|s| s.nonce).unwrap_or(0) + 1;
 
+        let tx_cost = amt + gas.limit * gas.price;
         let inputs = state
-            .tx_input_notes(profile_idx, amt + gas.limit * gas.price)
+            .tx_input_notes(profile_idx, tx_cost)
             .await?
             .into_iter()
             .map(|(a, b, _)| (a, b))
@@ -359,9 +362,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             return Err(Error::NotStaked);
         }
 
-        let inputs = state
-            .tx_input_notes(profile_idx, gas.limit * gas.price)
-            .await?;
+        let tx_cost = gas.limit * gas.price;
+        let inputs = state.tx_input_notes(profile_idx, tx_cost).await?;
 
         let root = state.fetch_root().await?;
         let chain_id = state.fetch_chain_id().await?;
@@ -440,9 +442,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let mut sender_sk = self.derive_phoenix_sk(sender_idx);
         let mut stake_sk = self.derive_bls_sk(sender_idx);
 
-        let inputs = state
-            .tx_input_notes(sender_idx, gas.limit * gas.price)
-            .await?;
+        let tx_cost = gas.limit * gas.price;
+        let inputs = state.tx_input_notes(sender_idx, tx_cost).await?;
 
         let root = state.fetch_root().await?;
         let chain_id = state.fetch_chain_id().await?;
@@ -510,10 +511,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
     ) -> Result<Transaction, Error> {
         let mut rng = StdRng::from_entropy();
         let state = self.state()?;
-        let amt = *amt;
-        let inputs = state
-            .tx_input_notes(profile_idx, amt + gas.limit * gas.price)
-            .await?;
+        let tx_cost = *amt + gas.limit * gas.price;
+        let inputs = state.tx_input_notes(profile_idx, tx_cost).await?;
 
         let root = state.fetch_root().await?;
         let chain_id = state.fetch_chain_id().await?;
@@ -527,7 +526,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             &moonlight_sk,
             inputs,
             root,
-            amt,
+            *amt,
             gas.limit,
             gas.price,
             chain_id,
@@ -591,9 +590,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let chain_id = state.fetch_chain_id().await?;
         let root = state.fetch_root().await?;
 
-        let inputs = state
-            .tx_input_notes(sender_idx, gas.limit * gas.price)
-            .await?;
+        let tx_cost = gas.limit * gas.price;
+        let inputs = state.tx_input_notes(sender_idx, tx_cost).await?;
 
         let mut sender_sk = self.derive_phoenix_sk(sender_idx);
         let owner_pk = self.public_key(sender_idx)?;

--- a/wallet-core/src/notes/pick.rs
+++ b/wallet-core/src/notes/pick.rs
@@ -42,20 +42,6 @@ pub fn notes(vk: &PhoenixViewKey, notes: NoteList, cost: u64) -> NoteList {
         })
         .collect();
 
-    // return an empty list if the sum of all notes cannot cover the cost
-    let sum: u64 = notes_values_nullifier
-        .iter()
-        .fold(0, |sum, &(_, value, _)| sum.saturating_add(value));
-    if sum < cost {
-        return NoteList::default();
-    }
-
-    // if there are less that MAX_INPUT_NOTES notes, we can return the list as
-    // it is
-    if notes.len() <= MAX_INPUT_NOTES {
-        return notes;
-    }
-
     // sort the input-notes from smallest to largest value
     notes_values_nullifier.sort_by(|(_, aval, _), (_, bval, _)| aval.cmp(bval));
 
@@ -63,12 +49,19 @@ pub fn notes(vk: &PhoenixViewKey, notes: NoteList, cost: u64) -> NoteList {
     // the cost
     if notes_values_nullifier
         .iter()
-        .skip(notes_values_nullifier.len() - MAX_INPUT_NOTES)
+        .rev()
+        .take(MAX_INPUT_NOTES)
         .map(|notes_values_nullifier| notes_values_nullifier.1)
         .sum::<u64>()
         < cost
     {
         return NoteList::default();
+    }
+
+    // if there are less than MAX_INPUT_NOTES notes, we can return the list as
+    // it is
+    if notes.len() <= MAX_INPUT_NOTES {
+        return notes;
     }
 
     // at this point we know that there is a possible combination of

--- a/wallet-core/src/notes/pick.rs
+++ b/wallet-core/src/notes/pick.rs
@@ -19,18 +19,19 @@ use execution_core::BlsScalar;
 /// while minimizing the value employed. To do this we sort the notes in
 /// ascending value order, and go through each combination in a
 /// lexicographic order until we find the first combination whose sum is
-/// larger or equal to the given value. If such a slice is not found, an
+/// larger or equal to the given cost. If such a slice is not found, an
 /// empty vector is returned.
 ///
-/// If the target sum is greater than the sum of the notes then an
-/// empty vector is returned.
+/// If the cost is greater than the sum of the notes then an empty vector is
+/// returned.
 #[must_use]
-pub fn notes(vk: &PhoenixViewKey, notes: NoteList, value: u64) -> NoteList {
+pub fn notes(vk: &PhoenixViewKey, notes: NoteList, cost: u64) -> NoteList {
     if notes.is_empty() {
         return NoteList::default();
     }
 
-    let mut notes_and_values: Vec<(NoteLeaf, u64, BlsScalar)> = notes
+    // decrypt the note-values
+    let mut notes_values_nullifier: Vec<(NoteLeaf, u64, BlsScalar)> = notes
         .iter()
         .filter_map(|(nullifier, leaf)| {
             leaf.as_ref()
@@ -40,36 +41,64 @@ pub fn notes(vk: &PhoenixViewKey, notes: NoteList, value: u64) -> NoteList {
         })
         .collect();
 
-    let sum: u64 = notes_and_values
+    // return an empty list if the sum of all notes cannot cover the cost
+    let sum: u64 = notes_values_nullifier
         .iter()
         .fold(0, |sum, &(_, value, _)| sum.saturating_add(value));
-
-    if sum < value {
+    if sum < cost {
         return NoteList::default();
     }
 
+    // if there are less that MAX_INPUT_NOTES notes, we can return the list as
+    // it is
     if notes.len() <= MAX_INPUT_NOTES {
         return notes;
     }
 
-    notes_and_values.sort_by(|(_, aval, _), (_, bval, _)| aval.cmp(bval));
-    pick_lexicographic(notes_and_values.len(), |indices| {
-        indices
-            .iter()
-            .map(|index| notes_and_values[*index].1)
-            .sum::<u64>()
-            >= value
-    })
-    .map(|index| notes_and_values[index].clone())
-    .map(|(n, _, b)| (b, n))
-    .to_vec()
-    .into()
+    // sort the input-notes from smallest to largest value
+    notes_values_nullifier.sort_by(|(_, aval, _), (_, bval, _)| aval.cmp(bval));
+
+    // return an empty list if the MAX_INPUT_NOTES highest notes do not cover
+    // the cost
+    if notes_values_nullifier
+        .iter()
+        .skip(notes_values_nullifier.len() - MAX_INPUT_NOTES)
+        .map(|notes_values_nullifier| notes_values_nullifier.1)
+        .sum::<u64>()
+        < cost
+    {
+        return NoteList::default();
+    }
+
+    // at this point we know that there is a possible combination of
+    // MAX_INPUT_NOTES notes that cover the cost and we pick the combination of
+    // the smallest note-values possible whose sum cover the cost
+    pick_lexicographic(&notes_values_nullifier, cost)
+        .map(|index| notes_values_nullifier[index].clone())
+        .map(|(n, _, b)| (b, n))
+        .to_vec()
+        .into()
 }
 
-fn pick_lexicographic<F: Fn(&[usize; MAX_INPUT_NOTES]) -> bool>(
-    max_len: usize,
-    is_valid: F,
+fn is_valid(
+    notes_values_nullifier: impl AsRef<[(NoteLeaf, u64, BlsScalar)]>,
+    cost: u64,
+    indices: &[usize; MAX_INPUT_NOTES],
+) -> bool {
+    indices
+        .iter()
+        .map(|index| notes_values_nullifier.as_ref()[*index].1)
+        .sum::<u64>()
+        >= cost
+}
+
+fn pick_lexicographic(
+    notes_values_nullifier: &Vec<(NoteLeaf, u64, BlsScalar)>,
+    cost: u64,
 ) -> [usize; MAX_INPUT_NOTES] {
+    let max_len = notes_values_nullifier.len();
+
+    // initialize the indices
     let mut indices = [0; MAX_INPUT_NOTES];
     indices
         .iter_mut()
@@ -77,7 +106,7 @@ fn pick_lexicographic<F: Fn(&[usize; MAX_INPUT_NOTES]) -> bool>(
         .for_each(|(i, index)| *index = i);
 
     loop {
-        if is_valid(&indices) {
+        if is_valid(notes_values_nullifier, cost, &indices) {
             return indices;
         }
 
@@ -101,5 +130,5 @@ fn pick_lexicographic<F: Fn(&[usize; MAX_INPUT_NOTES]) -> bool>(
         }
     }
 
-    [0; MAX_INPUT_NOTES]
+    indices
 }

--- a/wallet-core/src/notes/pick.rs
+++ b/wallet-core/src/notes/pick.rs
@@ -13,16 +13,17 @@ use crate::notes::MAX_INPUT_NOTES;
 use execution_core::transfer::phoenix::{NoteLeaf, ViewKey as PhoenixViewKey};
 use execution_core::BlsScalar;
 
-/// Pick the notes to be used in a transaction from a list of owned notes.
+/// Pick up to [`MAX_INPUT_NOTES`] notes to be used as input-notes in a
+/// transaction from a list of owned notes.
 ///
-/// The notes are picked in a way to maximize the number of notes used,
-/// while minimizing the value employed. To do this we sort the notes in
-/// ascending value order, and go through each combination in a
-/// lexicographic order until we find the first combination whose sum is
-/// larger or equal to the given cost. If such a slice is not found, an
-/// empty vector is returned.
+/// The notes are picked in a way to maximize the number of notes used, while
+/// minimizing the value employed. To do this we sort the notes in ascending
+/// value order, and go through each combination in a lexicographic order until
+/// we find the first combination whose sum is larger or equal to the given
+/// cost.
 ///
-/// If the cost is greater than the sum of the notes then an empty vector is
+/// If the cost is greater than the sum of the [`MAX_INPUT_NOTES`] notes with
+/// the largest value, no combination can be found and an empty vector is
 /// returned.
 #[must_use]
 pub fn notes(vk: &PhoenixViewKey, notes: NoteList, cost: u64) -> NoteList {
@@ -72,7 +73,8 @@ pub fn notes(vk: &PhoenixViewKey, notes: NoteList, cost: u64) -> NoteList {
 
     // at this point we know that there is a possible combination of
     // MAX_INPUT_NOTES notes that cover the cost and we pick the combination of
-    // the smallest note-values possible whose sum cover the cost
+    // MAX_INPUT_NOTES notes with the smallest possible values whose sum cover
+    // the cost
     pick_lexicographic(&notes_values_nullifier, cost)
         .map(|index| notes_values_nullifier[index].clone())
         .map(|(n, _, b)| (b, n))
@@ -80,6 +82,8 @@ pub fn notes(vk: &PhoenixViewKey, notes: NoteList, cost: u64) -> NoteList {
         .into()
 }
 
+// Sum up the values of the MAX_INPUT_NOTES notes stored at the given indices
+// and check that this sum is larger or equal the given cost.
 fn is_valid(
     notes_values_nullifier: impl AsRef<[(NoteLeaf, u64, BlsScalar)]>,
     cost: u64,
@@ -92,6 +96,8 @@ fn is_valid(
         >= cost
 }
 
+// Pick a combination of exactly MAX_INPUT_NOTES notes that cover the cost.
+// Notes with smaller values are favored.
 fn pick_lexicographic(
     notes_values_nullifier: &Vec<(NoteLeaf, u64, BlsScalar)>,
     cost: u64,

--- a/wallet-core/tests/notes.rs
+++ b/wallet-core/tests/notes.rs
@@ -219,7 +219,7 @@ fn test_pick_notes() {
     let all_notes = generate_note_list(leaves, &sk);
     assert_eq!(pick_notes(&vk, all_notes, 901), NoteList::default());
 
-    // checking that pick_notes works if spendable is smaller that the total
+    // checking that pick_notes works if spendable is smaller than the total
 
     // generate 5 notes with 10 dusk owned by the same key
     let leaves = [


### PR DESCRIPTION
The function `pick_notes` selects up to 4 input notes to be included in a phoenix-transaction.

With a spendable value lower than the total value of the notes, and the transaction target value higher than the spendable, `pick_notes` still returned 4 input-notes even though the transaction-costs weren't covered with those four notes.

To give an example:
Let's assume we have 5 unspent notes each with a value of 2 DUSK.
This means the max spendable is 8 DUSK (4 * 2).
For a transaction that costs 9 DUSK, `pick_notes` should return an empty list indicating that there is no combination of the input-notes where the transaction-costs is covered.
The old behavior of `pick_notes` however was to still return a  list of 4 input-notes, even though the values of those notes combined was lower than the transaction-cost.

Such a transaction isn't spendable (its circuit is invalid) so no harm was done, but the behavior is still not desirable.