### PR TITLE
web-wallet: fix edge case in Dusk to Lux conversion

### DIFF
--- a/web-wallet/CHANGELOG.md
+++ b/web-wallet/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix UI not scrolling to top after wizard and sub-route navigation [#2997]
+- Fix edge case in Dusk to Lux conversion [#3032]
 
 ## [0.8.0] - 2024-11-19
 
@@ -365,6 +366,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3006]: https://github.com/dusk-network/rusk/issues/3006
 [#3010]: https://github.com/dusk-network/rusk/issues/3010
 [#3028]: https://github.com/dusk-network/rusk/issues/3028
+[#3032]: https://github.com/dusk-network/rusk/issues/3032
 
 <!-- VERSIONS -->
 

--- a/web-wallet/src/lib/dusk/currency/__tests__/duskToLux.spec.js
+++ b/web-wallet/src/lib/dusk/currency/__tests__/duskToLux.spec.js
@@ -6,9 +6,14 @@ describe("duskToLux", () => {
   it("should convert an amount in Dusk to Lux", () => {
     expect(duskToLux(1)).toBe(BigInt(1e9));
     expect(duskToLux(21.78)).toBe(21_780_000_000n);
-    expect(duskToLux(3_456_789.012)).toBe(BigInt(3_456_789_012_000_000));
+    expect(duskToLux(3_456_789.012)).toBe(3_456_789_012_000_000n);
 
     // handles numbers in exponential notation
     expect(duskToLux(2e21)).toBe(BigInt(2e21) * BigInt(1e9));
+
+    // we would lose 1 Lux in these numbers without rounding
+    // the decimal part in the conversion function
+    expect(duskToLux(1_000_999.973939759)).toBe(1_000_999_973_939_759n);
+    expect(duskToLux(45.123456999)).toBe(45_123_456_999n);
   });
 });

--- a/web-wallet/src/lib/dusk/currency/__tests__/luxToDusk.spec.js
+++ b/web-wallet/src/lib/dusk/currency/__tests__/luxToDusk.spec.js
@@ -5,6 +5,18 @@ import { luxToDusk } from "..";
 describe("luxToDusk", () => {
   it("should take a lux value, as a bigInt, and return Dusk (as a number)", () => {
     expect(luxToDusk(BigInt(1e9))).toBe(1);
-    expect(luxToDusk(123_456_789_012n)).toBe(123.456789012);
+    expect(luxToDusk(123_456_789_989n)).toBe(123.456789989);
+    expect(luxToDusk(1n)).toBe(0.000000001);
+    expect(luxToDusk(5889n)).toBe(0.000005889);
+    expect(luxToDusk(1_000_999_973_939_759_000n)).toBe(1_000_999_973.939759);
+    expect(luxToDusk(9_007_199_254_740_993n)).toBe(9_007_199.254740993);
+    expect(luxToDusk(10_000_000_001n)).toBe(10.000000001);
+    expect(luxToDusk(3_141_592_653_589_793n)).toBe(3_141_592.653589793);
+
+    // result with integer part bigger than Number.MAX_SAFE_INTEGER
+    expect(luxToDusk(123_456_789_012_345_678_901_234_567_890n)).toBe(
+      // eslint-disable-next-line no-loss-of-precision
+      123_456_789_012_345_678_901.23456789
+    );
   });
 });

--- a/web-wallet/src/lib/dusk/currency/duskToLux.js
+++ b/web-wallet/src/lib/dusk/currency/duskToLux.js
@@ -6,6 +6,6 @@ const scaleFactor = 1e9;
  */
 const duskToLux = (n) =>
   BigInt(Math.floor(n)) * BigInt(scaleFactor) +
-  BigInt(Math.floor((n % 1) * scaleFactor));
+  BigInt(Math.round((n % 1) * scaleFactor));
 
 export default duskToLux;


### PR DESCRIPTION
- added test cases to `luxToDusk` function

Resolves #3032