### PR TITLE
node-data: Add BlockState enum

### DIFF
--- a/node-data/src/events.rs
+++ b/node-data/src/events.rs
@@ -9,7 +9,7 @@ mod transactions;
 
 pub mod contract;
 
-pub use blocks::{BlockEvent, BLOCK_CONFIRMED, BLOCK_FINALIZED};
+pub use blocks::{BlockEvent, BlockState};
 pub use transactions::TransactionEvent;
 
 /// Represents an event in the system, including its source (`component`),

--- a/node-data/src/events/transactions.rs
+++ b/node-data/src/events/transactions.rs
@@ -18,6 +18,9 @@ use crate::ledger::{Hash, SpentTransaction, Transaction};
 ///     Indicates that a transaction has been removed from the mempool. The
 ///     `Hash` represents the unique identifier of the removed transaction.
 ///
+///     This event is triggered when a transaction is removed from the mempool
+///     or discarded from the mempool.
+///
 /// - `Included(&'t Transaction)`
 ///
 ///     A transaction has been included in the mempool.
@@ -25,6 +28,12 @@ use crate::ledger::{Hash, SpentTransaction, Transaction};
 /// - `Executed(&'t SpentTransaction)`
 ///
 ///     Denotes that a transaction has been executed into an accepted block.
+///     Executed transactions also include failed transaction, as they have been
+///     spent and were correctly executed according to any contract logic.
+///     (including logic that triggers panics)
+///
+///     - A "successful" transaction: executed and the `err` field is `None`.
+///     - A "failed" transaction: executed and the `err` field is `Some`.
 #[derive(Clone, Debug)]
 pub enum TransactionEvent<'t> {
     Removed(Hash),

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -24,9 +24,7 @@ use execution_core::stake::{SlashEvent, StakeAmount, StakeEvent};
 use metrics::{counter, gauge, histogram};
 use node_data::bls::PublicKey;
 use node_data::events::contract::ContractEvent;
-use node_data::events::{
-    BlockEvent, Event, TransactionEvent, BLOCK_CONFIRMED, BLOCK_FINALIZED,
-};
+use node_data::events::{BlockEvent, BlockState, Event, TransactionEvent};
 use node_data::ledger::{
     self, to_str, Block, BlockWithLabel, Label, Seed, Slash,
 };
@@ -918,7 +916,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
 
                         let event = BlockEvent::StateChange {
                             hash: *hash,
-                            state: BLOCK_CONFIRMED,
+                            state: BlockState::Confirmed,
                             height: current_height,
                         };
                         events.push(event.into());
@@ -952,7 +950,7 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
                     label = Label::Final(finalized_after);
                     let event = BlockEvent::StateChange {
                         hash,
-                        state: BLOCK_FINALIZED,
+                        state: BlockState::Finalized,
                         height: current_height,
                     };
                     events.push(event.into());

--- a/rusk/src/lib/node/events.rs
+++ b/rusk/src/lib/node/events.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc::Receiver;
 use tracing::error;
 #[cfg(feature = "archive")]
 use {
-    node_data::archive::ArchivalData, node_data::events::BLOCK_FINALIZED,
+    node_data::archive::ArchivalData, node_data::events::BlockState,
     serde_json::Value, tokio::sync::mpsc::Sender,
 };
 
@@ -64,7 +64,7 @@ impl<N: Network, DB: database::DB, VM: node::vm::VMExecution>
                                     .and_then(Value::as_u64)
                                     .unwrap_or_default();
 
-                                if state == BLOCK_FINALIZED {
+                                if state == BlockState::Finalized.as_str() {
                                     if let Err(e) = self
                                         .archivist_sender
                                         .try_send(ArchivalData::FinalizedBlock(


### PR DESCRIPTION
I updated the comments in node-data for further explanation. While doing so, I had the idea to introduce a BlockState enum, which effectively makes it impossible to create StateChange events with non-valid states (arbitrary &str) by restricting it to the types of the enum.