### PR TITLE
Skip unncessary ValidationResult verification

### DIFF
--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -289,44 +289,39 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
                             // past-iteration Attestations without interrupting
                             // the step execution
                             if let RatificationResult::Fail(vote) = att.result {
-                                match vote {
-                                    Vote::NoCandidate | Vote::Invalid(_) => {
-                                        // Check if we know this Attestation
-                                        let mut sv_registry =
-                                            self.sv_registry.lock().await;
+                                // Check if we know this Attestation
+                                let mut sv_registry =
+                                    self.sv_registry.lock().await;
 
-                                        match sv_registry.get_fail_att(qiter) {
-                                            None => {
-                                                debug!(
-                                                  event = "Storing Fail Attestation",
-                                                  round = qround,
-                                                  iter = qiter,
-                                                  vote = ?vote,
-                                                );
+                                match sv_registry.get_fail_att(qiter) {
+                                    None => {
+                                        debug!(
+                                          event = "Storing Fail Attestation",
+                                          round = qround,
+                                          iter = qiter,
+                                          vote = ?vote,
+                                        );
 
-                                                let generator = self
-                                                    .iter_ctx
-                                                    .get_generator(qiter);
+                                        let generator =
+                                            self.iter_ctx.get_generator(qiter);
 
-                                                sv_registry
-                                                        .set_attestation(
-                                                          qiter,
-                                                          att,
-                                                          &generator.expect("There must be a valid generator")
-                                                        );
-                                            }
-                                            Some(_) => {
-                                                debug!(
-                                                  event = "Quorum discarded",
-                                                  reason = "known Fail Quorum",
-                                                  round = qround,
-                                                  iter = qiter,
-                                                  vote = ?vote,
-                                                );
-                                            }
-                                        }
+                                        sv_registry
+                                            .set_attestation(
+                                              qiter,
+                                              att,
+                                              &generator.expect("There must be a valid generator")
+                                            );
                                     }
-                                    _ => {}
+
+                                    Some(_) => {
+                                        debug!(
+                                          event = "Quorum discarded",
+                                          reason = "known Fail Quorum",
+                                          round = qround,
+                                          iter = qiter,
+                                          vote = ?vote,
+                                        );
+                                    }
                                 }
                             }
 

--- a/consensus/src/step_votes_reg.rs
+++ b/consensus/src/step_votes_reg.rs
@@ -220,11 +220,15 @@ impl AttInfoRegistry {
         let vote = attestation.result.vote();
         let att_info = iter_atts.get_or_insert(vote);
 
+        // If RatificationResult is NoQuorum, we assume Validation votes did not
+        // reach a quorum
+        let validation_quorum = !matches!(vote, Vote::NoQuorum);
+
         att_info.set_sv(
             iteration,
             attestation.validation,
             StepName::Validation,
-            true,
+            validation_quorum,
         );
         att_info.set_sv(
             iteration,

--- a/consensus/src/step_votes_reg.rs
+++ b/consensus/src/step_votes_reg.rs
@@ -275,6 +275,8 @@ impl AttInfoRegistry {
     pub(crate) fn get_fail_att(&self, iteration: u8) -> Option<Attestation> {
         self.att_list
             .get(&iteration)
-            .and_then(|atts| atts.failed().map(|info| info.att))
+            .and_then(|atts| atts.failed())
+            .filter(|info| info.is_ready())
+            .map(|info| info.att)
     }
 }


### PR DESCRIPTION
Change the Ratification collect to only verify the ValidationResult in the Ratification vote if it has a quorum and our result is NoQuorum. 
If the verification succeeds, we also replace our result with the received ValidationResult.

We also change the Quorum message to use the local ValidationResult (possibly updated from the one from a Ratification vote) instead of the ValidationResult from the last vote we received.