### PR TITLE
rusk-wallet: add support for export pwd in non-interactive

### DIFF
--- a/rusk-wallet/src/bin/interactive/command_menu.rs
+++ b/rusk-wallet/src/bin/interactive/command_menu.rs
@@ -400,6 +400,7 @@ pub(crate) async fn online(
                 "export keys",
                 settings.wallet_dir.clone(),
             )?,
+            export_pwd: None,
         })),
         MenuItem::Back => ProfileOp::Back,
     };
@@ -426,6 +427,7 @@ pub(crate) fn offline(
                 "export keys",
                 settings.wallet_dir.clone(),
             )?,
+            export_pwd: None,
         })),
         _ => unreachable!(),
     };


### PR DESCRIPTION
With this PR is not possible to specify a different password for the exported consensus keys