### PR TITLE
rusk-abi: freeze `arbitrary` to `1.3.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ url = "=2.5.2"
 version_check = "=0.9.5"
 zeroize = { version = "=1.8.1", default-features = false }
 zip = "=0.5.13"
+arbitrary = "=1.3.2"
 
 [profile.dev.build-override]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ zk-citadel = "=0.14.0"
 # External dependencies
 aes = "=0.7.5"
 anyhow = "=1.0.89"
+arbitrary = "=1.3.2"
 ark-bn254 = { version = "=0.4.0", default-features = false }
 ark-groth16 = { version = "=0.4.0", default-features = false }
 ark-relations = { version = "=0.4.0", default-features = false }
@@ -147,7 +148,6 @@ url = "=2.5.2"
 version_check = "=0.9.5"
 zeroize = { version = "=1.8.1", default-features = false }
 zip = "=0.5.13"
-arbitrary = "=1.3.2"
 
 [profile.dev.build-override]
 opt-level = 3

--- a/rusk-abi/Cargo.toml
+++ b/rusk-abi/Cargo.toml
@@ -14,6 +14,7 @@ execution-core = { workspace = true, features = ["zk"] }
 
 # abi feature dependency
 piecrust-uplink = { workspace = true, features = ["abi"], optional = true }
+arbitrary = { workspace = true, optional = true }
 
 # host feature dependencies
 piecrust = { workspace = true, optional = true }


### PR DESCRIPTION
This solve the compiling issue related to the new `1.4.0` arbitrary version

```
error[E0658]: use of unstable library feature 'error_in_core'
  --> /home/docker/.cargo/registry/src/index.crates.io-6f17d22bba15001f/arbitrary-1.4.0/src/lib.rs:52:6
   |
52 | impl core::error::Error for MaxRecursionReached {}
   |      ^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #103765 <https://github.com/rust-lang/rust/issues/103765> for more information
   = help: add `#![feature(error_in_core)]` to the crate attributes to enable
```