### PR TITLE
w3sper: Add `query { ... }` to argument given to `network.query`

### DIFF
--- a/w3sper.js/src/network/mod.js
+++ b/w3sper.js/src/network/mod.js
@@ -18,16 +18,6 @@ export { AddressSyncer } from "./syncer/address.js";
 export { AccountSyncer } from "./syncer/account.js";
 export { Bookmark } from "./bookmark.js";
 
-const abortable = (signal) =>
-  new Promise((resolve, reject) =>
-    signal?.aborted ? reject(signal.reason) : resolve(signal),
-  );
-
-const once = (target, topic) =>
-  new Promise((resolve) =>
-    target.addEventListener(topic, resolve, { once: true }),
-  );
-
 export class Network {
   #rues;
   node;
@@ -81,8 +71,8 @@ export class Network {
   // I suspect is a GraphQL limitation. In the meantime we convert the `Number`
   // to a `BigInt` for consistency and future proof of the API's consumers.
   get blockHeight() {
-    return this.query("query { block(height: -1) { header { height } }}").then(
-      (body) => BigInt(body?.block?.header?.height ?? 0),
+    return this.query("block(height: -1) { header { height } }").then((body) =>
+      BigInt(body?.block?.header?.height ?? 0),
     );
   }
 
@@ -110,6 +100,8 @@ export class Network {
   }
 
   async query(gql, options = {}) {
+    gql = gql ? `query { ${gql} }` : "";
+
     const response = await this.#rues.scope("graphql").call.query(gql, options);
 
     switch (response.status) {


### PR DESCRIPTION
- Remove unused private functions from network module