### PR TITLE
node, node-data: truncate trace logs of contract deployments

### DIFF
--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -129,7 +129,10 @@ impl Message {
             Payload::Validation(v) => v.sign_info().signer,
             Payload::Ratification(r) => r.sign_info().signer,
             msg => {
-                warn!("Calling get_signer for {msg:?}");
+                warn!(
+                    "Calling get_signer for payload: {:?}",
+                    msg.variant_name()
+                );
                 return None;
             }
         };
@@ -437,6 +440,24 @@ impl Payload {
             Payload::GetMempool(p) => p.set_nonce(nonce),
             Payload::GetBlocks(p) => p.set_nonce(nonce),
             _ => {}
+        }
+    }
+
+    fn variant_name(&self) -> &'static str {
+        match self {
+            Payload::Block(_) => "Block",
+            Payload::Candidate(_) => "Candidate",
+            Payload::Empty => "Empty",
+            Payload::GetBlocks(_) => "GetBlocks",
+            Payload::GetMempool(_) => "GetMempool",
+            Payload::GetResource(_) => "GetResource",
+            Payload::Inv(_) => "Inv",
+            Payload::Quorum(_) => "Quorum",
+            Payload::Ratification(_) => "Ratification",
+            Payload::Transaction(_) => "Transaction",
+            Payload::Validation(_) => "Validation",
+            Payload::ValidationQuorum(_) => "ValidationQuorum",
+            Payload::ValidationResult(_) => "ValidationResult",
         }
     }
 }

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -212,7 +212,7 @@ impl<const N: usize> crate::Network for Kadcast<N> {
 
         let mut encoded = vec![];
         msg.write(&mut encoded).map_err(|err| {
-            error!("could not encode message {msg:?}: {err}");
+            error!("could not encode message (version: {:?}, topics: {:?}, header: {:?}): {err}", msg.version(), msg.topic(), msg.header);
             anyhow::anyhow!("failed to broadcast: {err}")
         })?;
 


### PR DESCRIPTION
To resolve the noisy log as described in #2742, the `ContractDeploy::bytecode` field now pretty prints as `ContractBytecode { ... }` and the Phoenix transaction's `proof` field now pretty prints as `[ ... ]`.