### PR TITLE
rusk: add gql endpoint for events from specific contract id

### DIFF
--- a/node/.sqlx/query-0ea0095fd1d173e4d259bce7877000866b46c0e5c5bdbc39721dd993b831533e.json
+++ b/node/.sqlx/query-0ea0095fd1d173e4d259bce7877000866b46c0e5c5bdbc39721dd993b831533e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "\n                SELECT origin, topic, source, data FROM finalized_events\n                WHERE block_height = (SELECT MAX(block_height) FROM finalized_events)\n            ",
+  "query": "\n                SELECT origin, topic, source, data FROM unfinalized_events\n                WHERE block_height = (SELECT MAX(block_height) FROM unfinalized_events)\n            ",
   "describe": {
     "columns": [
       {
@@ -34,5 +34,5 @@
       false
     ]
   },
-  "hash": "c3207b9139137f86573f37893130985499d99040c00551afe21b68f3b63a5707"
+  "hash": "0ea0095fd1d173e4d259bce7877000866b46c0e5c5bdbc39721dd993b831533e"
 }

--- a/node/src/archive/archivist.rs
+++ b/node/src/archive/archivist.rs
@@ -40,7 +40,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
                     ) => {
                         if let Err(e) = self
                             .archivist
-                            .store_unfinalized_vm_events(
+                            .store_unfinalized_events(
                                 blk_height, blk_hash, events,
                             )
                             .await

--- a/node/src/archive/moonlight.rs
+++ b/node/src/archive/moonlight.rs
@@ -231,6 +231,8 @@ impl Archive {
     }
 
     /// Get the full moonlight transaction history of a given AccountPublicKey.
+    ///
+    /// Returns all finalized moonlight events for the given public key
     pub fn full_moonlight_history(
         &self,
         pk: AccountPublicKey,

--- a/node/src/archive/transformer.rs
+++ b/node/src/archive/transformer.rs
@@ -126,7 +126,7 @@ pub(super) fn filter_and_convert(
 
             /*
             Cases of a moonlight in- or outflow:
-            1. Any MoonlightTransactionEvent. This implicitly also catches a moonlight outflow for deposit or convert (from moonlight)
+            1. Any MoonlightTransactionEvent. This implicitly also catches a moonlight outflow for deposit, convert or refund (from moonlight)
             2a. Any withdraw event where the receiver is moonlight. (from phoenix)
             2b. Any mint event where the receiver is moonlight. (from staking)
             3. Any convert event where the receiver is moonlight. (from phoenix)

--- a/rusk/src/lib/http/chain/graphql.rs
+++ b/rusk/src/lib/http/chain/graphql.rs
@@ -187,18 +187,29 @@ impl Query {
         moonlight_tx_by_memo(ctx, memo).await
     }
 
+    /// Get contract events by height or hash.
     #[cfg(feature = "archive")]
-    async fn block_events(
+    async fn contract_events(
         &self,
         ctx: &Context<'_>,
         height: Option<i64>,
         hash: Option<String>,
-    ) -> OptResult<BlockEvents> {
+    ) -> OptResult<ContractEvents> {
         match (height, hash) {
-            (Some(height), None) => block_events_by_height(ctx, height).await,
-            (None, Some(hash)) => block_events_by_hash(ctx, hash).await,
+            (Some(height), None) => events_by_height(ctx, height).await,
+            (None, Some(hash)) => events_by_hash(ctx, hash).await,
             _ => Err(FieldError::new("Specify height or hash")),
         }
+    }
+
+    /// Get all finalized contract events from a specific contract id.
+    #[cfg(feature = "archive")]
+    async fn finalized_events(
+        &self,
+        ctx: &Context<'_>,
+        contract_id: String,
+    ) -> OptResult<ContractEvents> {
+        finalized_events_by_contractid(ctx, contract_id).await
     }
 
     /// Check if a given block height matches a given block hash.

--- a/rusk/src/lib/http/chain/graphql/archive/data.rs
+++ b/rusk/src/lib/http/chain/graphql/archive/data.rs
@@ -11,7 +11,7 @@ use node::archive::MoonlightGroup;
 
 pub struct MoonlightTransactions(pub Vec<MoonlightGroup>);
 
-pub struct BlockEvents(pub(super) serde_json::Value);
+pub struct ContractEvents(pub(super) serde_json::Value);
 
 pub(super) struct NewAccountPublicKey(pub AccountPublicKey);
 
@@ -39,7 +39,7 @@ impl MoonlightTransactions {
 }
 
 #[Object]
-impl BlockEvents {
+impl ContractEvents {
     pub async fn json(&self) -> serde_json::Value {
         self.0.clone()
     }


### PR DESCRIPTION
The main change is adding the graphQL endpoint for finalized contract events from a specific contract id to the archive gql endpoint now.

This pull request also includes a small refactor with changes to rename methods, types, and variables for shorter names, better clarity and consistency. An unused, redundant function also got removed. Additionally, the archive block events endpoint and type is now called contract events (as it sends out events emitted by a contract).