### PR TITLE
Remove Option<> on origin field for ContractTxEvent

### DIFF
--- a/node-data/src/events/contract.rs
+++ b/node-data/src/events/contract.rs
@@ -10,17 +10,18 @@ use anyhow::Result;
 use execution_core::{ContractId, Event, CONTRACT_ID_BYTES};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-pub const TX_HASH_BYTES: usize = 32;
-pub type TxHash = [u8; TX_HASH_BYTES];
+pub const ORIGIN_HASH_BYTES: usize = 32;
+/// Origin hash of a contract event. This is in most cases the transaction hash.
+/// In the case of a reward or slash event, it is the block hash.
+pub type OriginHash = [u8; ORIGIN_HASH_BYTES];
 
-/// Contract event with optional origin (tx hash).
+/// Contract event with origin `OriginHash`.
 #[serde_with::serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ContractTxEvent {
     pub event: ContractEvent,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[serde_as(as = "Option<serde_with::hex::Hex>")]
-    pub origin: Option<TxHash>,
+    #[serde_as(as = "serde_with::hex::Hex")]
+    pub origin: OriginHash,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]

--- a/node/src/archive/moonlight.rs
+++ b/node/src/archive/moonlight.rs
@@ -12,7 +12,7 @@ use core::result::Result as CoreResult;
 use dusk_bytes::Serializable;
 use execution_core::signatures::bls::PublicKey as AccountPublicKey;
 use node_data::events::contract::ContractEvent;
-use node_data::events::contract::{ContractTxEvent, TxHash};
+use node_data::events::contract::{ContractTxEvent, OriginHash};
 use rocksdb::{
     BlockBasedOptions, ColumnFamily, ColumnFamilyDescriptor, DBPinnableSlice,
     LogLevel, OptimisticTransactionDB, Options,
@@ -33,13 +33,13 @@ const DEFAULT_MAX_COUNT: usize = 1000;
 
 // Column family names.
 
-/// Moonlight TxHash to MoonlightTxEvents mapping  
+/// Moonlight TxHash to MoonlightTxEvents mapping
 const CF_MTXHASH_MEVENTS: &str = "cf_mtxhash_mevents";
-/// AccountPublicKey to Inflow MoonlightTx mapping  
+/// AccountPublicKey to Inflow MoonlightTx mapping
 const CF_M_INFLOW_ADDRESS_TX: &str = "cf_m_inflow_address_tx";
-/// AccountPublicKey to Outflow MoonlightTx mapping  
+/// AccountPublicKey to Outflow MoonlightTx mapping
 const CF_M_OUTFLOW_ADDRESS_TX: &str = "cf_m_outflow_address_tx";
-/// Memo to MoonlightTx mapping (in- & outlfows)  
+/// Memo to MoonlightTx mapping (in- & outlfows)
 const CF_M_MEMO_TX: &str = "cf_m_memo_tx";
 
 /// Group of events belonging to a single Moonlight transaction and additional
@@ -56,7 +56,7 @@ const CF_M_MEMO_TX: &str = "cf_m_memo_tx";
 pub struct MoonlightGroup {
     events: Vec<ContractEvent>,
     #[serde_as(as = "serde_with::hex::Hex")]
-    origin: TxHash,
+    origin: OriginHash,
     block_height: u64,
 }
 
@@ -67,7 +67,7 @@ impl MoonlightGroup {
     }
 
     /// Returns the origin of the MoonlightGroup/Events.
-    pub fn origin(&self) -> &TxHash {
+    pub fn origin(&self) -> &OriginHash {
         &self.origin
     }
 
@@ -597,7 +597,7 @@ impl Archive {
             }
         };
 
-        let keys: Vec<&TxHash> =
+        let keys: Vec<&OriginHash> =
             moonlight_txs.iter().map(|tx| tx.origin()).collect();
 
         // sorted_input - If true, it means the input keys are already sorted by
@@ -740,7 +740,7 @@ mod tests {
     };
     use execution_core::{ContractId, CONTRACT_ID_BYTES};
     use node_data::events::contract::{
-        ContractEvent, WrappedContractId, TX_HASH_BYTES,
+        ContractEvent, WrappedContractId, ORIGIN_HASH_BYTES,
     };
     use rand::distributions::Alphanumeric;
     use rand::rngs::StdRng;
@@ -1140,7 +1140,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(fetched_moonlight_tx[0].block_height(), 1);
-        assert_eq!(fetched_moonlight_tx[0].origin(), &[1u8; TX_HASH_BYTES]);
+        assert_eq!(fetched_moonlight_tx[0].origin(), &[1u8; ORIGIN_HASH_BYTES]);
         assert_eq!(fetched_moonlight_tx[0], moonlight_tx);
 
         let events = fetched_events_by_moonlight_tx.events();
@@ -1183,7 +1183,7 @@ mod tests {
         assert_eq!(fetched_tx3.len(), 4);
 
         for (i, fetched_tx) in fetched_tx3.iter().enumerate() {
-            assert_eq!(fetched_tx.origin(), &[i as u8; TX_HASH_BYTES]);
+            assert_eq!(fetched_tx.origin(), &[i as u8; ORIGIN_HASH_BYTES]);
             fetched_tx.events().iter().for_each(|e| {
                 assert_eq!(e.topic, "moonlight");
                 assert_eq!(

--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -1272,7 +1272,7 @@ mod tests {
                 topic: TOPIC.into(),
                 data: b"hello, events".to_vec(),
             },
-            origin: None,
+            origin: [0; 32],
         });
 
         // This event is at first subscribed to, so it should be received the
@@ -1283,7 +1283,7 @@ mod tests {
                 topic: TOPIC.into(),
                 data: b"hello, events".to_vec(),
             },
-            origin: None,
+            origin: [1; 32],
         });
 
         // This event is not subscribed to, so it should not be received
@@ -1293,7 +1293,7 @@ mod tests {
                 topic: TOPIC.into(),
                 data: b"hello, events".to_vec(),
             },
-            origin: None,
+            origin: [2; 32],
         });
 
         event_sender

--- a/rusk/src/lib/http/chain/graphql/archive/data.rs
+++ b/rusk/src/lib/http/chain/graphql/archive/data.rs
@@ -57,7 +57,7 @@ pub mod deserialized_archive_data {
         TRANSFER_CONTRACT, WITHDRAW_TOPIC,
     };
     use node_data::events::contract::{
-        ContractEvent, TxHash, WrappedContractId,
+        ContractEvent, OriginHash, WrappedContractId,
     };
     use serde::ser::SerializeStruct;
     use serde::{Deserialize, Serialize};
@@ -67,7 +67,7 @@ pub mod deserialized_archive_data {
     pub struct DeserializedMoonlightGroup {
         pub events: serde_json::Value,
         #[serde_as(as = "serde_with::hex::Hex")]
-        pub origin: TxHash,
+        pub origin: OriginHash,
         pub block_height: u64,
     }
     pub struct DeserializedMoonlightGroups(pub Vec<DeserializedMoonlightGroup>);

--- a/rusk/src/lib/http/event.rs
+++ b/rusk/src/lib/http/event.rs
@@ -936,9 +936,10 @@ impl RuesEvent {
 impl From<node_data::events::contract::ContractTxEvent> for RuesEvent {
     fn from(tx_event: node_data::events::contract::ContractTxEvent) -> Self {
         let mut headers = serde_json::Map::new();
-        if let Some(origin) = tx_event.origin {
-            headers.insert("Rusk-Origin".into(), hex::encode(origin).into());
-        }
+
+        headers
+            .insert("Rusk-Origin".into(), hex::encode(tx_event.origin).into());
+
         let event = tx_event.event;
         Self {
             uri: RuesEventUri {

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -256,9 +256,11 @@ impl Rusk {
     }
 
     /// Verify the given transactions are ok.
+    #[allow(clippy::too_many_arguments)]
     pub fn verify_transactions(
         &self,
         block_height: u64,
+        block_hash: Hash,
         block_gas_limit: u64,
         generator: &BlsPublicKey,
         txs: &[Transaction],
@@ -270,6 +272,7 @@ impl Rusk {
         accept(
             session,
             block_height,
+            block_hash,
             block_gas_limit,
             generator,
             txs,
@@ -291,7 +294,7 @@ impl Rusk {
         &self,
         block_height: u64,
         block_gas_limit: u64,
-        _archive_block_hash: Hash,
+        block_hash: Hash,
         generator: BlsPublicKey,
         txs: Vec<Transaction>,
         consistency_check: Option<VerificationOutput>,
@@ -307,6 +310,7 @@ impl Rusk {
         let (spent_txs, verification_output, session, events) = accept(
             session,
             block_height,
+            block_hash,
             block_gas_limit,
             &generator,
             &txs[..],
@@ -333,7 +337,7 @@ impl Rusk {
         {
             let _ = self.archive_sender.try_send(ArchivalData::ArchivedEvents(
                 block_height,
-                _archive_block_hash,
+                block_hash,
                 events.clone(),
             ));
         }
@@ -512,6 +516,7 @@ impl Rusk {
 fn accept(
     session: Session,
     block_height: u64,
+    block_hash: Hash,
     block_gas_limit: u64,
     generator: &BlsPublicKey,
     txs: &[Transaction],
@@ -552,7 +557,7 @@ fn accept(
             .into_iter()
             .map(|event| ContractTxEvent {
                 event: event.into(),
-                origin: Some(tx_id),
+                origin: tx_id,
             })
             .collect();
 
@@ -589,7 +594,7 @@ fn accept(
         .into_iter()
         .map(|event| ContractTxEvent {
             event: event.into(),
-            origin: None,
+            origin: block_hash,
         })
         .collect();
     events.extend(coinbase_events);

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -58,6 +58,7 @@ impl VMExecution for Rusk {
         let (_, verification_output) = self
             .verify_transactions(
                 blk.header().height,
+                blk.header().hash,
                 blk.header().gas_limit,
                 &generator,
                 blk.txs(),


### PR DESCRIPTION
To have data consistency for available fields and to avoid NULL or None handling, I have removed the optionality of an origin for `ContractTxEvent`. 

Now the origin field always enriches a `ContractEvent` with an origin hash. This is the block hash for the three possible coinbase events. In all other cases, it is still the tx hash (tx id).