### PR TITLE
Improve ratification propagation

### DIFF
--- a/consensus/src/errors.rs
+++ b/consensus/src/errors.rs
@@ -52,6 +52,7 @@ pub enum ConsensusError {
     ChildTaskTerminated,
     Canceled(u64),
     VoteAlreadyCollected,
+    VoteMismatch(Vote, Vote),
     TooManyTransactions(usize),
     TooManyFaults(usize),
     UnknownBlockSize,

--- a/consensus/src/errors.rs
+++ b/consensus/src/errors.rs
@@ -10,7 +10,7 @@ use execution_core::signatures::bls::Error as BlsSigError;
 use node_data::{
     bls::PublicKeyBytes,
     ledger::{Hash, InvalidFault},
-    message::payload::{QuorumType, RatificationResult, Vote},
+    message::payload::{RatificationResult, Vote},
     StepName,
 };
 use thiserror::Error;
@@ -39,7 +39,6 @@ pub enum ConsensusError {
     InvalidSignature(BlsSigError),
     InvalidMsgType,
     InvalidValidationStepVotes(StepSigError),
-    InvalidValidation(QuorumType),
     InvalidPrevBlockHash(Hash),
     InvalidQuorumType,
     InvalidVote(Vote),
@@ -47,6 +46,7 @@ pub enum ConsensusError {
     FutureEvent,
     PastEvent,
     NotCommitteeMember,
+    CommitteeNotGenerated,
     NotImplemented,
     NotReady,
     ChildTaskTerminated,

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -618,10 +618,6 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
                 self.handle_past_msg(msg).await;
                 return None;
             }
-            Err(ConsensusError::InvalidValidation(QuorumType::NoQuorum)) => {
-                warn!(event = "No quorum reached", iter = msg.header.iteration);
-                return None;
-            }
             // An error here means this message is invalid due to failed
             // verification.
             Err(e) => {

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -639,7 +639,13 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
         let collected = phase
             .lock()
             .await
-            .collect(msg, &self.round_update, committee, generator)
+            .collect(
+                msg,
+                &self.round_update,
+                committee,
+                generator,
+                &self.iter_ctx.committees,
+            )
             .await;
 
         match collected {
@@ -716,7 +722,13 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
                     match phase
                         .lock()
                         .await
-                        .collect(msg, &self.round_update, committee, generator)
+                        .collect(
+                            msg,
+                            &self.round_update,
+                            committee,
+                            generator,
+                            &self.iter_ctx.committees,
+                        )
                         .await
                     {
                         Ok(StepOutcome::Ready(msg)) => {

--- a/consensus/src/msg_handler.rs
+++ b/consensus/src/msg_handler.rs
@@ -163,6 +163,7 @@ pub trait MsgHandler {
         ru: &RoundUpdate,
         committee: &Committee,
         generator: Option<PublicKeyBytes>,
+        round_committees: &RoundCommittees,
     ) -> Result<StepOutcome, ConsensusError>;
 
     /// collect allows each Phase to process a verified message from a former

--- a/consensus/src/proposal/handler.rs
+++ b/consensus/src/proposal/handler.rs
@@ -44,7 +44,7 @@ impl<D: Database> MsgHandler for ProposalHandler<D> {
         let generator = round_committees
             .get_generator(iteration)
             .expect("committee to be created before run");
-        super::handler::verify_new_block(p, &generator)?;
+        super::handler::verify_candidate_msg(p, &generator)?;
 
         Ok(())
     }
@@ -132,7 +132,7 @@ impl<D: Database> ProposalHandler<D> {
     }
 }
 
-fn verify_new_block(
+fn verify_candidate_msg(
     p: &Candidate,
     expected_generator: &PublicKeyBytes,
 ) -> Result<(), ConsensusError> {
@@ -148,7 +148,7 @@ fn verify_new_block(
         return Err(ConsensusError::InvalidBlockSize(candidate_size));
     }
 
-    //  Verify new_block msg signature
+    // Verify msg signature
     p.verify_signature()?;
 
     if p.consensus_header().prev_block_hash
@@ -157,12 +157,20 @@ fn verify_new_block(
         return Err(ConsensusError::InvalidBlockHash);
     }
 
+    // INFO: we verify the transaction number and the merkle roots here because
+    // the signature only includes the header's hash, making 'txs' and 'faults'
+    // fields malleable from an adversary. We then discard blocks with errors
+    // related to these fields rather than propagating the message and vote
+    // Invalid
+
+    // Check number of transactions
     if p.candidate.txs().len() > MAX_NUMBER_OF_TRANSACTIONS {
         return Err(ConsensusError::TooManyTransactions(
             p.candidate.txs().len(),
         ));
     }
 
+    // Verify tx_root
     let tx_hashes: Vec<_> =
         p.candidate.txs().iter().map(|t| t.hash()).collect();
     let tx_root = merkle_root(&tx_hashes[..]);
@@ -170,10 +178,12 @@ fn verify_new_block(
         return Err(ConsensusError::InvalidBlock);
     }
 
+    // Check number of faults
     if p.candidate.faults().len() > MAX_NUMBER_OF_FAULTS {
         return Err(ConsensusError::TooManyFaults(p.candidate.faults().len()));
     }
 
+    // Verify fault_root
     let fault_hashes: Vec<_> =
         p.candidate.faults().iter().map(|t| t.hash()).collect();
     let fault_root = merkle_root(&fault_hashes[..]);
@@ -192,7 +202,7 @@ pub fn verify_stateless(
     let generator = round_committees
         .get_generator(iteration)
         .expect("committee to be created before run");
-    verify_new_block(c, &generator)?;
+    verify_candidate_msg(c, &generator)?;
 
     Ok(())
 }

--- a/consensus/src/proposal/handler.rs
+++ b/consensus/src/proposal/handler.rs
@@ -49,13 +49,14 @@ impl<D: Database> MsgHandler for ProposalHandler<D> {
         Ok(())
     }
 
-    /// Collects а new_block message.
+    /// Collects а Candidate message.
     async fn collect(
         &mut self,
         msg: Message,
         _ru: &RoundUpdate,
         _committee: &Committee,
         _generator: Option<PublicKeyBytes>,
+        _round_committees: &RoundCommittees,
     ) -> Result<StepOutcome, ConsensusError> {
         // store candidate block
         let p = Self::unwrap_msg(&msg)?;

--- a/consensus/src/proposal/step.rs
+++ b/consensus/src/proposal/step.rs
@@ -89,7 +89,13 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
                     .handler
                     .lock()
                     .await
-                    .collect(msg, &ctx.round_update, committee, None)
+                    .collect(
+                        msg,
+                        &ctx.round_update,
+                        committee,
+                        None,
+                        &ctx.iter_ctx.committees,
+                    )
                     .await
                 {
                     Ok(StepOutcome::Ready(msg)) => {

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -79,7 +79,7 @@ impl MsgHandler for RatificationHandler {
     fn verify(
         &self,
         msg: &Message,
-        round_committees: &RoundCommittees,
+        _round_committees: &RoundCommittees,
     ) -> Result<(), ConsensusError> {
         if let Payload::Ratification(p) = &msg.payload {
             if self.aggregator.is_vote_collected(p) {
@@ -87,11 +87,6 @@ impl MsgHandler for RatificationHandler {
             }
 
             p.verify_signature()?;
-            Self::verify_validation_result(
-                &p.header,
-                &p.validation_result,
-                round_committees,
-            )?;
 
             return Ok(());
         }
@@ -116,6 +111,12 @@ impl MsgHandler for RatificationHandler {
             // collect_from_past fn
             return Err(ConsensusError::InvalidMsgIteration(iteration));
         }
+
+        Self::verify_validation_result(
+            &p.header,
+            &p.validation_result,
+            round_committees,
+        )?;
 
         // Collect vote, if msg payload is of ratification type
         let (sv, quorum_reached) = self

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -99,13 +99,14 @@ impl MsgHandler for RatificationHandler {
         Err(ConsensusError::InvalidMsgType)
     }
 
-    /// Collect the ratification message.
+    /// Collect the Ratification message.
     async fn collect(
         &mut self,
         msg: Message,
         ru: &RoundUpdate,
         committee: &Committee,
         generator: Option<PublicKeyBytes>,
+        round_committees: &RoundCommittees,
     ) -> Result<StepOutcome, ConsensusError> {
         let p = Self::unwrap_msg(msg)?;
         let iteration = p.header().iteration;

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -283,7 +283,7 @@ impl RatificationHandler {
             .get_validation_committee(iter)
             .ok_or_else(|| {
                 error!("could not get validation committee");
-                ConsensusError::InvalidValidation(result.quorum())
+                ConsensusError::CommitteeNotGenerated
             })?;
         verify_votes(
             header,

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -118,6 +118,14 @@ impl MsgHandler for RatificationHandler {
             round_committees,
         )?;
 
+        // Ensure the vote matches that of Validation
+        if *p.validation_result.vote() != p.vote {
+            return Err(ConsensusError::VoteMismatch(
+                *p.validation_result.vote(),
+                p.vote,
+            ));
+        }
+
         // Collect vote, if msg payload is of ratification type
         let (sv, quorum_reached) = self
             .aggregator

--- a/consensus/src/ratification/step.rs
+++ b/consensus/src/ratification/step.rs
@@ -142,7 +142,13 @@ impl RatificationStep {
 
             // Collect my own vote
             match handler
-                .collect(vote_msg, &ctx.round_update, committee, generator)
+                .collect(
+                    vote_msg,
+                    &ctx.round_update,
+                    committee,
+                    generator,
+                    &ctx.iter_ctx.committees,
+                )
                 .await
             {
                 Ok(StepOutcome::Ready(m)) => return m,

--- a/consensus/src/validation/handler.rs
+++ b/consensus/src/validation/handler.rs
@@ -156,6 +156,7 @@ impl<D: Database> MsgHandler for ValidationHandler<D> {
         _ru: &RoundUpdate,
         committee: &Committee,
         generator: Option<PublicKeyBytes>,
+        _round_committees: &RoundCommittees,
     ) -> Result<StepOutcome, ConsensusError> {
         let p = Self::unwrap_msg(msg)?;
 


### PR DESCRIPTION
Resolves #2834

- Moves `verify_validation_result` from `verify` to `collect`
- Ensure Ratification vote matches vote in ValidationResult

Refactor:
- Rename `verify_new_block` to `verify_candidate_msg`
- Improve comments in `verify_candidate_msg`