### PR TITLE
Bugfix-2512 | rusk-wallet: Remove all panics in the codebase

### DIFF
--- a/rusk-wallet/src/bin/command/history.rs
+++ b/rusk-wallet/src/bin/command/history.rs
@@ -66,7 +66,8 @@ pub(crate) async fn transaction_from_notes(
 ) -> anyhow::Result<Vec<TransactionHistory>> {
     notes.sort_by(|a, b| a.note.pos().cmp(b.note.pos()));
     let mut ret: Vec<TransactionHistory> = vec![];
-    let gql = GraphQL::new(settings.state.to_string(), io::status::interactive);
+    let gql =
+        GraphQL::new(settings.state.to_string(), io::status::interactive)?;
 
     let nullifiers = notes
         .iter()

--- a/rusk-wallet/src/bin/interactive.rs
+++ b/rusk-wallet/src/bin/interactive.rs
@@ -106,7 +106,7 @@ pub(crate) async fn run_loop(
                                     let gql = GraphQL::new(
                                         settings.state.to_string(),
                                         io::status::interactive,
-                                    );
+                                    )?;
                                     gql.wait_for(&tx_id).await?;
 
                                     if let Some(explorer) = &settings.explorer {
@@ -169,6 +169,8 @@ async fn profile_idx(
                         DatFileVersion::RuskBinaryFileFormat(LATEST_VERSION),
                     )?;
 
+                // UNWRAP: we can safely unwrap here because we know the file is
+                // not None since we've checked the file version
                 wallet.save_to(WalletFile {
                     path: wallet.file().clone().unwrap().path,
                     pwd,
@@ -364,7 +366,7 @@ fn confirm(cmd: &Command, wallet: &Wallet<WalletFile>) -> anyhow::Result<bool> {
             gas_price,
             memo,
         } => {
-            let sender = sender.as_ref().expect("sender to be a valid address");
+            let sender = sender.as_ref().ok_or(Error::BadAddress)?;
             sender.same_transaction_model(rcvr)?;
             let max_fee = gas_limit * gas_price;
             println!("   > Pay with {}", sender.preview());
@@ -385,8 +387,7 @@ fn confirm(cmd: &Command, wallet: &Wallet<WalletFile>) -> anyhow::Result<bool> {
             gas_limit,
             gas_price,
         } => {
-            let sender =
-                address.as_ref().expect("address to be a valid address");
+            let sender = address.as_ref().ok_or(Error::BadAddress)?;
             let max_fee = gas_limit * gas_price;
             let stake_to = wallet.public_address(wallet.find_index(sender)?)?;
             println!("   > Pay with {}", sender.preview());
@@ -403,8 +404,7 @@ fn confirm(cmd: &Command, wallet: &Wallet<WalletFile>) -> anyhow::Result<bool> {
             gas_limit,
             gas_price,
         } => {
-            let sender =
-                address.as_ref().expect("address to be a valid address");
+            let sender = address.as_ref().ok_or(Error::BadAddress)?;
             let unstake_from =
                 wallet.public_address(wallet.find_index(sender)?)?;
             let max_fee = gas_limit * gas_price;
@@ -424,8 +424,7 @@ fn confirm(cmd: &Command, wallet: &Wallet<WalletFile>) -> anyhow::Result<bool> {
             gas_limit,
             gas_price,
         } => {
-            let sender =
-                address.as_ref().expect("address to be a valid address");
+            let sender = address.as_ref().ok_or(Error::BadAddress)?;
             let max_fee = gas_limit * gas_price;
             let withdraw_from =
                 wallet.public_address(wallet.find_index(sender)?)?;
@@ -447,8 +446,7 @@ fn confirm(cmd: &Command, wallet: &Wallet<WalletFile>) -> anyhow::Result<bool> {
             gas_limit,
             gas_price,
         } => {
-            let sender =
-                address.as_ref().expect("address to be a valid address");
+            let sender = address.as_ref().ok_or(Error::BadAddress)?;
             let code_len = code.metadata()?.len();
             let max_fee = gas_limit * gas_price;
 

--- a/rusk-wallet/src/bin/main.rs
+++ b/rusk-wallet/src/bin/main.rs
@@ -131,7 +131,7 @@ async fn exec() -> anyhow::Result<()> {
     let cmd = args.command.clone();
 
     // Get the initial settings from the args
-    let settings_builder = Settings::args(args);
+    let settings_builder = Settings::args(args)?;
 
     // Obtain the wallet dir from the settings
     let wallet_dir = settings_builder.wallet_dir().clone();
@@ -357,7 +357,7 @@ async fn exec() -> anyhow::Result<()> {
                     let tx_id = hex::encode(hash.to_bytes());
 
                     // Wait for transaction confirmation from network
-                    let gql = GraphQL::new(settings.state, status::headless);
+                    let gql = GraphQL::new(settings.state, status::headless)?;
                     gql.wait_for(&tx_id).await?;
 
                     println!("{tx_id}");

--- a/rusk-wallet/src/bin/settings.rs
+++ b/rusk-wallet/src/bin/settings.rs
@@ -123,29 +123,31 @@ impl SettingsBuilder {
 }
 
 impl Settings {
-    pub fn args(args: WalletArgs) -> SettingsBuilder {
+    pub fn args(args: WalletArgs) -> Result<SettingsBuilder, Error> {
         let wallet_dir = if let Some(path) = &args.wallet_dir {
             path.clone()
         } else {
-            let mut path = dirs::home_dir().expect("OS not supported");
+            let mut path = dirs::home_dir().ok_or(Error::OsNotSupported)?;
             path.push(".dusk");
             path.push(env!("CARGO_BIN_NAME"));
             path
         };
 
-        SettingsBuilder { wallet_dir, args }
+        Ok(SettingsBuilder { wallet_dir, args })
     }
 
-    pub async fn check_state_con(&self) -> Result<(), reqwest::Error> {
-        RuesHttpClient::new(self.state.as_ref())
+    pub async fn check_state_con(&self) -> Result<(), Error> {
+        RuesHttpClient::new(self.state.as_ref())?
             .check_connection()
             .await
+            .map_err(Error::from)
     }
 
-    pub async fn check_prover_con(&self) -> Result<(), reqwest::Error> {
-        RuesHttpClient::new(self.prover.as_ref())
+    pub async fn check_prover_con(&self) -> Result<(), Error> {
+        RuesHttpClient::new(self.prover.as_ref())?
             .check_connection()
             .await
+            .map_err(Error::from)
     }
 }
 

--- a/rusk-wallet/src/currency.rs
+++ b/rusk-wallet/src/currency.rs
@@ -151,12 +151,15 @@ impl PartialOrd<f64> for Dusk {
 /// Convenient conversion of primitives to and from Dusk
 
 /// Floats are used directly as Dusk value
-impl From<f64> for Dusk {
-    fn from(val: f64) -> Self {
+impl TryFrom<f64> for Dusk {
+    type Error = Error;
+    fn try_from(val: f64) -> Result<Self, Error> {
         if val < 0.0 {
-            panic!("Dusk type does not support negative values");
+            return Err(Error::Conversion(
+                "Dusk type does not support negative values".to_string(),
+            ));
         }
-        Self(dusk(val))
+        Ok(Self(dusk(val)))
     }
 }
 
@@ -181,10 +184,17 @@ impl From<Lux> for Dusk {
 
 /// Strings are parsed as Dusk values (floats)
 impl FromStr for Dusk {
-    type Err = ParseFloatError;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        f64::from_str(s).map(Dusk::from)
+        let parse_result = f64::from_str(s).map_err(|e: ParseFloatError| {
+            Error::Conversion(format!(
+                "Failed to parse Dusk from string: {}",
+                e
+            ))
+        })?;
+
+        Dusk::try_from(parse_result)
     }
 }
 
@@ -211,20 +221,20 @@ mod tests {
 
     #[test]
     fn basics() {
-        let one = Dusk::from(1.0);
-        let dec = Dusk::from(2.25);
+        let one = Dusk::try_from(1.0).unwrap();
+        let dec = Dusk::try_from(2.25).unwrap();
         assert_eq!(one, 1.0);
         assert_eq!(dec, 2.25);
         assert_eq!(Dusk::MIN, 0);
-        assert_eq!(Dusk::MIN, Dusk::from(0.0));
+        assert_eq!(Dusk::MIN, Dusk::try_from(0.0).unwrap());
     }
 
     #[test]
     fn compare_dusk() {
-        let one = Dusk::from(1.0);
-        let two = Dusk::from(2.0);
-        let dec_a = Dusk::from(0.00025);
-        let dec_b = Dusk::from(0.00190);
+        let one = Dusk::try_from(1.0).unwrap();
+        let two = Dusk::try_from(2.0).unwrap();
+        let dec_a = Dusk::try_from(0.00025).unwrap();
+        let dec_b = Dusk::try_from(0.00190).unwrap();
         assert!(one == one);
         assert!(one != two);
         assert!(one < two);
@@ -236,22 +246,22 @@ mod tests {
 
     #[test]
     fn ops_dusk_dusk() {
-        let one = Dusk::from(1.0);
-        let two = Dusk::from(2.0);
-        let three = Dusk::from(3.0);
+        let one = Dusk::try_from(1.0).unwrap();
+        let two = Dusk::try_from(2.0).unwrap();
+        let three = Dusk::try_from(3.0).unwrap();
         assert_eq!(one + two, three);
         assert_eq!(three - two, one);
         assert_eq!(one * one, one);
         assert_eq!(two * one, two);
         assert_eq!(two / one, two);
-        let point_five = Dusk::from(0.5);
+        let point_five = Dusk::try_from(0.5).unwrap();
         assert_eq!(one / two, point_five);
-        assert_eq!(point_five * point_five, Dusk::from(0.25))
+        assert_eq!(point_five * point_five, Dusk::try_from(0.25).unwrap());
     }
 
     #[test]
     fn ops_dusk_lux() {
-        let one = Dusk::from(1.0);
+        let one = Dusk::try_from(1.0).unwrap();
         let one_dusk = 1000000000;
         assert_eq!(one + one_dusk, 2.0);
         assert_eq!(one - one_dusk, 0.0);
@@ -262,43 +272,42 @@ mod tests {
     #[test]
     fn conversions() {
         let my_float = 35.049;
-        let dusk: Dusk = my_float.into();
+        let dusk: Dusk = my_float.try_into().unwrap();
         assert_eq!(dusk, my_float);
         let one_dusk = 1_000_000_000u64;
-        let dusk: Dusk = one_dusk.into();
+        let dusk: Dusk = one_dusk.try_into().unwrap();
         assert_eq!(dusk, 1.0);
         assert_eq!(*dusk, one_dusk);
         let dusk = Dusk::from_str("69.420").unwrap();
         assert_eq!(dusk, 69.420);
-        let float: f64 = dusk.into();
+        let float: f64 = dusk.try_into().unwrap();
         assert_eq!(float, 69.420);
         let borrowed = &Dusk(one_dusk);
-        let float: f64 = borrowed.into();
+        let float: f64 = borrowed.try_into().unwrap();
         assert_eq!(float, 1.0);
         let zero = 0;
-        assert_eq!(Dusk::from(zero), 0);
+        assert_eq!(Dusk::try_from(zero).unwrap(), 0);
         let zero = 0.0;
-        assert_eq!(Dusk::from(zero), 0.0);
+        assert_eq!(Dusk::try_from(zero).unwrap(), 0.0);
     }
 
     #[test]
     #[should_panic]
     fn overflow() {
-        let ten = Dusk::from(10.0);
+        let ten = Dusk::try_from(10.0).unwrap();
         let _ = Dusk::MAX + ten;
     }
 
     #[test]
-    #[should_panic]
     fn negative_dusk() {
-        let _ = Dusk::from(-1.0);
+        assert!(Dusk::try_from(-1.0).is_err());
     }
 
     #[test]
     #[should_panic]
     fn negative_result() {
-        let one = Dusk::from(1.0);
-        let two = Dusk::from(2.0);
+        let one = Dusk::try_from(1.0).unwrap();
+        let two = Dusk::try_from(2.0).unwrap();
         let _ = one - two;
     }
 }

--- a/rusk-wallet/src/error.rs
+++ b/rusk-wallet/src/error.rs
@@ -4,9 +4,12 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use inquire::InquireError;
 use rand::Error as RngError;
 use std::io;
 use std::str::Utf8Error;
+
+use crate::gql::GraphQLError;
 
 /// Errors returned by this library
 #[derive(Debug, thiserror::Error)]
@@ -35,6 +38,9 @@ pub enum Error {
     /// Rkyv errors
     #[error("A serialization error occurred.")]
     Rkyv,
+    /// Error creating HTTP client
+    #[error("Cannot create HTTP client")]
+    HttpClient,
     /// Reqwest errors
     #[error("A request error occurred: {0}")]
     Reqwest(#[from] reqwest::Error),
@@ -57,6 +63,9 @@ pub enum Error {
     /// The note wasn't found in the note-tree of the transfer-contract
     #[error("Note wasn't found in transfer-contract")]
     NoteNotFound,
+    /// The note couldn't be decrypted with the provided ViewKey
+    #[error("Note couldn't be decrypted with the provided ViewKey")]
+    WrongViewKey,
     /// Not enough gas to perform this transaction
     #[error("Not enough gas to perform this transaction")]
     NotEnoughGas,
@@ -75,12 +84,18 @@ pub enum Error {
     /// Address does not belong to this wallet
     #[error("Address does not belong to this wallet")]
     AddressNotOwned,
+    /// No menu item selected
+    #[error("No menu item selected")]
+    NoMenuItemSelected,
     /// Mnemonic phrase is not valid
     #[error("Invalid mnemonic phrase")]
     InvalidMnemonicPhrase,
     /// Path provided is not a directory
     #[error("Path provided is not a directory")]
     NotDirectory,
+    /// Cannot get the path to the $HOME directory
+    #[error("OS not supported")]
+    OsNotSupported,
     /// Wallet file content is not valid
     #[error("Wallet file content is not valid")]
     WalletFileCorrupted,
@@ -137,6 +152,18 @@ pub enum Error {
     /// Contract file location not found
     #[error("Invalid WASM contract path provided")]
     InvalidWasmContractPath,
+    /// Invalid environment variable value
+    #[error("Invalid environment variable value {0}")]
+    InvalidEnvVar(String),
+    /// Conversion error
+    #[error("Conversion error: {0}")]
+    Conversion(String),
+    /// GraphQL error
+    #[error("GraphQL error: {0}")]
+    GraphQLError(GraphQLError),
+    /// Inquire error
+    #[error("Inquire error: {0}")]
+    InquireError(String),
 }
 
 impl From<dusk_bytes::Error> for Error {
@@ -176,5 +203,17 @@ impl From<execution_core::Error> for Error {
 impl From<rocksdb::Error> for Error {
     fn from(e: rocksdb::Error) -> Self {
         Self::RocksDB(e)
+    }
+}
+
+impl From<GraphQLError> for Error {
+    fn from(e: GraphQLError) -> Self {
+        Self::GraphQLError(e)
+    }
+}
+
+impl From<InquireError> for Error {
+    fn from(e: InquireError) -> Self {
+        Self::InquireError(e.to_string())
     }
 }

--- a/rusk-wallet/src/lib.rs
+++ b/rusk-wallet/src/lib.rs
@@ -61,6 +61,8 @@ pub const MAX_PROFILES: usize = get_max_profiles();
 
 const DEFAULT_MAX_PROFILES: usize = 2;
 
+// PANIC: the function is const and will panic during compilation if the value
+// is invalid
 const fn get_max_profiles() -> usize {
     match option_env!("WALLET_MAX_PROFILES") {
         Some(v) => match konst::primitive::parse_usize(v) {

--- a/rusk-wallet/src/rues.rs
+++ b/rusk-wallet/src/rues.rs
@@ -26,13 +26,18 @@ pub struct RuesHttpClient {
 
 impl RuesHttpClient {
     /// Create a new HTTP Client
-    pub fn new<S: Into<String>>(uri: S) -> Self {
+    pub fn new<S: Into<String>>(uri: S) -> Result<Self, Error> {
         let client = reqwest::ClientBuilder::new()
             .connect_timeout(Duration::from_secs(30))
-            .build()
-            .expect("Client to be created");
-        let uri = uri.into();
-        Self { uri, client }
+            .build();
+
+        match client {
+            Ok(client) => Ok(Self {
+                uri: uri.into(),
+                client,
+            }),
+            Err(_) => Err(Error::HttpClient),
+        }
     }
 
     /// Utility for querying the rusk VM


### PR DESCRIPTION
- [x] Remove all unwraps (some unwraps are left in tests)
- [x] Properly handle all expects
- [x] Remove `From<f64> for Dusk` implementation and replace it with `TryFrom<f64> for Dusk` implementation
- [x] Implement `From<GraphQLError> for Error` and `From< InquireError> for Error`
- [x] Remove `MAX_PROFILES` constant and replace it with `get_max_profiles` function call to handle possible errors properly

#### Unrelated to panic handling
- [x] Replace `PasswordDisplayMode::Hidden` with `PasswordDisplayMode::Masked` in password prompts to improve user experience when entering passwords

#### Future improvements (for a separate PR)
- Enhance error handling in the `inquire` menu. For non-critical errors, provide users with options to retry the failed operation or return to the previous menu, rather than always exiting with an error message.