### PR TITLE
rusk-wallet-2622 | Set default gas price to the average mempool gas price

### DIFF
--- a/rusk-wallet/src/bin/interactive.rs
+++ b/rusk-wallet/src/bin/interactive.rs
@@ -112,6 +112,7 @@ pub(crate) async fn run_loop(
                     moonlight_bal,
                     settings,
                 )
+                .await
             };
 
             prompt::hide_cursor()?;

--- a/rusk-wallet/src/bin/interactive/command_menu.rs
+++ b/rusk-wallet/src/bin/interactive/command_menu.rs
@@ -39,7 +39,7 @@ enum MenuItem {
 
 /// Allows the user to choose the operation to perform for the
 /// selected profile
-pub(crate) fn online(
+pub(crate) async fn online(
     profile_idx: u8,
     wallet: &Wallet<WalletFile>,
     phoenix_spendable: Dusk,
@@ -102,6 +102,8 @@ pub(crate) fn online(
                 prompt::request_token_amt("transfer", balance)
             }?;
 
+            let mempool_gas_prices = wallet.get_mempool_gas_prices().await?;
+
             ProfileOp::Run(Box::new(Command::Transfer {
                 sender: Some(sender),
                 rcvr,
@@ -110,7 +112,10 @@ pub(crate) fn online(
                     gas::DEFAULT_LIMIT_TRANSFER,
                 )?,
                 memo,
-                gas_price: prompt::request_gas_price(DEFAULT_PRICE)?,
+                gas_price: prompt::request_gas_price(
+                    DEFAULT_PRICE,
+                    mempool_gas_prices,
+                )?,
             }))
         }
         MenuItem::Stake => {
@@ -131,11 +136,16 @@ pub(crate) fn online(
                 return Ok(ProfileOp::Stay);
             }
 
+            let mempool_gas_prices = wallet.get_mempool_gas_prices().await?;
+
             ProfileOp::Run(Box::new(Command::Stake {
                 address: Some(addr),
                 amt: prompt::request_stake_token_amt(balance)?,
                 gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
-                gas_price: prompt::request_gas_price(DEFAULT_PRICE)?,
+                gas_price: prompt::request_gas_price(
+                    DEFAULT_PRICE,
+                    mempool_gas_prices,
+                )?,
             }))
         }
         MenuItem::Unstake => {
@@ -156,10 +166,15 @@ pub(crate) fn online(
                 return Ok(ProfileOp::Stay);
             }
 
+            let mempool_gas_prices = wallet.get_mempool_gas_prices().await?;
+
             ProfileOp::Run(Box::new(Command::Unstake {
                 address: Some(addr),
                 gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
-                gas_price: prompt::request_gas_price(DEFAULT_PRICE)?,
+                gas_price: prompt::request_gas_price(
+                    DEFAULT_PRICE,
+                    mempool_gas_prices,
+                )?,
             }))
         }
         MenuItem::Withdraw => {
@@ -180,10 +195,15 @@ pub(crate) fn online(
                 return Ok(ProfileOp::Stay);
             }
 
+            let mempool_gas_prices = wallet.get_mempool_gas_prices().await?;
+
             ProfileOp::Run(Box::new(Command::Withdraw {
                 address: Some(addr),
                 gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
-                gas_price: prompt::request_gas_price(DEFAULT_PRICE)?,
+                gas_price: prompt::request_gas_price(
+                    DEFAULT_PRICE,
+                    mempool_gas_prices,
+                )?,
             }))
         }
         MenuItem::ContractDeploy => {
@@ -198,8 +218,13 @@ pub(crate) fn online(
             let code = prompt::request_contract_code()?;
             let code_len = code.metadata()?.len() as u64;
 
+            let mempool_gas_prices = wallet.get_mempool_gas_prices().await?;
+
             // Calculate the effective cost for the deployment
-            let gas_price = prompt::request_gas_price(MIN_PRICE_DEPLOYMENT)?;
+            let gas_price = prompt::request_gas_price(
+                MIN_PRICE_DEPLOYMENT,
+                mempool_gas_prices,
+            )?;
             let gas_limit =
                 (code_len * GAS_PER_DEPLOY_BYTE) + DEFAULT_LIMIT_TRANSFER;
 
@@ -240,6 +265,8 @@ pub(crate) fn online(
                 return Ok(ProfileOp::Stay);
             }
 
+            let mempool_gas_prices = wallet.get_mempool_gas_prices().await?;
+
             ProfileOp::Run(Box::new(Command::ContractCall {
                 address: Some(addr),
                 contract_id: prompt::request_bytes("contract id")?,
@@ -251,7 +278,10 @@ pub(crate) fn online(
                     "arguments of calling function",
                 )?,
                 gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
-                gas_price: prompt::request_gas_price(DEFAULT_PRICE)?,
+                gas_price: prompt::request_gas_price(
+                    DEFAULT_PRICE,
+                    mempool_gas_prices,
+                )?,
             }))
         }
         MenuItem::History => {
@@ -273,11 +303,16 @@ pub(crate) fn online(
                 return Ok(ProfileOp::Stay);
             }
 
+            let mempool_gas_prices = wallet.get_mempool_gas_prices().await?;
+
             ProfileOp::Run(Box::new(Command::Shield {
                 profile_idx: Some(profile_idx),
                 amt: prompt::request_token_amt("convert", moonlight_balance)?,
                 gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
-                gas_price: prompt::request_gas_price(DEFAULT_PRICE)?,
+                gas_price: prompt::request_gas_price(
+                    DEFAULT_PRICE,
+                    mempool_gas_prices,
+                )?,
             }))
         }
         MenuItem::Unshield => {
@@ -291,11 +326,16 @@ pub(crate) fn online(
                 return Ok(ProfileOp::Stay);
             }
 
+            let mempool_gas_prices = wallet.get_mempool_gas_prices().await?;
+
             ProfileOp::Run(Box::new(Command::Unshield {
                 profile_idx: Some(profile_idx),
                 amt: prompt::request_token_amt("convert", phoenix_spendable)?,
                 gas_limit: prompt::request_gas_limit(gas::DEFAULT_LIMIT_CALL)?,
-                gas_price: prompt::request_gas_price(DEFAULT_PRICE)?,
+                gas_price: prompt::request_gas_price(
+                    DEFAULT_PRICE,
+                    mempool_gas_prices,
+                )?,
             }))
         }
         MenuItem::CalculateContractId => {

--- a/rusk-wallet/src/clients.rs
+++ b/rusk-wallet/src/clients.rs
@@ -110,6 +110,11 @@ impl State {
         })
     }
 
+    /// Returns the reference to the client
+    pub fn client(&self) -> &RuesHttpClient {
+        &self.client
+    }
+
     pub async fn check_connection(&self) -> bool {
         self.client.check_connection().await.is_ok()
     }

--- a/rusk-wallet/src/gas.rs
+++ b/rusk-wallet/src/gas.rs
@@ -7,6 +7,8 @@
 //! This module contains the primitive related to the gas used for transaction
 //! in the Dusk Network.
 
+use serde::Deserialize;
+
 use crate::currency::Lux;
 
 /// The minimum gas limit
@@ -88,4 +90,17 @@ impl Default for Gas {
     fn default() -> Self {
         Self::new(DEFAULT_LIMIT_TRANSFER)
     }
+}
+
+/// Dynamic gas prices information from the mempool
+#[derive(Debug, Deserialize)]
+pub struct MempoolGasPrices {
+    /// Average gas price in the mempool in [Lux]
+    pub average: Lux,
+    /// Maximum gas price in the mempool in [Lux]
+    pub max: Lux,
+    /// Median gas price in the mempool in [Lux]
+    pub median: Lux,
+    /// Minimum gas price in the mempool in [Lux]
+    pub min: Lux,
 }

--- a/rusk-wallet/src/wallet.rs
+++ b/rusk-wallet/src/wallet.rs
@@ -38,6 +38,7 @@ use wallet_core::{
     BalanceInfo,
 };
 
+use crate::gas::MempoolGasPrices;
 use crate::{
     clients::State,
     crypto::encrypt,
@@ -601,6 +602,21 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         if let Some(x) = &mut self.state {
             x.close();
         }
+    }
+
+    /// Get gas prices from the mempool
+    pub async fn get_mempool_gas_prices(
+        &self,
+    ) -> Result<MempoolGasPrices, Error> {
+        let client = self.state()?.client();
+
+        let response = client
+            .call("blocks", None, "gas-price", &[] as &[u8])
+            .await?;
+
+        let gas_prices: MempoolGasPrices = serde_json::from_slice(&response)?;
+
+        Ok(gas_prices)
     }
 }
 


### PR DESCRIPTION
Closes [#2622 ](https://github.com/dusk-network/rusk/issues/2622)

- [x] Add `MempoolGasPrices` struct 
- [x] Provide an access to the HTTP client to the `Wallet` struct and its `call` method
- [x] Add `get_mempool_gas_prices` method to the `Wallet`
- [x] Refactor `prompt::request_gas_price` function to use the average gas price from the mempool as the default gas price value
- [x] Update calls of the `prompt::request_gas_price` function