### PR TITLE
rusk: relax `check_version_header`

### DIFF
--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add `Rusk-Version-Strict` header for version match
+
+### Changed
+
+- Change `check_rusk_version` to ignore pre-release by default
+
 ## [1.0.0] - 2025-01-05
 
 ### Added

--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -78,6 +78,7 @@ use self::event::{MessageRequest, ResponseData, RuesEventUri, SessionId};
 use self::stream::{Listener, Stream};
 
 const RUSK_VERSION_HEADER: &str = "Rusk-Version";
+const RUSK_VERSION_STRICT_HEADER: &str = "Rusk-Version-Strict";
 
 pub struct HttpServer {
     handle: task::JoinHandle<()>,


### PR DESCRIPTION
If client is not requesting a strict check we should ignore the prerelease version of the current binary
If instead the client request a strict version we should respect that and check the version as is

This solves the issue when connecting to a node that is in`-dev` mode
