### PR TITLE
Refactor and fix event_loop

### DIFF
--- a/consensus/src/aggregator.rs
+++ b/consensus/src/aggregator.rs
@@ -176,10 +176,11 @@ impl<V: StepVote> Aggregator<V> {
         let quorum_reached = total >= quorum_target;
         if quorum_reached {
             tracing::info!(
-                event = "quorum reached",
-                ?vote,
-                iter = v.header().iteration,
+                event = "Quorum reached",
                 step = ?V::STEP_NAME,
+                round = v.header().round,
+                iter = v.header().iteration,
+                ?vote,
                 total,
                 target = quorum_target,
                 bitset,

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -501,7 +501,8 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
                         info!(
                             event = "New Quorum",
                             mode = "emergency",
-                            inf = ?m.header,
+                            round = q.header.round,
+                            iter = q.header.iteration,
                             vote = ?q.vote(),
                         );
 

--- a/consensus/src/phase.rs
+++ b/consensus/src/phase.rs
@@ -6,7 +6,7 @@
 
 use node_data::message::Message;
 use node_data::StepName;
-use tracing::{debug, trace};
+use tracing::{info, trace};
 
 use crate::commons::Database;
 use crate::execution_ctx::ExecutionCtx;
@@ -54,10 +54,16 @@ impl<T: Operations + 'static, D: Database + 'static> Phase<T, D> {
     pub async fn run(&mut self, mut ctx: ExecutionCtx<'_, T, D>) -> Message {
         ctx.set_start_time();
 
-        let timeout = ctx.iter_ctx.get_timeout(ctx.step_name());
-        debug!(event = "execute_step", ?timeout);
+        let step = ctx.step_name();
+        let round = ctx.round_update.round;
+        let iter = ctx.iteration;
+        let timeout = ctx.iter_ctx.get_timeout(step);
 
         // Execute step
-        await_phase!(self, run(ctx))
+        info!(event = "Step started", ?step, round, iter, ?timeout);
+        let msg = await_phase!(self, run(ctx));
+        info!(event = "Step ended", ?step, round, iter);
+
+        msg
     }
 }

--- a/consensus/src/proposal/block_generator.rs
+++ b/consensus/src/proposal/block_generator.rs
@@ -57,6 +57,9 @@ impl<T: Operations> Generator<T> {
         info!(
             event = "Candidate generated",
             hash = &to_str(&candidate.header().hash),
+            round = candidate.header().height,
+            iter = candidate.header().iteration,
+            prev_block = &to_str(&candidate.header().prev_block_hash),
             gas_limit = candidate.header().gas_limit,
             state_hash = &to_str(&candidate.header().state_hash),
             dur = format!("{:?}ms", start.elapsed().as_millis()),

--- a/consensus/src/proposal/handler.rs
+++ b/consensus/src/proposal/handler.rs
@@ -67,6 +67,14 @@ impl<D: Database> MsgHandler for ProposalHandler<D> {
             .store_candidate_block(p.candidate.clone())
             .await;
 
+        info!(
+            event = "New Candidate",
+            hash = &to_str(&p.candidate.header().hash),
+            round = p.candidate.header().height,
+            iter = p.candidate.header().iteration,
+            prev_block = &to_str(&p.candidate.header().prev_block_hash)
+        );
+
         Ok(StepOutcome::Ready(msg))
     }
 
@@ -83,6 +91,14 @@ impl<D: Database> MsgHandler for ProposalHandler<D> {
             .await
             .store_candidate_block(p.candidate.clone())
             .await;
+
+        info!(
+            event = "New Candidate",
+            hash = &to_str(&p.candidate.header().hash),
+            round = p.candidate.header().height,
+            iter = p.candidate.header().iteration,
+            prev_block = &to_str(&p.candidate.header().prev_block_hash)
+        );
 
         Ok(StepOutcome::Ready(msg))
     }

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -8,7 +8,7 @@ mod query;
 
 use dusk_consensus::errors::VstError;
 use node_data::events::contract::ContractEvent;
-use tracing::info;
+use tracing::{debug, info};
 
 use dusk_bytes::DeserializableSlice;
 use dusk_consensus::operations::{CallParams, VerificationOutput, Voter};
@@ -90,7 +90,7 @@ impl VMExecution for Rusk {
         VerificationOutput,
         Vec<ContractEvent>,
     )> {
-        info!("Received accept request");
+        debug!("Received accept request");
         let generator = blk.header().generator_bls_pubkey;
         let generator = BlsPublicKey::from_slice(&generator.0)
             .map_err(|e| anyhow::anyhow!("Error in from_slice {e:?}"))?;
@@ -129,7 +129,7 @@ impl VMExecution for Rusk {
         commit: [u8; 32],
         to_merge: Vec<[u8; 32]>,
     ) -> anyhow::Result<()> {
-        info!("Received finalize request");
+        debug!("Received finalize request");
         self.finalize_state(commit, to_merge)
             .map_err(|e| anyhow::anyhow!("Cannot finalize state: {e}"))
     }


### PR DESCRIPTION
- Fix `event_loop` to start Open Consensus Mode at the end of the last Ratification step (instead of the beginning of the last iteration)

Refactors:
- rename `last_step_running` to `is_last_step`
- delete `QuorumMsgSender` (replace `send_quorum` with `try_send`)
- order messages in `message.rs`
- improve logs