### PR TITLE
wallet-core: expose staking capabilities via FFI

### DIFF
--- a/wallet-core/src/ffi/error.rs
+++ b/wallet-core/src/ffi/error.rs
@@ -27,6 +27,8 @@ pub enum ErrorCode {
     PhoenixTransactionError = 252,
     // Moonlight Transaction error
     MoonlightTransactionError = 251,
+    // Contract Call Error
+    ContractCallError = 250,
     // Success
     Ok = 0,
 }

--- a/wallet-core/src/transaction.rs
+++ b/wallet-core/src/transaction.rs
@@ -723,7 +723,7 @@ fn stake_reward_to_phoenix<R: RngCore + CryptoRng>(
     ContractCall::new(STAKE_CONTRACT, "withdraw", &reward_withdraw)
 }
 
-fn stake_reward_to_moonlight<R: RngCore + CryptoRng>(
+pub(crate) fn stake_reward_to_moonlight<R: RngCore + CryptoRng>(
     rng: &mut R,
     moonlight_receiver_sk: &BlsSecretKey,
     stake_sk: &BlsSecretKey,
@@ -763,7 +763,7 @@ fn unstake_to_phoenix<R: RngCore + CryptoRng>(
     ContractCall::new(STAKE_CONTRACT, "unstake", &unstake)
 }
 
-fn unstake_to_moonlight<R: RngCore + CryptoRng>(
+pub(crate) fn unstake_to_moonlight<R: RngCore + CryptoRng>(
     rng: &mut R,
     moonlight_receiver_sk: &BlsSecretKey,
     stake_sk: &BlsSecretKey,


### PR DESCRIPTION
- Add `moonlight_stake` in FFI module
- Add `moonlight_unstake` in FFI module
- Add `moonlight_stake_reward` in FFI module
- Add `ErrorCode::ContractCallError`
- Change the visibility of `stake_reward_to_moonlight` to `pub(crate)`
- Change the visibility of `unstake_to_moonlight` to `pub(crate)`

Resolves #2955