### PR TITLE
explorer: Fix Cluster Location Layout

### DIFF
--- a/explorer/CHANGELOG.md
+++ b/explorer/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2662]: https://github.com/dusk-network/rusk/issues/2662
 [#3038]: https://github.com/dusk-network/rusk/issues/3038
 [#3064]: https://github.com/dusk-network/rusk/issues/3064
+[#3034]: https://github.com/dusk-network/rusk/issues/3034
 
 <!-- VERSIONS -->
 

--- a/explorer/CHANGELOG.md
+++ b/explorer/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Transactions Fee is not properly computed [#2348]
 - Fix shield icons used for tx type [#2389]
 - Fix Gas Used meter if Gas Limit is zero [#2668]
+- Fix Cluster Location Layout [#3034]
 
 ## [0.2.0] - 2024-08-26
 

--- a/explorer/src/lib/containers/statistics-panel/StatisticsPanel.css
+++ b/explorer/src/lib/containers/statistics-panel/StatisticsPanel.css
@@ -92,13 +92,7 @@
   }
 
   .statistics-panel__statistics-column:nth-child(5) {
-    grid-column: span 2;
-    text-align: center;
-  }
-
-  .statistics-panel__statistics-column:nth-child(5)
-    .statistics-panel__statistics-item-value-container {
-    justify-content: center;
+    display: contents;
   }
 
   .statistics-panel__statistics-item-value {
@@ -123,12 +117,6 @@
   }
 
   .statistics-panel__statistics-column:nth-child(5) {
-    grid-column: span 1;
-    text-align: start;
-  }
-
-  .statistics-panel__statistics-column:nth-child(5)
-    .statistics-panel__statistics-item-value-container {
-    justify-content: start;
+    display: flex;
   }
 }


### PR DESCRIPTION
Using `display: contents;` between `992px` and `1330px` width suppresses the effect of the wrapper element, putting the items next to each other.

This should give the desired responsive behavior and resolve https://github.com/dusk-network/rusk/issues/3034

![image](https://github.com/user-attachments/assets/7c0150e9-38ac-42f3-80c7-d97a004aaf96)
![image](https://github.com/user-attachments/assets/a3b61b54-bdd9-4745-9766-01e4fd82d400)
![image](https://github.com/user-attachments/assets/01906244-84b6-448b-a959-cceb182ca576)
