### PR TITLE
web-wallet: Release v.0.8.0

### DIFF
--- a/web-wallet/CHANGELOG.md
+++ b/web-wallet/CHANGELOG.md
@@ -9,19 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+- Update Transactions list design [#1922]
+
+### Removed
+
+### Fixed
+
+## [0.8.0] - 2024-11-19
+
+### Added
+
 - Added gas settings validation on Unstake / Widthdraw Rewards flows [#2000]
 - Add temporary link to the block explorer on the dashboard [#2882]
-- Update Staking-Related functionality to make use of w3sper [#3006]
+- Add Staking-Related Functionality Utilizing w3sper [#3006]
 - Add minimum stake amount supplied by w3sper instead of using an env var [#3010]
 
 ### Changed
 
-- Update Transactions list design [#1922]
 - Update `Stake` to use `Stepper` [#2436]
 - Update Mnemonic (Authenticate) Enter key behavior [#2879]
 - Enhance Error Handling on Wallet Access Page [#2932]
-
-### Removed
 
 ### Fixed
 
@@ -355,6 +364,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- VERSIONS -->
 
 [Unreleased]: https://github.com/dusk-network/rusk/tree/master/web-wallet
+[0.8.0]: https://github.com/dusk-network/rusk/tree/web-wallet-v0.8.0
 [0.7.0]: https://github.com/dusk-network/rusk/tree/web-wallet-v0.7.0
 [0.6.0]: https://github.com/dusk-network/rusk/tree/web-wallet-v0.6.0
 [0.5.0]: https://github.com/dusk-network/rusk/tree/web-wallet-v0.5.0

--- a/web-wallet/package-lock.json
+++ b/web-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-wallet",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-wallet",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@floating-ui/dom": "1.6.5",

--- a/web-wallet/package.json
+++ b/web-wallet/package.json
@@ -33,7 +33,7 @@
     "typecheck:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch --fail-on-warnings"
   },
   "type": "module",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "dependencies": {
     "@floating-ui/dom": "1.6.5",
     "@mdi/js": "7.4.47",


### PR DESCRIPTION
Resolves #3020


## 0.8.0 - 2024-11-19

### Added

- Added gas settings validation on Unstake / Widthdraw Rewards flows [#2000]
- Add temporary link to the block explorer on the dashboard [#2882]
- Add Staking-Related Functionality Utilizing w3sper [#3006]
- Add minimum stake amount supplied by w3sper instead of using an env var [#3010]

### Changed

- Update `Stake` to use `Stepper` [#2436]
- Update Mnemonic (Authenticate) Enter key behavior [#2879]
- Enhance Error Handling on Wallet Access Page [#2932]

### Fixed

- Suggested words in the Mnemonic (Authenticate) are accessible using Tab [#2879]
- Enhance Allocate flow on full amount allocation [#2938]
- Broken link in the stake warning [#2990]
- Change "Transaction created" copy [#2991]
- Fix Dashboard navigation menu padding [#3000]
