### PR TITLE
w3sper: Add `shield` / `unshield` API and transaction's type

### DIFF
--- a/w3sper.js/src/mod.js
+++ b/w3sper.js/src/mod.js
@@ -7,3 +7,4 @@
 export * from "./network/mod.js";
 export * from "./profile.js";
 export * from "./bookkeeper.js";
+export * from "./transaction.js";

--- a/w3sper.js/src/network/gas.js
+++ b/w3sper.js/src/network/gas.js
@@ -32,8 +32,8 @@ export class Gas {
 
   // Passing null/undefined/0 or negative values will set the default value for price and limit
   constructor({ limit, price } = {}) {
-    this.limit = max(limit, 0n) || Gas.DEFAULT_LIMIT;
-    this.price = max(price, 0n) || Gas.DEFAULT_PRICE;
+    this.limit = max(BigInt(limit || 0), 0n) || Gas.DEFAULT_LIMIT;
+    this.price = max(BigInt(price || 0), 0n) || Gas.DEFAULT_PRICE;
     this.total = this.limit * this.price;
 
     Object.freeze(this);

--- a/w3sper.js/src/network/mod.js
+++ b/w3sper.js/src/network/mod.js
@@ -88,8 +88,10 @@ export class Network {
     );
   }
 
-  async execute(builder) {
-    const tx = await builder.build(this);
+  async execute(tx) {
+    if (typeof tx?.build === "function") {
+      tx = await tx.build(this);
+    }
 
     // Attempt to preverify the transaction
     await this.transactions.preverify(tx.buffer);

--- a/w3sper.js/src/transaction.js
+++ b/w3sper.js/src/transaction.js
@@ -10,53 +10,149 @@ export const TRANSFER =
 import { AddressSyncer } from "./network/syncer/address.js";
 import { Gas } from "./network/gas.js";
 import * as ProtocolDriver from "./protocol-driver/mod.js";
-import { ProfileGenerator } from "./profile.js";
+import { ProfileGenerator, Profile } from "./profile.js";
 
-export class TransactionBuilder {
-  #bookkeeper;
+const _attributes = Symbol("builder::attributes");
 
-  #from;
-  #to;
-  #amount;
-  #obfuscated = false;
-  #gas;
+class BasicTransfer {
+  [_attributes];
 
-  constructor(bookkeeper) {
-    this.#bookkeeper = bookkeeper;
+  constructor(from) {
+    this[_attributes] = Object.create(null);
 
-    this.#gas = new Gas();
+    const value = from instanceof Profile ? { profile: from } : from;
+
+    Object.defineProperty(this, "bookentry", {
+      value,
+    });
+
+    this[_attributes].gas = new Gas();
   }
 
-  from(identifier) {
-    this.#from = identifier;
-    return this;
-  }
-
-  to(identifier) {
-    this.#to = identifier;
-    return this;
+  get attributes() {
+    return { ...this[_attributes] };
   }
 
   amount(value) {
-    this.#amount = value;
-    return this;
-  }
-
-  obfuscated() {
-    this.#obfuscated = true;
+    this[_attributes].amount = value;
     return this;
   }
 
   gas(value) {
-    this.#gas = new Gas(value);
+    this[_attributes].gas = new Gas(value);
+    return this;
+  }
+}
+
+export class Transfer extends BasicTransfer {
+  constructor(from) {
+    super(from);
+  }
+
+  to(identifier) {
+    let builder;
+    switch (ProfileGenerator.typeOf(String(identifier))) {
+      case "account":
+        builder = new AccountTransfer(this.bookentry);
+        break;
+      case "address":
+        builder = new AddressTransfer(this.bookentry);
+        break;
+      default:
+        throw new TypeError("Invalid identifier");
+    }
+    this[_attributes].to = identifier;
+    builder[_attributes] = this.attributes;
+
+    return builder;
+  }
+}
+
+class AccountTransfer extends Transfer {
+  constructor(from) {
+    super(from);
+  }
+
+  chain(value) {
+    this[_attributes].chain = value;
     return this;
   }
 
-  async #addressBuild(network) {
+  nonce(value) {
+    this[_attributes].nonce = value;
+    return this;
+  }
+
+  async build(network) {
+    const sender = this.bookentry.profile;
+    const { attributes } = this;
+    const { to: receiver, amount: transfer_value, gas } = attributes;
+
+    // Obtain the chain id
+    let chainId;
+    if (!isNaN(+attributes.chain)) {
+      chainId = +attributes.chain;
+    } else if (network) {
+      ({ chainId } = await network.node.info);
+    } else {
+      throw new Error("Chain ID is required.");
+    }
+
+    // Obtain the nonce
+    let nonce;
+    if ("nonce" in attributes) {
+      ({ nonce } = attributes);
+    } else if (typeof this.bookentry?.balance === "function") {
+      ({ nonce } = await this.bookentry.balance("account"));
+    }
+
+    nonce += 1n;
+
+    let [buffer, hash] = await ProtocolDriver.moonlight({
+      sender,
+      receiver,
+      transfer_value,
+      deposit: 0n,
+      gas_limit: gas.limit,
+      gas_price: gas.price,
+      nonce,
+      chainId,
+      data: null,
+    });
+
+    return Object.freeze({
+      buffer,
+      hash,
+      nonce,
+    });
+  }
+}
+
+class AddressTransfer extends Transfer {
+  constructor(from) {
+    super(from);
+  }
+
+  obfuscated() {
+    this[_attributes].obfuscated = true;
+    return this;
+  }
+
+  async build(network) {
+    const { attributes } = this;
+    const {
+      to: receiver,
+      amount: transfer_value,
+      obfuscated: obfuscated_transaction,
+      gas,
+    } = attributes;
+    const sender = this.bookentry.profile;
+    const { bookkeeper } = this.bookentry;
+
     // Pick notes to spend from the treasury
-    const picked = await this.#bookkeeper.pick(
-      this.#from,
-      this.#amount + this.#gas.total,
+    const picked = await bookkeeper.pick(
+      sender.address,
+      transfer_value + gas.total,
     );
 
     const syncer = new AddressSyncer(network);
@@ -69,8 +165,6 @@ export class TransactionBuilder {
     // Fetch the root
     const root = await syncer.root;
 
-    const sender = this.#from;
-    const receiver = this.#to;
     const inputs = picked.values();
     const nullifiers = [...picked.keys()];
 
@@ -84,11 +178,11 @@ export class TransactionBuilder {
       inputs,
       openings,
       root,
-      transfer_value: this.#amount,
-      obfuscated_transaction: this.#obfuscated,
+      transfer_value,
+      obfuscated_transaction,
       deposit: 0n,
-      gas_limit: this.#gas.limit,
-      gas_price: this.#gas.price,
+      gas_limit: gas.limit,
+      gas_price: gas.price,
       chainId,
       data: null,
     });
@@ -96,8 +190,8 @@ export class TransactionBuilder {
     // Attempt to prove the transaction
     const proof = await network.prove(circuits);
 
-    // Transform the unproven transaction into a proved transaction
-    const [buffer, hash] = await ProtocolDriver.intoProved(tx, proof);
+    // Transform the unproven transaction into a proven transaction
+    const [buffer, hash] = await ProtocolDriver.intoProven(tx, proof);
 
     return Object.freeze({
       buffer,
@@ -105,28 +199,92 @@ export class TransactionBuilder {
       nullifiers,
     });
   }
+}
 
-  async #accountBuild(network) {
-    const sender = this.#from;
-    const receiver = this.#to;
+export class UnshieldTransfer extends BasicTransfer {
+  constructor(from) {
+    super(from);
+  }
+
+  async build(network) {
+    const { attributes } = this;
+    const { amount: allocate_value, gas } = attributes;
+    const { profile, bookkeeper } = this.bookentry;
+
+    // Pick notes to spend from the treasury
+    const picked = await bookkeeper.pick(
+      profile.address,
+      allocate_value + gas.total,
+    );
+
+    const syncer = new AddressSyncer(network);
+
+    // Fetch the openings from the network for the picked notes
+    const openings = (await syncer.openings(picked)).map((opening) => {
+      return new Uint8Array(opening.slice(0));
+    });
+
+    // Fetch the root
+    const root = await syncer.root;
+
+    const inputs = picked.values();
+    const nullifiers = [...picked.keys()];
 
     // Get the chain id from the network
     const { chainId } = await network.node.info;
 
-    // Get the nonce
-    let { nonce } = await this.#bookkeeper.balance(sender);
+    // Create the unproven transaction
+    let [tx, circuits] = await ProtocolDriver.unshield({
+      profile,
+      inputs,
+      openings,
+      nullifiers,
+      root,
+      allocate_value,
+      gas_limit: gas.limit,
+      gas_price: gas.price,
+      chainId,
+    });
+
+    // Attempt to prove the transaction
+    const proof = await network.prove(circuits);
+
+    // Transform the unproven transaction into a proven transaction
+    const [buffer, hash] = await ProtocolDriver.intoProven(tx, proof);
+
+    return Object.freeze({
+      buffer,
+      hash,
+      nullifiers,
+    });
+  }
+}
+
+export class ShieldTransfer extends BasicTransfer {
+  constructor(from) {
+    super(from);
+  }
+
+  async build(network) {
+    const { attributes } = this;
+    const { amount: allocate_value, gas } = attributes;
+    const { profile, bookkeeper } = this.bookentry;
+
+    // Get the chain id from the network
+    const { chainId } = await network.node.info;
+
+    // Obtain the nonce
+    let { nonce } = await this.bookentry.balance("account");
+
     nonce += 1n;
 
-    let [buffer, hash] = await ProtocolDriver.moonlight({
-      sender,
-      receiver,
-      transfer_value: this.#amount,
-      deposit: 0n,
-      gas_limit: this.#gas.limit,
-      gas_price: this.#gas.price,
+    let [buffer, hash] = await ProtocolDriver.shield({
+      profile,
+      allocate_value,
+      gas_limit: gas.limit,
+      gas_price: gas.price,
       nonce,
       chainId,
-      data: null,
     });
 
     return Object.freeze({
@@ -134,14 +292,5 @@ export class TransactionBuilder {
       hash,
       nonce,
     });
-  }
-
-  async build(network) {
-    switch (ProfileGenerator.typeOf(this.#from.toString())) {
-      case "account":
-        return this.#accountBuild(network);
-      case "address":
-        return this.#addressBuild(network);
-    }
   }
 }

--- a/w3sper.js/tests/balances_test.js
+++ b/w3sper.js/tests/balances_test.js
@@ -74,5 +74,9 @@ test("Balances synchronization", async () => {
   assert.equal(accountBalances[1].value, 8800000000n);
   assert.equal(accountBalances[2].value, 6060000000n);
 
+  const bookentry = bookkeeper.as(await profiles.default);
+  assert.equal((await bookentry.balance("address")).value, 1026179647718621n);
+  assert.equal((await bookentry.balance("account")).value, 10100000000n);
+
   await network.disconnect();
 });


### PR DESCRIPTION
- Remove `Bookkeeper#transfer()`
- Add `Bookkeeper#as()` method that returns a `BookEntry`
- Add private class `BookEntry` with `balance`, `transfer`, `unshield`, `shield` methods
- Add private class `BasicTransfer`, and public classes `Transfer`, `UnshieldTransfer`, `ShieldTransfer`
- Remove `TransactionBuilder` class
- Change `Gas` class to enforce `limit` and `price` conversion to `BigInt` when possible
- Change `Network#execute` to build a given `transaction` only if it has a `build` method
- Rename `intoProved` in `intoProven`, and `into_proved` in `into_proven`
- Add `ProtocolDriver#unshield()` method
- Add `ProtocolDriver#shield()` method
- Change tests accordingly to the new APIs
- Fix dupes error on Treasury test implementation by implementing a lookup table of nullifiers
- Add test `getGasPaid` to calculate the actual gas paid for a given transaction's execution
- Add `Offline account transfers` test
- Add `shield` / `unshield` tests

Resolves #2859