### PR TITLE
Add minimum deployment gas points setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ phoenix-circuits = { version = "=0.4.0", default-features = false }
 phoenix-core = { version = "=0.32.0", default-features = false }
 # we leave piecrust open until a stable release is out
 piecrust = "=0.27.0"
-piecrust-uplink = "0.17.2-rc.0"
+piecrust-uplink = "0.17.3"
 poseidon-merkle = "=0.7.0"
 
 # External dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ kadcast = "=0.7.0"
 phoenix-circuits = { version = "=0.4.0", default-features = false }
 phoenix-core = { version = "=0.32.0", default-features = false }
 # we leave piecrust open until a stable release is out
-piecrust = "=0.27.0-rc.0"
+piecrust = "=0.27.0-rc.1"
 piecrust-uplink = "0.17.2-rc.0"
 poseidon-merkle = "=0.7.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ kadcast = "=0.7.0"
 phoenix-circuits = { version = "=0.4.0", default-features = false }
 phoenix-core = { version = "=0.32.0", default-features = false }
 # we leave piecrust open until a stable release is out
-piecrust = "=0.27.0-rc.1"
+piecrust = "=0.27.0"
 piecrust-uplink = "0.17.2-rc.0"
 poseidon-merkle = "=0.7.0"
 

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -222,8 +222,11 @@ impl MempoolSrv {
             }
 
             let gas_per_deploy_byte = vm.gas_per_deploy_byte();
-            let min_gas_limit =
-                vm::bytecode_charge(&deploy.bytecode, gas_per_deploy_byte);
+            let min_gas_limit = vm::bytecode_charge(
+                &deploy.bytecode,
+                gas_per_deploy_byte,
+                vm.min_deploy_points(),
+            );
             if tx.inner.gas_limit() < min_gas_limit {
                 return Err(TxAcceptanceError::GasLimitTooLow(min_gas_limit));
             }

--- a/node/src/vm.rs
+++ b/node/src/vm.rs
@@ -13,6 +13,7 @@ use dusk_core::transfer::data::ContractBytecode;
 use dusk_core::transfer::moonlight::AccountData;
 use node_data::events::contract::ContractEvent;
 use node_data::ledger::{Block, SpentTransaction, Transaction};
+use std::cmp::max;
 
 #[derive(Default)]
 pub struct Config {}
@@ -88,6 +89,7 @@ pub trait VMExecution: Send + Sync + 'static {
     fn gas_per_deploy_byte(&self) -> u64;
     fn min_deployment_gas_price(&self) -> u64;
     fn min_gas_limit(&self) -> u64;
+    fn min_deploy_points(&self) -> u64;
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -105,6 +107,10 @@ pub enum PreverificationResult {
 pub fn bytecode_charge(
     bytecode: &ContractBytecode,
     gas_per_deploy_byte: u64,
+    min_deploy_points: u64,
 ) -> u64 {
-    bytecode.bytes.len() as u64 * gas_per_deploy_byte
+    max(
+        bytecode.bytes.len() as u64 * gas_per_deploy_byte,
+        min_deploy_points,
+    )
 }

--- a/rusk/default.config.toml
+++ b/rusk/default.config.toml
@@ -26,6 +26,7 @@
 #gas_per_deploy_byte = 100
 #min_deployment_gas_price = 2000
 #min_gas_limit = 75000
+#min_deploy_points = 5000000
 
 [databroker]
 max_inv_entries = 100

--- a/rusk/src/bin/config/chain.rs
+++ b/rusk/src/bin/config/chain.rs
@@ -32,6 +32,7 @@ pub(crate) struct ChainConfig {
     // forking the chain.
     gas_per_deploy_byte: Option<u64>,
     min_deployment_gas_price: Option<u64>,
+    min_deploy_points: Option<u64>,
     min_gas_limit: Option<u64>,
     block_gas_limit: Option<u64>,
 
@@ -91,6 +92,10 @@ impl ChainConfig {
 
     pub(crate) fn min_deployment_gas_price(&self) -> Option<u64> {
         self.min_deployment_gas_price
+    }
+
+    pub(crate) fn min_deploy_points(&self) -> Option<u64> {
+        self.min_deploy_points
     }
 
     pub(crate) fn min_gas_limit(&self) -> Option<u64> {

--- a/rusk/src/bin/main.rs
+++ b/rusk/src/bin/main.rs
@@ -85,6 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_min_deployment_gas_price(
                 config.chain.min_deployment_gas_price(),
             )
+            .with_min_deploy_points(config.chain.min_deploy_points())
             .with_min_gas_limit(config.chain.min_gas_limit())
             .with_block_gas_limit(config.chain.block_gas_limit());
     };

--- a/rusk/src/lib/builder/node.rs
+++ b/rusk/src/lib/builder/node.rs
@@ -44,6 +44,7 @@ pub struct RuskNodeBuilder {
     gas_per_deploy_byte: Option<u64>,
     min_deployment_gas_price: Option<u64>,
     min_gas_limit: Option<u64>,
+    min_deploy_points: Option<u64>,
     block_gas_limit: u64,
     feeder_call_gas: u64,
     state_dir: PathBuf,
@@ -56,6 +57,7 @@ pub struct RuskNodeBuilder {
 const DEFAULT_GAS_PER_DEPLOY_BYTE: u64 = 100;
 const DEFAULT_MIN_DEPLOYMENT_GAS_PRICE: u64 = 2000;
 const DEFAULT_MIN_GAS_LIMIT: u64 = 75000;
+const DEFAULT_MIN_DEPLOY_POINTS: u64 = 5_000_000;
 
 impl RuskNodeBuilder {
     pub fn with_consensus_keys(mut self, consensus_keys_path: String) -> Self {
@@ -142,6 +144,14 @@ impl RuskNodeBuilder {
         self
     }
 
+    pub fn with_min_deploy_points(
+        mut self,
+        min_deploy_points: Option<u64>,
+    ) -> Self {
+        self.min_deploy_points = min_deploy_points;
+        self
+    }
+
     pub fn with_block_gas_limit(mut self, block_gas_limit: u64) -> Self {
         self.block_gas_limit = block_gas_limit;
         self
@@ -187,6 +197,8 @@ impl RuskNodeBuilder {
             .min_deployment_gas_price
             .unwrap_or(DEFAULT_MIN_DEPLOYMENT_GAS_PRICE);
         let min_gas_limit = self.min_gas_limit.unwrap_or(DEFAULT_MIN_GAS_LIMIT);
+        let min_deploy_points =
+            self.min_deploy_points.unwrap_or(DEFAULT_MIN_DEPLOY_POINTS);
 
         let rusk = Rusk::new(
             self.state_dir,
@@ -195,6 +207,7 @@ impl RuskNodeBuilder {
             gas_per_deploy_byte,
             min_deployment_gas_price,
             min_gas_limit,
+            min_deploy_points,
             self.block_gas_limit,
             self.feeder_call_gas,
             rues_sender.clone(),

--- a/rusk/src/lib/node.rs
+++ b/rusk/src/lib/node.rs
@@ -44,6 +44,7 @@ pub struct Rusk {
     pub(crate) gas_per_deploy_byte: u64,
     pub(crate) min_deployment_gas_price: u64,
     pub(crate) min_gas_limit: u64,
+    pub(crate) min_deploy_points: u64,
     pub(crate) feeder_gas_limit: u64,
     pub(crate) block_gas_limit: u64,
     pub(crate) event_sender: broadcast::Sender<RuesEvent>,

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -279,6 +279,10 @@ impl VMExecution for Rusk {
     fn min_gas_limit(&self) -> u64 {
         self.min_gas_limit
     }
+
+    fn min_deploy_points(&self) -> u64 {
+        self.min_deploy_points
+    }
 }
 
 fn has_unique_elements<T>(iter: T) -> bool

--- a/rusk/tests/common/state.rs
+++ b/rusk/tests/common/state.rs
@@ -33,6 +33,7 @@ const CHAIN_ID: u8 = 0xFA;
 pub const DEFAULT_GAS_PER_DEPLOY_BYTE: u64 = 100;
 pub const DEFAULT_MIN_DEPLOYMENT_GAS_PRICE: u64 = 2000;
 pub const DEFAULT_MIN_GAS_LIMIT: u64 = 75000;
+pub const DEFAULT_MIN_DEPLOY_POINTS: u64 = 5000000;
 
 // Creates a Rusk initial state in the given directory
 pub fn new_state<P: AsRef<Path>>(
@@ -64,6 +65,7 @@ pub fn new_state_with_chainid<P: AsRef<Path>>(
         DEFAULT_GAS_PER_DEPLOY_BYTE,
         DEFAULT_MIN_DEPLOYMENT_GAS_PRICE,
         DEFAULT_MIN_GAS_LIMIT,
+        DEFAULT_MIN_DEPLOY_POINTS,
         block_gas_limit,
         u64::MAX,
         sender,

--- a/rusk/tests/services/contract_deployment.rs
+++ b/rusk/tests/services/contract_deployment.rs
@@ -25,6 +25,7 @@ use tracing::info;
 
 use crate::common::logger;
 use crate::common::state::DEFAULT_MIN_DEPLOYMENT_GAS_PRICE;
+use crate::common::state::DEFAULT_MIN_DEPLOY_POINTS;
 use crate::common::state::{generator_procedure, ExecuteResult};
 use crate::common::state::{
     DEFAULT_GAS_PER_DEPLOY_BYTE, DEFAULT_MIN_GAS_LIMIT,
@@ -106,6 +107,7 @@ fn initial_state<P: AsRef<Path>>(dir: P, deploy_bob: bool) -> Result<Rusk> {
         DEFAULT_GAS_PER_DEPLOY_BYTE,
         DEFAULT_MIN_DEPLOYMENT_GAS_PRICE,
         DEFAULT_MIN_GAS_LIMIT,
+        DEFAULT_MIN_DEPLOY_POINTS,
         BLOCK_GAS_LIMIT,
         u64::MAX,
         sender,

--- a/rusk/tests/services/owner_calls.rs
+++ b/rusk/tests/services/owner_calls.rs
@@ -32,6 +32,7 @@ use tracing::info;
 
 use crate::common::logger;
 use crate::common::state::DEFAULT_MIN_DEPLOYMENT_GAS_PRICE;
+use crate::common::state::DEFAULT_MIN_DEPLOY_POINTS;
 use crate::common::state::{
     DEFAULT_GAS_PER_DEPLOY_BYTE, DEFAULT_MIN_GAS_LIMIT,
 };
@@ -85,6 +86,7 @@ fn initial_state<P: AsRef<Path>>(
         DEFAULT_GAS_PER_DEPLOY_BYTE,
         DEFAULT_MIN_DEPLOYMENT_GAS_PRICE,
         DEFAULT_MIN_GAS_LIMIT,
+        DEFAULT_MIN_DEPLOY_POINTS,
         BLOCK_GAS_LIMIT,
         u64::MAX,
         sender,


### PR DESCRIPTION
Adds minimum deployment gas points setting, 
enforces a minimum cost for contract deployment even if the contract size is small.
Protects network from spamming with a large number of small contracts.

Implements a top priority #3210