### PR TITLE
stake-contract: relax hard-slash to soft-slash

### DIFF
--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -930,19 +930,23 @@ fn slash(session: &mut Session, slash: Vec<Slash>) -> Result<Vec<Event>> {
                 &(provisioner, None::<u64>),
                 u64::MAX,
             ),
+            // INFO: Hard Slashing is currently "relaxed" to Soft Slashing as a
+            // safety measure for the initial period after mainnet launch.
+            // Proper behavior should be restored in the future
             node_data::ledger::SlashType::Hard => session.call::<_, ()>(
                 STAKE_CONTRACT,
-                "hard_slash",
-                &(provisioner, None::<u64>, None::<u8>),
+                "slash",
+                &(provisioner, None::<u64>),
                 u64::MAX,
             ),
-            node_data::ledger::SlashType::HardWithSeverity(severity) => session
-                .call::<_, ()>(
+            node_data::ledger::SlashType::HardWithSeverity(_severity) => {
+                session.call::<_, ()>(
                     STAKE_CONTRACT,
-                    "hard_slash",
-                    &(provisioner, None::<u64>, Some(severity)),
+                    "slash",
+                    &(provisioner, None::<u64>),
                     u64::MAX,
-                ),
+                )
+            }
         }?;
         events.extend(r.events);
     }


### PR DESCRIPTION
Replace calls to the `hard_slash` method with `soft_slash`.
This is a failsafe measure to guarantee no money is (permanently) lost due to unforseen errors.
Hard slashing should be restored as soon as the network proved to be stable.