### PR TITLE
w3sper: Align tests with actual library usage

### DIFF
--- a/w3sper.js/deno.json
+++ b/w3sper.js/deno.json
@@ -2,6 +2,10 @@
   "name": "@dusk/w3sper",
   "version": "0.1.0-beta.1",
   "exports": "./src/mod.js",
+  "imports": {
+    "@dusk/exu": "jsr:@dusk/exu@0.1.2",
+    "@dusk/w3sper": "./src/mod.js"
+  },
   "tasks": {
     "test": "deno test --allow-net --allow-read --allow-write --allow-run --allow-import",
     "wasm": "cd ../wallet-core && cargo wasm",

--- a/w3sper.js/src/mod.js
+++ b/w3sper.js/src/mod.js
@@ -8,3 +8,4 @@ export * from "./network/mod.js";
 export * from "./profile.js";
 export * from "./bookkeeper.js";
 export * from "./transaction.js";
+export { useAsProtocolDriver } from "./protocol-driver/mod.js";

--- a/w3sper.js/tests/balances_test.js
+++ b/w3sper.js/tests/balances_test.js
@@ -10,14 +10,12 @@ import {
   Bookkeeper,
   AddressSyncer,
   AccountSyncer,
-} from "../src/mod.js";
+} from "@dusk/w3sper";
 
 import { test, assert, seeder, Treasury } from "./harness.js";
 
-test.withLocalWasm = "release";
-
 test("Account Balance", async () => {
-  const network = new Network("http://localhost:8080/");
+  const network = await Network.connect("http://localhost:8080/");
 
   const user =
     "oCqYsUMRqpRn2kSabH52Gt6FQCwH5JXj5MtRdYVtjMSJ73AFvdbPf98p3gz98fQwNy9ZBiDem6m9BivzURKFSKLYWP3N9JahSPZs9PnZ996P18rTGAjQTNFsxtbrKx79yWu";
@@ -28,6 +26,8 @@ test("Account Balance", async () => {
     nonce: 0n,
     value: 1_001_000_000_000_000n,
   });
+
+  await network.disconnect();
 });
 
 test("Balances synchronization", async () => {

--- a/w3sper.js/tests/harness.js
+++ b/w3sper.js/tests/harness.js
@@ -19,41 +19,21 @@ const mergeMap = (dest, source, lookup) => {
   return;
 };
 
-import * as ProtocolDriver from "../src/protocol-driver/mod.js";
-import {
-  test as harnessTest,
+export {
+  test,
   assert,
 } from "http://rawcdn.githack.com/mio-mini/test-harness/0.1.0/mod.js";
 
-import { Bookmark } from "../src/mod.js";
+import { Bookmark } from "@dusk/w3sper";
 
-export { assert };
+const WASM_RELEASE_PATH =
+  "../target/wasm32-unknown-unknown/release/wallet_core.wasm";
 
-export async function test(name, fn) {
-  let path = "";
-  switch (test.withLocalWasm) {
-    case "debug":
-      path = "../target/wasm32-unknown-unknown/debug/wallet_core.wasm";
-      break;
-    case "release":
-      path = "../target/wasm32-unknown-unknown/release/wallet_core.wasm";
-      break;
+export function getLocalWasmBuffer() {
+  if (typeof Deno !== "undefined") {
+    return Deno.readFile(WASM_RELEASE_PATH);
   }
-
-  if (path.length > 0 && typeof Deno !== "undefined") {
-    const testFn = async (...args) => {
-      const wasm = await Deno.readFile(path);
-
-      ProtocolDriver.load(
-        wasm,
-        new URL("./assets/debug-imports.js", import.meta.url),
-      );
-
-      await Promise.resolve(fn(...args)).finally(ProtocolDriver.unload);
-    };
-
-    return harnessTest(name, testFn);
-  }
+  return Promise.reject("Can't accesso to file system");
 }
 
 // Define a seed for deterministic profile generation

--- a/w3sper.js/tests/index.html
+++ b/w3sper.js/tests/index.html
@@ -15,7 +15,8 @@
         <script type="importmap">
             {
                 "imports": {
-                    "jsr:@dusk/exu@0.1.2": "https://rawcdn.githack.com/dusk-network/exu/v0.1.2/src/mod.js"
+                    "@dusk/exu": "https://rawcdn.githack.com/dusk-network/exu/v0.1.2/src/mod.js",
+                    "@dusk/w3sper": "../src/mod.js"
                 }
             }
         </script>

--- a/w3sper.js/tests/network_test.js
+++ b/w3sper.js/tests/network_test.js
@@ -4,17 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-import {
-  Network,
-  ProfileGenerator,
-  Bookkeeper,
-  AddressSyncer,
-  AccountSyncer,
-} from "../src/mod.js";
+import { Network } from "@dusk/w3sper";
 
-import { test, assert, seeder, Treasury } from "./harness.js";
-
-test.withLocalWasm = "release";
+import { test, assert } from "./harness.js";
 
 test("Network connection", async () => {
   const network = new Network("http://localhost:8080/");

--- a/w3sper.js/tests/notes_test.js
+++ b/w3sper.js/tests/notes_test.js
@@ -3,8 +3,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-import { test, assert } from "./harness.js";
-import { ProfileGenerator, Bookkeeper } from "../src/mod.js";
+import { test, assert, getLocalWasmBuffer } from "./harness.js";
+import { ProfileGenerator, Bookkeeper } from "@dusk/w3sper";
 
 const hex = (bytes) =>
   Array.from(bytes)
@@ -18,12 +18,13 @@ const seeder = async () => SEED;
 const NOTES_RKYV = "./tests/assets/notes.rkyv";
 const notesBuffer = await Deno.readFile(NOTES_RKYV);
 
+// NOTE: This tests helps to check some of the protocol driver internals
 import * as ProtocolDriver from "../src/protocol-driver/mod.js";
-
-test.withLocalWasm = "release";
 
 // Test case for default profile
 test("owened notes balance", async () => {
+  ProtocolDriver.load(await getLocalWasmBuffer());
+
   const profiles = new ProfileGenerator(seeder);
 
   const owner1 = await Promise.all([
@@ -166,4 +167,6 @@ test("owened notes balance", async () => {
 
   picked = await ProtocolDriver.pickNotes(owner4, notes4[0], 1n);
   assert.equal(picked.size, 0);
+
+  await ProtocolDriver.unload();
 });

--- a/w3sper.js/tests/stake_info_test.js
+++ b/w3sper.js/tests/stake_info_test.js
@@ -9,11 +9,9 @@ import {
   ProfileGenerator,
   Bookkeeper,
   AccountSyncer,
-} from "../src/mod.js";
+} from "@dusk/w3sper";
 
 import { test, assert, seeder, Treasury } from "./harness.js";
-
-test.withLocalWasm = "release";
 
 /**
  * Tests fetching the stake information using string representations
@@ -26,7 +24,7 @@ test("stake info without profiles", async () => {
     "ocXXBAafr7xFqQTpC1vfdSYdHMXerbPCED2apyUVpLjkuycsizDxwA6b9D7UW91kG58PFKqm9U9NmY9VSwufUFL5rVRSnFSYxbiKK658TF6XjHsHGBzavFJcxAzjjBRM4eF",
   ];
 
-  const network = new Network("http://localhost:8080/");
+  const network = await Network.connect("http://localhost:8080/");
   const syncer = new AccountSyncer(network);
 
   const stakes = await syncer.stakes(users);
@@ -52,6 +50,8 @@ test("stake info without profiles", async () => {
   assert.equal(stakes[1].nonce, 0n);
   assert.equal(stakes[1].faults, 0);
   assert.equal(stakes[1].hardFaults, 0);
+
+  await network.disconnect();
 });
 
 /**
@@ -62,10 +62,11 @@ test("stake info without profiles", async () => {
  * the use of a decoupled cache to retrieve and store the stake information.
  */
 test("stake info with treasury", async () => {
+  const network = await Network.connect("http://localhost:8080/");
+
   const profiles = new ProfileGenerator(seeder);
   const users = await Promise.all([profiles.default, profiles.next()]);
 
-  const network = new Network("http://localhost:8080/");
   const accounts = new AccountSyncer(network);
 
   const treasury = new Treasury(users);
@@ -104,4 +105,6 @@ test("stake info with treasury", async () => {
   assert.equal(stakes[1].nonce, 0n);
   assert.equal(stakes[1].faults, 0);
   assert.equal(stakes[1].hardFaults, 0);
+
+  await network.disconnect();
 });


### PR DESCRIPTION
 - Add `@dusk/w3sper`  to import map for integration-like testing
 - Add `useAsProtocolDriver` to avoid exposing full `ProtocolDriver`
 - Fix `ProtocolDriver` leftover to use cryptographically secure `rng`
 - Change tests to avoid automagically WASM loading