### PR TITLE
node: change Blockevent Deleted variant to Reverted

### DIFF
--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -53,6 +53,7 @@ pub struct ChainSrv<N: Network, DB: database::DB, VM: vm::VMExecution> {
     keys_path: String,
     acceptor: Option<Arc<RwLock<Acceptor<N, DB, VM>>>>,
     max_consensus_queue_size: usize,
+    /// Sender channel for sending out RUES events
     event_sender: Sender<Event>,
     genesis_timestamp: u64,
 }

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -79,7 +79,7 @@ pub(crate) struct Acceptor<N: Network, DB: database::DB, VM: vm::VMExecution> {
     pub(crate) db: Arc<RwLock<DB>>,
     pub(crate) vm: Arc<RwLock<VM>>,
     pub(crate) network: Arc<RwLock<N>>,
-
+    /// Sender channel for sending out RUES events
     event_sender: Sender<Event>,
 }
 
@@ -1049,7 +1049,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
                 }
 
                 if let Err(e) = self.event_sender.try_send(
-                    BlockEvent::Deleted {
+                    BlockEvent::Reverted {
                         hash: h.hash,
                         height: h.height,
                     }
@@ -1059,7 +1059,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
                 };
 
                 info!(
-                    event = "block deleted",
+                    event = "block reverted",
                     height = h.height,
                     iter = h.iteration,
                     label = ?label,

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -58,6 +58,7 @@ impl From<anyhow::Error> for TxAcceptanceError {
 pub struct MempoolSrv {
     inbound: AsyncQueue<Message>,
     conf: Params,
+    /// Sender channel for sending out RUES events
     event_sender: Sender<Event>,
 }
 


### PR DESCRIPTION
Currently, the block event variant sent when a block is reverted is called "Deleted". We should not use different terminology or phrasing for the same thing to avoid ambiguity.

For that reason I changed the Event variant to "Reverted", to match what actually happens.