### PR TITLE
ci: Update Rusk wallet binary artifacts

### DIFF
--- a/.github/workflows/ruskwallet_build.yml
+++ b/.github/workflows/ruskwallet_build.yml
@@ -18,16 +18,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, macos-15, windows-latest, arm-linux]
+        os: [ubuntu-24.04, macos-latest, macos-15, windows-latest, arm-linux]
         compiler: [cargo]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             compiler: cargo
             target: linux-x64
 
-          - os: ubuntu-22.04
+          - os: arm-linux
             compiler: cargo
-            target: linux-x64-libssl3
+            target: linux-arm64
+            flags: --target=aarch64-unknown-linux-gnu
+            platform: aarch64-unknown-linux-gnu
 
           - os: macos-latest
             compiler: cargo
@@ -42,12 +44,6 @@ jobs:
           - os: windows-latest
             compiler: cargo
             target: windows-x64
-
-          - os: arm-linux
-            compiler: cargo
-            target: linux-arm64
-            flags: --target=aarch64-unknown-linux-gnu
-            platform: aarch64-unknown-linux-gnu
 
     steps:
       - name: Checkout Repository
@@ -75,18 +71,16 @@ jobs:
 
       - name: "Pack binaries"
         run: |
-          mkdir rusk-wallet${{env.SEMVER}}-${{matrix.target}}
-          echo "Fetching changelog and readme files..."
-          mv target/${{matrix.platform}}/release/rusk-wallet rusk-wallet${{env.SEMVER}}-${{matrix.target}}
-          cp ./rusk-wallet/CHANGELOG.md rusk-wallet${{env.SEMVER}}-${{matrix.target}}
-          cp ./rusk-wallet/README.md rusk-wallet${{env.SEMVER}}-${{matrix.target}}
-          tar -czvf ruskwallet${{env.SEMVER}}-${{matrix.target}}.tar.gz rusk-wallet${{env.SEMVER}}-${{matrix.target}}
+          mkdir rusk-wallet-${{env.SEMVER}}-${{matrix.target}}
+          mv target/${{matrix.platform}}/release/rusk-wallet rusk-wallet-${{env.SEMVER}}-${{matrix.target}}
+          cp ./rusk-wallet/CHANGELOG.md rusk-wallet-${{env.SEMVER}}-${{matrix.target}}
+          cp ./rusk-wallet/README.md rusk-wallet-${{env.SEMVER}}-${{matrix.target}}
+          tar -czvf rusk-wallet-${{env.SEMVER}}-${{matrix.target}}.tar.gz rusk-wallet-${{env.SEMVER}}-${{matrix.target}}
           ls -la *.gz
 
-      - name: "Upload Wallet Artifacts"
-        uses: actions/upload-artifact@v3
+      - name: Upload Wallet Artifacts
+        uses: actions/upload-artifact@v4
         with:
-          name: wallet-binaries-${{env.SEMVER}}
-          path: |
-            ./*.gz
+          name: rusk-wallet-${{ env.SEMVER }}-${{ matrix.target }}
+          path: ./rusk-wallet-${{ env.SEMVER }}-${{ matrix.target }}.tar.gz
           retention-days: 5

--- a/.github/workflows/ruskwallet_build.yml
+++ b/.github/workflows/ruskwallet_build.yml
@@ -22,27 +22,18 @@ jobs:
         compiler: [cargo]
         include:
           - os: ubuntu-24.04
-            compiler: cargo
             target: linux-x64
-
           - os: arm-linux
-            compiler: cargo
             target: linux-arm64
             flags: --target=aarch64-unknown-linux-gnu
             platform: aarch64-unknown-linux-gnu
-
           - os: macos-latest
-            compiler: cargo
             target: macos-intel
-
           - os: macos-15
-            compiler: cargo
             target: macos-arm64
             flags: --target=aarch64-apple-darwin
             platform: aarch64-apple-darwin
-
           - os: windows-latest
-            compiler: cargo
             target: windows-x64
 
     steps:
@@ -58,15 +49,14 @@ jobs:
         run: rustup target add aarch64-apple-darwin
         if: ${{ matrix.os == 'macos-15' }}
 
-      - name: Build Wallet
+      - name: Build Rusk Wallet
         shell: bash
         working-directory: ./rusk-wallet
-        run: ${{matrix.compiler}} b --release --verbose ${{matrix.flags}}
+        run: cargo build --release --verbose ${{matrix.flags}}
 
       - name: Get semver from wallet binary
         run: |
-          ls -la target/release
-          export SEMVER=$(cargo pkgid --mainfest-path ./rusk-wallet/Cargo.toml | perl -lpe 's/.*\@(.*)/$1/')
+          export SEMVER=$(cargo pkgid --manifest-path ./rusk-wallet/Cargo.toml | sed -E 's/.*#([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
           echo "SEMVER=$SEMVER" >> $GITHUB_ENV
 
       - name: "Pack binaries"


### PR DESCRIPTION
This PR:
- Updates `actions/upload-artifact` to v4
- Fixes semver use in the artifact
- Removes unnecessary use of compiler in the Matrix strategy
- Removes older Ubuntu versions