### PR TITLE
web-wallet: The network store doesn't always use the cached connection

### DIFF
--- a/web-wallet/src/lib/stores/__tests__/networkStore.spec.js
+++ b/web-wallet/src/lib/stores/__tests__/networkStore.spec.js
@@ -119,6 +119,11 @@ describe("Network store", async () => {
 
     expect(connectSpy).toHaveBeenCalledTimes(1);
     expect(syncer).toBeInstanceOf(AccountSyncer);
+
+    // check that the cached network is used
+    await store.getAccountSyncer();
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect(syncer).toBeInstanceOf(AccountSyncer);
   });
 
   it("should expose a service method to retrieve a `AddressSyncer` for the network", async () => {
@@ -131,6 +136,11 @@ describe("Network store", async () => {
 
     const syncer = await store.getAddressSyncer();
 
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect(syncer).toBeInstanceOf(AddressSyncer);
+
+    // check that the cached network is used
+    await store.getAddressSyncer();
     expect(connectSpy).toHaveBeenCalledTimes(1);
     expect(syncer).toBeInstanceOf(AddressSyncer);
   });

--- a/web-wallet/src/lib/stores/networkStore.js
+++ b/web-wallet/src/lib/stores/networkStore.js
@@ -72,12 +72,11 @@ const disconnect = () => network.disconnect();
 const getCurrentBlockHeight = () => network.blockHeight;
 
 /** @type {() => Promise<AccountSyncer>} */
-const getAccountSyncer = () =>
-  network.connect().then(() => new AccountSyncer(network));
+const getAccountSyncer = () => connect().then(() => new AccountSyncer(network));
 
 /** @type {(options?: NetworkSyncerOptions) => Promise<AddressSyncer>} */
 const getAddressSyncer = (options) =>
-  network.connect().then(() => new AddressSyncer(network, options));
+  connect().then(() => new AddressSyncer(network, options));
 
 /** @type {NetworkStore} */
 export default {


### PR DESCRIPTION
Resolves #2911