### PR TITLE
rusk: release `1.0.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-rusk"
-version = "1.0.2-dev"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-rusk"
-version = "1.0.2"
+version = "1.0.3-alpha.1"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -326,7 +326,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#290]: https://github.com/dusk-network/rusk/issues/290
 
 
-[unreleased]: https://github.com/dusk-network/rusk/compare/rusk-1.0.1...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-1.0.1...HEAD
 [1.0.1]: https://github.com/dusk-network/rusk/compare/rusk-1.0.0...rusk-1.0.1
 [1.0.0]: https://github.com/dusk-network/rusk/compare/v0.8.0...rusk-1.0.0
 [0.8.0]: https://github.com/dusk-network/rusk/compare/v0.7.0...v0.8.0

--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2025-01-27
+
 ### Added
 
 - Add `/on/account:<address>/status` endpoint [#3422]
@@ -326,7 +328,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#290]: https://github.com/dusk-network/rusk/issues/290
 
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-1.0.1...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.0.2...HEAD
+[1.0.2]: https://github.com/dusk-network/rusk/compare/rusk-1.0.1...dusk-rusk-1.0.2
 [1.0.1]: https://github.com/dusk-network/rusk/compare/rusk-1.0.0...rusk-1.0.1
 [1.0.0]: https://github.com/dusk-network/rusk/compare/v0.8.0...rusk-1.0.0
 [0.8.0]: https://github.com/dusk-network/rusk/compare/v0.7.0...v0.8.0

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-rusk"
-version = "1.0.2"
+version = "1.0.3-alpha.1"
 edition = "2021"
 autobins = false
 

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-rusk"
-version = "1.0.2-dev"
+version = "1.0.2"
 edition = "2021"
 autobins = false
 


### PR DESCRIPTION
## [1.0.2] - 2025-01-27

### Added

- Add `/on/account:<address>/status` endpoint [#3422]

### Changed

- Change dependency declaration to not require strict equal [#3405]

[1.0.2]: https://github.com/dusk-network/rusk/compare/rusk-1.0.1...dusk-rusk-1.0.2