### PR TITLE
rusk-wallet: Align shielded address naming with Web wallet terminology

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change Rusk wallet name and version information [#2647]
 - Update Clap from v3 to workspace v4 [#2489]
 - Rename all instances of recovery phrase to mnemonic phrase [#2839]
+- Rename Shielded account to be aligned with the Web wallet [#3263]
 
 ### Fix
 
@@ -35,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix stake info for inactive stakes with rewards [#2766]
 - Fix Moonlight stake reward withdrawal [#2523]
 
+[#3263]: https://github.com/dusk-network/rusk/issues/3263
 [#2839]: https://github.com/dusk-network/rusk/issues/2839
 [#2768]: https://github.com/dusk-network/rusk/issues/2768
 [#2766]: https://github.com/dusk-network/rusk/issues/2766

--- a/rusk-wallet/src/bin/command.rs
+++ b/rusk-wallet/src/bin/command.rs
@@ -715,7 +715,7 @@ impl fmt::Display for RunResult<'_> {
                     f,
                     "> {}\n>   {}\n>   {}",
                     crate::Profile::index_string(*profile_idx),
-                    profile.shielded_address_string(),
+                    profile.shielded_account_string(),
                     profile.public_account_string(),
                 )
             }
@@ -727,7 +727,7 @@ impl fmt::Display for RunResult<'_> {
                         format!(
                             "> {}\n>   {}\n>   {}\n",
                             crate::Profile::index_string(profile_idx as u8),
-                            profile.shielded_address_string(),
+                            profile.shielded_account_string(),
                             profile.public_account_string(),
                         )
                     })

--- a/rusk-wallet/src/bin/interactive.rs
+++ b/rusk-wallet/src/bin/interactive.rs
@@ -32,7 +32,7 @@ pub(crate) async fn run_loop(
             prompt::hide_cursor()?;
 
             let op = if !wallet.is_online().await {
-                println!("\r{}", profile.shielded_address_string());
+                println!("\r{}", profile.shielded_account_string());
                 println!("{}", profile.public_account_string());
                 println!();
 
@@ -49,7 +49,7 @@ pub(crate) async fn run_loop(
 
                 // display profile information
                 // display shielded balance and keys information
-                println!("{}", profile.shielded_address_string());
+                println!("{}", profile.shielded_account_string());
                 if is_synced {
                     println!(
                         "{0: <16} - Spendable: {phoenix_spendable}",
@@ -483,7 +483,7 @@ impl<'a> Display for ProfileSelect<'a> {
                 f,
                 "{}\n  {}\n  {}",
                 Profile::index_string(*index),
-                profile.shielded_address_preview(),
+                profile.shielded_account_preview(),
                 profile.public_account_preview(),
             ),
             ProfileSelect::New => write!(f, "Create a new profile"),

--- a/rusk-wallet/src/bin/interactive/command_menu.rs
+++ b/rusk-wallet/src/bin/interactive/command_menu.rs
@@ -102,7 +102,7 @@ pub(crate) async fn online(
 
             let (sender, balance) = match &rcvr {
                 Address::Shielded(_) => {
-                    (wallet.shielded_address(profile_idx)?, phoenix_spendable)
+                    (wallet.shielded_account(profile_idx)?, phoenix_spendable)
                 }
                 Address::Public(_) => {
                     (wallet.public_address(profile_idx)?, moonlight_balance)
@@ -445,7 +445,7 @@ fn pick_transaction_model(
 ) -> anyhow::Result<(Address, Dusk)> {
     match prompt::request_transaction_model()? {
         prompt::TransactionModel::Shielded => {
-            let addr = wallet.shielded_address(profile_idx)?;
+            let addr = wallet.shielded_account(profile_idx)?;
             Ok((addr, phoenix_spendable))
         }
         prompt::TransactionModel::Public => {

--- a/rusk-wallet/src/bin/main.rs
+++ b/rusk-wallet/src/bin/main.rs
@@ -338,7 +338,7 @@ async fn exec() -> anyhow::Result<()> {
                     println!(
                         "> {}\n>   {}\n>   {}\n",
                         Profile::index_string(profile_idx),
-                        profile.shielded_address_string(),
+                        profile.shielded_account_string(),
                         profile.public_account_string(),
                     );
                 }
@@ -347,7 +347,7 @@ async fn exec() -> anyhow::Result<()> {
                         println!(
                             "> {}\n>   {}\n>   {}\n\n",
                             Profile::index_string(profile_idx as u8),
-                            profile.shielded_address_string(),
+                            profile.shielded_account_string(),
                             profile.public_account_string(),
                         );
                     }

--- a/rusk-wallet/src/wallet.rs
+++ b/rusk-wallet/src/wallet.rs
@@ -368,9 +368,9 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         self.default_public_address()
     }
 
-    /// Returns the default shielded address for this wallet
-    pub fn default_shielded_address(&self) -> Address {
-        self.shielded_address(0)
+    /// Returns the default shielded account address for this wallet
+    pub fn default_shielded_account(&self) -> Address {
+        self.shielded_account(0)
             .expect("there to be an address at index 0")
     }
 
@@ -450,8 +450,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         Ok(addr.into())
     }
 
-    /// Returns the shielded address for a given index.
-    pub fn shielded_address(&self, index: u8) -> Result<Address, Error> {
+    /// Returns the shielded account address for a given index.
+    pub fn shielded_account(&self, index: u8) -> Result<Address, Error> {
         let addr = *self.shielded_key(index)?;
         Ok(addr.into())
     }
@@ -687,7 +687,7 @@ mod tests {
         let mut wallet: Wallet<WalletFile> = Wallet::new("uphold stove tennis fire menu three quick apple close guilt poem garlic volcano giggle comic")?;
 
         // check address generation
-        let default_addr = wallet.default_shielded_address();
+        let default_addr = wallet.default_shielded_account();
         let other_addr_idx = wallet.add_profile();
         let other_addr =
             Address::Shielded(*wallet.shielded_key(other_addr_idx)?);
@@ -700,7 +700,7 @@ mod tests {
         let wallet: Wallet<WalletFile> = Wallet::new("demise monitor elegant cradle squeeze cheap parrot venture stereo humor scout denial action receive flat")?;
 
         // check addresses are different
-        let addr = wallet.default_shielded_address();
+        let addr = wallet.default_shielded_account();
         assert!(format!("{}", addr).ne(TEST_ADDR));
 
         // attempt to create a wallet from an invalid mnemonic
@@ -729,8 +729,8 @@ mod tests {
         // load from file and check
         let loaded_wallet = Wallet::from_file(file)?;
 
-        let original_addr = wallet.default_shielded_address();
-        let loaded_addr = loaded_wallet.default_shielded_address();
+        let original_addr = wallet.default_shielded_account();
+        let loaded_addr = loaded_wallet.default_shielded_account();
         assert!(original_addr.eq(&loaded_addr));
 
         Ok(())

--- a/rusk-wallet/src/wallet/address.rs
+++ b/rusk-wallet/src/wallet/address.rs
@@ -17,7 +17,7 @@ use crate::Error;
 #[derive(Clone, Eq)]
 #[allow(missing_docs)]
 pub enum Address {
-    /// Shielded address for shielded transactions.
+    /// Shielded account address for shielded transactions.
     Shielded(PhoenixPublicKey),
     /// Public account address for public transactions and staking
     /// operations.
@@ -156,18 +156,18 @@ impl fmt::Debug for Address {
 /// transactions as well as for staking operations.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Profile {
-    /// Shielded address for shielded transactions
+    /// Shielded account address for shielded transactions
     pub shielded_addr: PhoenixPublicKey,
     /// Public account address for public transactions and staking operations.
     pub public_addr: BlsPublicKey,
 }
 
 impl Profile {
-    /// Format the shielded address into a string.
-    pub fn shielded_address_string(&self) -> String {
+    /// Format the shielded account into a string.
+    pub fn shielded_account_string(&self) -> String {
         format!(
             "{} - {}",
-            shielded_address_prefix(),
+            shielded_account_prefix(),
             Address::Shielded(self.shielded_addr)
         )
     }
@@ -190,11 +190,11 @@ impl Profile {
         )
     }
 
-    /// Format the shortened shielded address into a string.
-    pub fn shielded_address_preview(&self) -> String {
+    /// Format the shortened shielded account into a string.
+    pub fn shielded_account_preview(&self) -> String {
         format!(
             "{} - {}",
-            shielded_address_prefix(),
+            shielded_account_prefix(),
             Address::Shielded(self.shielded_addr).preview(),
         )
     }
@@ -228,8 +228,8 @@ impl Profile {
     }
 }
 
-fn shielded_address_prefix() -> String {
-    format!("{:<16}", "Shielded address")
+fn shielded_account_prefix() -> String {
+    format!("{:<16}", "Shielded account")
 }
 
 fn public_account_prefix() -> String {

--- a/rusk-wallet/src/wallet/transaction.rs
+++ b/rusk-wallet/src/wallet/transaction.rs
@@ -28,7 +28,7 @@ use crate::gas::Gas;
 use crate::Error;
 
 impl<F: SecureWalletFile + Debug> Wallet<F> {
-    /// Transfers funds between shielded addresses.
+    /// Transfers funds between shielded accounts.
     pub async fn phoenix_transfer(
         &self,
         sender_idx: u8,
@@ -131,7 +131,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         state.propagate(tx).await
     }
 
-    /// Executes a generic contract call, paying gas with a shielded address.
+    /// Executes a generic contract call, paying gas with a shielded account.
     pub async fn phoenix_execute(
         &self,
         sender_idx: u8,
@@ -468,7 +468,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         state.propagate(unstake).await
     }
 
-    /// Withdraws accumulated staking to a shielded address.
+    /// Withdraws accumulated staking to a shielded account.
     pub async fn phoenix_stake_withdraw(
         &self,
         sender_idx: u8,
@@ -556,7 +556,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         state.propagate(withdraw).await
     }
 
-    /// Converts Dusk from a shielded address to a public account.
+    /// Converts Dusk from a shielded account to a public account.
     pub async fn phoenix_to_moonlight(
         &self,
         profile_idx: u8,
@@ -594,7 +594,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         state.propagate(convert).await
     }
 
-    /// Converts Dusk from a public account to a shielded address.
+    /// Converts Dusk from a public account to a shielded account.
     pub async fn moonlight_to_phoenix(
         &self,
         profile_idx: u8,


### PR DESCRIPTION
Resolves #3263