### PR TITLE
stake-contract: use StakeConfig for minimum_stake and slash warning

### DIFF
--- a/consensus/src/user/provisioners.rs
+++ b/consensus/src/user/provisioners.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use std::mem;
 
 use dusk_core::dusk;
-use dusk_core::stake::MINIMUM_STAKE;
+use dusk_core::stake::DEFAULT_MINIMUM_STAKE;
 use node_data::bls::{PublicKey, PublicKeyBytes};
 use node_data::ledger::Seed;
 use node_data::StepName;
@@ -182,7 +182,7 @@ impl Provisioners {
         round: u64,
     ) -> impl Iterator<Item = (&PublicKey, &Stake)> {
         self.members.iter().filter(move |(_, m)| {
-            m.is_eligible(round) && m.value() >= MINIMUM_STAKE
+            m.is_eligible(round) && m.value() >= DEFAULT_MINIMUM_STAKE
         })
     }
 

--- a/contracts/stake/src/lib.rs
+++ b/contracts/stake/src/lib.rs
@@ -94,6 +94,11 @@ unsafe fn get_version(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |_: ()| STATE.get_version())
 }
 
+#[no_mangle]
+unsafe fn get_config(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |_: ()| STATE.config().clone())
+}
+
 // "Feeder" queries
 
 #[no_mangle]
@@ -113,6 +118,14 @@ unsafe fn before_state_transition(arg_len: u32) -> u32 {
     rusk_abi::wrap_call(arg_len, |_: ()| {
         assert_external_caller();
         STATE.on_new_block()
+    })
+}
+
+#[no_mangle]
+unsafe fn set_config(arg_len: u32) -> u32 {
+    rusk_abi::wrap_call(arg_len, |config| {
+        assert_external_caller();
+        STATE.configure(config)
     })
 }
 

--- a/contracts/stake/src/state.rs
+++ b/contracts/stake/src/state.rs
@@ -53,6 +53,14 @@ impl StakeState {
         }
     }
 
+    pub fn config(&self) -> &StakeConfig {
+        &self.config
+    }
+
+    pub fn configure(&mut self, config: StakeConfig) {
+        self.config = config;
+    }
+
     pub fn on_new_block(&mut self) {
         self.previous_block_state.clear()
     }

--- a/contracts/stake/src/state.rs
+++ b/contracts/stake/src/state.rs
@@ -6,23 +6,19 @@
 
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
-
 use core::cmp::min;
 
 use dusk_bytes::Serializable;
-
-use dusk_core::{
-    signatures::bls::PublicKey as BlsPublicKey,
-    stake::{
-        next_epoch, Reward, SlashEvent, Stake, StakeAmount, StakeConfig,
-        StakeData, StakeEvent, StakeFundOwner, StakeKeys, Withdraw,
-        WithdrawToContract, EPOCH, STAKE_CONTRACT,
-    },
-    transfer::{ContractToContract, ReceiveFromContract, TRANSFER_CONTRACT},
-    ContractId,
+use dusk_core::signatures::bls::PublicKey as BlsPublicKey;
+use dusk_core::stake::{
+    next_epoch, Reward, SlashEvent, Stake, StakeAmount, StakeConfig, StakeData,
+    StakeEvent, StakeFundOwner, StakeKeys, Withdraw, WithdrawToContract, EPOCH,
+    STAKE_CONTRACT,
 };
-
-use crate::*;
+use dusk_core::transfer::{
+    ContractToContract, ReceiveFromContract, TRANSFER_CONTRACT,
+};
+use dusk_core::ContractId;
 
 /// Contract keeping track of each public key's stake.
 ///

--- a/core/src/stake.rs
+++ b/core/src/stake.rs
@@ -30,6 +30,33 @@ pub const EPOCH: u64 = 2160;
 /// Number of warnings before being penalized
 pub const STAKE_WARNINGS: u8 = 1;
 
+/// Configuration for the stake contract
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
+#[archive_attr(derive(CheckBytes))]
+pub struct StakeConfig {
+    /// Number of warnings before being penalized
+    pub warnings: u8,
+    /// Minimum amount of Dusk that can be staked
+    pub minimum_stake: Dusk,
+}
+
+impl StakeConfig {
+    /// Create a new default stake configuration.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            warnings: STAKE_WARNINGS,
+            minimum_stake: MINIMUM_STAKE,
+        }
+    }
+}
+
+impl Default for StakeConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Calculate the block height at which the next epoch takes effect.
 #[must_use]
 pub const fn next_epoch(block_height: u64) -> u64 {

--- a/core/src/stake.rs
+++ b/core/src/stake.rs
@@ -30,6 +30,9 @@ pub const EPOCH: u64 = 2160;
 /// Number of warnings before being penalized
 pub const STAKE_WARNINGS: u8 = 1;
 
+/// The minimum amount of Dusk one can stake.
+pub const MINIMUM_STAKE: Dusk = dusk(1_000.0);
+
 /// Configuration for the stake contract
 #[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]
@@ -400,9 +403,6 @@ pub struct SlashEvent {
     /// New eligibility for the slashed account
     pub next_eligibility: u64,
 }
-
-/// The minimum amount of Dusk one can stake.
-pub const MINIMUM_STAKE: Dusk = dusk(1_000.0);
 
 /// The representation of a public key's stake.
 ///

--- a/core/src/stake.rs
+++ b/core/src/stake.rs
@@ -27,8 +27,8 @@ pub const STAKE_CONTRACT: ContractId = crate::reserved(0x2);
 /// Epoch used for stake operations
 pub const EPOCH: u64 = 2160;
 
-/// Number of warnings before being penalized
-pub const STAKE_WARNINGS: u8 = 1;
+/// Default number of warnings before being penalized
+pub const DEFAULT_STAKE_WARNINGS: u8 = 1;
 
 /// The minimum amount of Dusk one can stake.
 pub const MINIMUM_STAKE: Dusk = dusk(1_000.0);
@@ -48,7 +48,7 @@ impl StakeConfig {
     #[must_use]
     pub const fn new() -> Self {
         Self {
-            warnings: STAKE_WARNINGS,
+            warnings: DEFAULT_STAKE_WARNINGS,
             minimum_stake: MINIMUM_STAKE,
         }
     }

--- a/core/src/stake.rs
+++ b/core/src/stake.rs
@@ -31,7 +31,14 @@ pub const EPOCH: u64 = 2160;
 pub const DEFAULT_STAKE_WARNINGS: u8 = 1;
 
 /// The minimum amount of Dusk one can stake.
-pub const MINIMUM_STAKE: Dusk = dusk(1_000.0);
+#[deprecated(
+    since = "0.1.0",
+    note = "please use `DEFAULT_MINIMUM_STAKE` instead"
+)]
+pub const MINIMUM_STAKE: Dusk = DEFAULT_MINIMUM_STAKE;
+
+/// The default minimum amount of Dusk one can stake.
+pub const DEFAULT_MINIMUM_STAKE: Dusk = dusk(1_000.0);
 
 /// Configuration for the stake contract
 #[derive(Debug, Clone, Archive, Serialize, Deserialize)]
@@ -49,7 +56,7 @@ impl StakeConfig {
     pub const fn new() -> Self {
         Self {
             warnings: DEFAULT_STAKE_WARNINGS,
-            minimum_stake: MINIMUM_STAKE,
+            minimum_stake: DEFAULT_MINIMUM_STAKE,
         }
     }
 }

--- a/rusk-recovery/src/state/snapshot.rs
+++ b/rusk-recovery/src/state/snapshot.rs
@@ -103,7 +103,7 @@ mod tests {
 
     use std::error::Error;
 
-    use dusk_core::stake::MINIMUM_STAKE;
+    use dusk_core::stake::DEFAULT_MINIMUM_STAKE;
 
     use super::*;
     use crate::state;
@@ -133,7 +133,8 @@ mod tests {
         }
 
         if !testnet.stakes().any(|s| {
-            s.amount >= MINIMUM_STAKE && s.eligibility.unwrap_or_default() == 0
+            s.amount >= DEFAULT_MINIMUM_STAKE
+                && s.eligibility.unwrap_or_default() == 0
         }) {
             panic!("Testnet must have at least a provisioner configured");
         }

--- a/rusk-wallet/src/bin/io/prompt.rs
+++ b/rusk-wallet/src/bin/io/prompt.rs
@@ -16,7 +16,7 @@ use crossterm::{
 
 use anyhow::Result;
 use bip39::{ErrorKind, Language, Mnemonic};
-use dusk_core::stake::MINIMUM_STAKE;
+use dusk_core::stake::DEFAULT_MINIMUM_STAKE;
 
 use inquire::ui::RenderConfig;
 use inquire::validator::Validation;
@@ -267,7 +267,7 @@ pub(crate) fn request_optional_token_amt(
 
 /// Request amount of tokens that can't be lower than MINIMUM_STAKE
 pub(crate) fn request_stake_token_amt(balance: Dusk) -> Result<Dusk, Error> {
-    let min: Dusk = MINIMUM_STAKE.into();
+    let min: Dusk = DEFAULT_MINIMUM_STAKE.into();
 
     request_token("stake", min, balance, None).map_err(Error::from)
 }

--- a/rusk/tests/services/contract_stake.rs
+++ b/rusk/tests/services/contract_stake.rs
@@ -7,7 +7,7 @@
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 
-use dusk_core::stake::{self, Stake, EPOCH, MINIMUM_STAKE};
+use dusk_core::stake::{self, Stake, DEFAULT_MINIMUM_STAKE, EPOCH};
 
 use dusk_bytes::Serializable;
 use dusk_core::transfer::data::ContractCall;
@@ -72,7 +72,7 @@ pub async fn stake_from_contract() -> Result<()> {
     let stake = Stake::new_from_contract(
         &sk,
         contract_id,
-        MINIMUM_STAKE,
+        DEFAULT_MINIMUM_STAKE,
         rusk.chain_id().unwrap(),
     );
     let call = ContractCall::new(contract_id, "stake", &stake)
@@ -81,7 +81,7 @@ pub async fn stake_from_contract() -> Result<()> {
         .moonlight_execute(
             0,
             0,
-            MINIMUM_STAKE,
+            DEFAULT_MINIMUM_STAKE,
             GAS_LIMIT,
             GAS_PRICE,
             Some(call.clone()),
@@ -92,7 +92,7 @@ pub async fn stake_from_contract() -> Result<()> {
 
     let stake = wallet.get_stake(0).expect("stake to be found");
     assert_eq!(
-        MINIMUM_STAKE,
+        DEFAULT_MINIMUM_STAKE,
         stake.amount.expect("stake amount to be found").value
     );
 
@@ -100,7 +100,7 @@ pub async fn stake_from_contract() -> Result<()> {
         .moonlight_execute(
             0,
             0,
-            MINIMUM_STAKE,
+            DEFAULT_MINIMUM_STAKE,
             GAS_LIMIT,
             GAS_PRICE,
             Some(call.clone()),
@@ -111,7 +111,7 @@ pub async fn stake_from_contract() -> Result<()> {
 
     let stake = wallet.get_stake(0).expect("stake to be found");
     assert_eq!(
-        MINIMUM_STAKE * 2,
+        DEFAULT_MINIMUM_STAKE * 2,
         stake.amount.expect("stake amount to be found").value
     );
 
@@ -119,7 +119,7 @@ pub async fn stake_from_contract() -> Result<()> {
         .moonlight_execute(
             0,
             0,
-            MINIMUM_STAKE,
+            DEFAULT_MINIMUM_STAKE,
             GAS_LIMIT,
             GAS_PRICE,
             Some(call),
@@ -136,12 +136,12 @@ pub async fn stake_from_contract() -> Result<()> {
 
     let stake = wallet.get_stake(0).expect("stake to be found");
     assert_eq!(
-        MINIMUM_STAKE * 2 + (MINIMUM_STAKE / 10 * 9) as u64,
+        DEFAULT_MINIMUM_STAKE * 2 + (DEFAULT_MINIMUM_STAKE / 10 * 9) as u64,
         stake.amount.expect("stake amount to be found").value
     );
 
     assert_eq!(
-        (MINIMUM_STAKE / 10) as u64,
+        (DEFAULT_MINIMUM_STAKE / 10) as u64,
         stake.amount.expect("stake amount to be found").locked
     );
 
@@ -175,7 +175,7 @@ pub async fn stake_from_contract() -> Result<()> {
             &mut rng,
             &sk,
             contract_id,
-            3 * MINIMUM_STAKE,
+            3 * DEFAULT_MINIMUM_STAKE,
             transfer::withdraw::WithdrawReceiver::Moonlight(pk),
             transfer::withdraw::WithdrawReplayToken::Moonlight(7),
         ),
@@ -189,7 +189,7 @@ pub async fn stake_from_contract() -> Result<()> {
             .amount
             .unwrap()
             .total_funds(),
-        3 * MINIMUM_STAKE
+        3 * DEFAULT_MINIMUM_STAKE
     );
     let call = ContractCall::new(contract_id, "unstake", &unstake)
         .expect("call to be successful");
@@ -202,7 +202,10 @@ pub async fn stake_from_contract() -> Result<()> {
     assert_eq!(wallet.get_stake(0).expect("stake to exists").amount, None);
     let new_balance = wallet.get_account(0).unwrap().balance;
     let fee_paid = tx.gas_spent * GAS_PRICE;
-    assert_eq!(new_balance, prev_balance + 3 * MINIMUM_STAKE - fee_paid);
+    assert_eq!(
+        new_balance,
+        prev_balance + 3 * DEFAULT_MINIMUM_STAKE - fee_paid
+    );
 
     let current_reward = wallet.get_stake(0).expect("Stake to exists").reward;
 

--- a/rusk/tests/services/moonlight_stake.rs
+++ b/rusk/tests/services/moonlight_stake.rs
@@ -7,7 +7,7 @@
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 
-use dusk_core::stake::MINIMUM_STAKE;
+use dusk_core::stake::DEFAULT_MINIMUM_STAKE;
 
 use rand::prelude::*;
 use rand::rngs::StdRng;
@@ -149,7 +149,7 @@ pub async fn stake() -> Result<()> {
     info!("Original Root: {:?}", hex::encode(original_root));
 
     // Perform some staking actions.
-    wallet_stake(&rusk, &wallet, MINIMUM_STAKE);
+    wallet_stake(&rusk, &wallet, DEFAULT_MINIMUM_STAKE);
 
     // Check the state's root is changed from the original one
     let new_root = rusk.state_root();

--- a/rusk/tests/services/phoenix_stake.rs
+++ b/rusk/tests/services/phoenix_stake.rs
@@ -7,7 +7,7 @@
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 
-use dusk_core::stake::MINIMUM_STAKE;
+use dusk_core::stake::DEFAULT_MINIMUM_STAKE;
 use dusk_core::{
     dusk,
     signatures::bls::PublicKey as BlsPublicKey,
@@ -164,7 +164,7 @@ pub async fn stake() -> Result<()> {
     info!("Original Root: {:?}", hex::encode(original_root));
 
     // Perform some staking actions.
-    wallet_stake(&rusk, &wallet, MINIMUM_STAKE);
+    wallet_stake(&rusk, &wallet, DEFAULT_MINIMUM_STAKE);
 
     // Check the state's root is changed from the original one
     let new_root = rusk.state_root();

--- a/wallet-core/src/ffi.rs
+++ b/wallet-core/src/ffi.rs
@@ -56,7 +56,7 @@ static KEY_SIZE: usize = BlsScalar::SIZE;
 static ITEM_SIZE: usize = core::mem::size_of::<ArchivedNoteLeaf>();
 
 #[no_mangle]
-static MINIMUM_STAKE: u64 = dusk_core::stake::MINIMUM_STAKE;
+static MINIMUM_STAKE: u64 = dusk_core::stake::DEFAULT_MINIMUM_STAKE;
 
 /// The size of the scratch buffer used for parsing the notes.
 const NOTES_BUFFER_SIZE: usize = 96 * 1024;


### PR DESCRIPTION
- Change stake contract to use configurable values instead of const
- Deprecate MINIMUM_STAKE (use DEFAULT_MINIMUM_STAKE instead)
- Reorganize imports for stake-contract