### PR TITLE
execution-core: reorder imports to align with convention

### DIFF
--- a/execution-core/src/stake.rs
+++ b/execution-core/src/stake.rs
@@ -12,16 +12,12 @@ use bytecheck::CheckBytes;
 use dusk_bytes::{DeserializableSlice, Serializable, Write};
 use rkyv::{Archive, Deserialize, Serialize};
 
-use crate::{
-    signatures::bls::{
-        PublicKey as BlsPublicKey, SecretKey as BlsSecretKey,
-        Signature as BlsSignature,
-    },
-    transfer::withdraw::Withdraw as TransferWithdraw,
-    ContractId,
+use crate::signatures::bls::{
+    PublicKey as BlsPublicKey, SecretKey as BlsSecretKey,
+    Signature as BlsSignature,
 };
-
-use crate::{dusk, Dusk};
+use crate::transfer::withdraw::Withdraw as TransferWithdraw;
+use crate::{dusk, ContractId, Dusk};
 
 /// ID of the genesis stake contract
 pub const STAKE_CONTRACT: ContractId = crate::reserved(0x2);

--- a/execution-core/src/transfer.rs
+++ b/execution-core/src/transfer.rs
@@ -9,7 +9,6 @@
 
 use alloc::string::String;
 use alloc::vec::Vec;
-
 use core::fmt::Debug;
 
 use bytecheck::CheckBytes;
@@ -18,12 +17,11 @@ use poseidon_merkle::Opening;
 use rand::{CryptoRng, RngCore};
 use rkyv::{Archive, Deserialize, Serialize};
 
-use crate::{
-    signatures::bls::{
-        PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
-    },
-    BlsScalar, ContractId, Error,
+use crate::signatures::bls::{
+    PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
 };
+use crate::{BlsScalar, ContractId, Error};
+
 use data::{ContractCall, ContractDeploy, TransactionData};
 use moonlight::Transaction as MoonlightTransaction;
 use phoenix::{

--- a/execution-core/src/transfer/data.rs
+++ b/execution-core/src/transfer/data.rs
@@ -13,9 +13,8 @@ use alloc::vec::Vec;
 
 use bytecheck::CheckBytes;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
-use rkyv::{
-    ser::serializers::AllocSerializer, Archive, Deserialize, Serialize,
-};
+use rkyv::ser::serializers::AllocSerializer;
+use rkyv::{Archive, Deserialize, Serialize};
 
 use crate::{ContractId, Error, ARGBUF_LEN};
 

--- a/execution-core/src/transfer/moonlight.rs
+++ b/execution-core/src/transfer/moonlight.rs
@@ -13,17 +13,15 @@ use bytecheck::CheckBytes;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 use rkyv::{Archive, Deserialize, Serialize};
 
-use crate::{
-    signatures::bls::{
-        PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
-        Signature as AccountSignature,
-    },
-    transfer::data::{
-        ContractBytecode, ContractCall, ContractDeploy, TransactionData,
-        MAX_MEMO_SIZE,
-    },
-    BlsScalar, Error,
+use crate::signatures::bls::{
+    PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
+    Signature as AccountSignature,
 };
+use crate::transfer::data::{
+    ContractBytecode, ContractCall, ContractDeploy, TransactionData,
+    MAX_MEMO_SIZE,
+};
+use crate::{BlsScalar, Error};
 
 /// A Moonlight account's information.
 #[derive(Debug, Clone, PartialEq, Eq, Archive, Serialize, Deserialize)]

--- a/execution-core/src/transfer/phoenix.rs
+++ b/execution-core/src/transfer/phoenix.rs
@@ -17,16 +17,14 @@ use ff::Field;
 use rand::{CryptoRng, RngCore};
 use rkyv::{Archive, Deserialize, Serialize};
 
-use crate::{
-    signatures::schnorr::{
-        SecretKey as SchnorrSecretKey, Signature as SchnorrSignature,
-    },
-    transfer::data::{
-        ContractBytecode, ContractCall, ContractDeploy, TransactionData,
-        MAX_MEMO_SIZE,
-    },
-    BlsScalar, Error, JubJubAffine, JubJubScalar,
+use crate::signatures::schnorr::{
+    SecretKey as SchnorrSecretKey, Signature as SchnorrSignature,
 };
+use crate::transfer::data::{
+    ContractBytecode, ContractCall, ContractDeploy, TransactionData,
+    MAX_MEMO_SIZE,
+};
+use crate::{BlsScalar, Error, JubJubAffine, JubJubScalar};
 
 // phoenix types
 pub use phoenix_circuits::{InputNoteInfo, OutputNoteInfo, TxCircuit};

--- a/execution-core/src/transfer/withdraw.rs
+++ b/execution-core/src/transfer/withdraw.rs
@@ -13,17 +13,15 @@ use dusk_bytes::Serializable;
 use rand::{CryptoRng, RngCore};
 use rkyv::{Archive, Deserialize, Serialize};
 
-use crate::{
-    signatures::{
-        bls::{
-            PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
-            Signature as AccountSignature,
-        },
-        schnorr::{SecretKey as NoteSecretKey, Signature as NoteSignature},
-    },
-    transfer::phoenix::StealthAddress,
-    BlsScalar, ContractId,
+use crate::signatures::bls::{
+    PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
+    Signature as AccountSignature,
 };
+use crate::signatures::schnorr::{
+    SecretKey as NoteSecretKey, Signature as NoteSignature,
+};
+use crate::transfer::phoenix::StealthAddress;
+use crate::{BlsScalar, ContractId};
 
 /// Withdrawal information, proving the intent of a user to withdraw from a
 /// contract.

--- a/execution-core/tests/serialization.rs
+++ b/execution-core/tests/serialization.rs
@@ -4,23 +4,18 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use execution_core::{
-    signatures::bls::{
-        PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
-    },
-    transfer::{
-        data::{
-            ContractBytecode, ContractCall, ContractDeploy, TransactionData,
-        },
-        phoenix::{
-            Note, NoteTreeItem, NotesTree, Prove,
-            PublicKey as PhoenixPublicKey, SecretKey as PhoenixSecretKey,
-            TxCircuitVec,
-        },
-        Transaction,
-    },
-    BlsScalar, Error, JubJubScalar,
+use execution_core::signatures::bls::{
+    PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
 };
+use execution_core::transfer::data::{
+    ContractBytecode, ContractCall, ContractDeploy, TransactionData,
+};
+use execution_core::transfer::phoenix::{
+    Note, NoteTreeItem, NotesTree, Prove, PublicKey as PhoenixPublicKey,
+    SecretKey as PhoenixSecretKey, TxCircuitVec,
+};
+use execution_core::transfer::Transaction;
+use execution_core::{BlsScalar, Error, JubJubScalar};
 use ff::Field;
 use rand::rngs::StdRng;
 use rand::{CryptoRng, Rng, RngCore, SeedableRng};

--- a/execution-core/tests/transaction.rs
+++ b/execution-core/tests/transaction.rs
@@ -4,21 +4,18 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use execution_core::{
-    signatures::bls::{
-        PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
-    },
-    transfer::{
-        data::{ContractCall, TransactionData, MAX_MEMO_SIZE},
-        phoenix::{
-            Note, NoteOpening, NoteTreeItem, NotesTree, Prove,
-            PublicKey as PhoenixPublicKey, SecretKey as PhoenixSecretKey,
-            TxCircuitVec,
-        },
-        Transaction,
-    },
-    Error, JubJubScalar,
+use execution_core::signatures::bls::{
+    PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
 };
+use execution_core::transfer::data::{
+    ContractCall, TransactionData, MAX_MEMO_SIZE,
+};
+use execution_core::transfer::phoenix::{
+    Note, NoteOpening, NoteTreeItem, NotesTree, Prove,
+    PublicKey as PhoenixPublicKey, SecretKey as PhoenixSecretKey, TxCircuitVec,
+};
+use execution_core::transfer::Transaction;
+use execution_core::{Error, JubJubScalar};
 use ff::Field;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};


### PR DESCRIPTION
#2947 for execution-core