### PR TITLE
web-wallet: Release 1.3.0

### DIFF
--- a/web-wallet/CHANGELOG.md
+++ b/web-wallet/CHANGELOG.md
@@ -9,13 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+- Update Transactions list design [#1922]
+
+### Removed
+
+### Fixed
+
+## [1.3.0] - 2025-01-28
+
+### Added
+
 - Add support for partial unstake/claim rewards [#3009]
 - Add "Unstake" flow validation [#3009]
 - Store the wallet creation block height and show it in settings [#3381]
 
 ### Changed
 
-- Update Transactions list design [#1922]
 - Change Review step label to "Overview" (Send flow) [#3387]
 
 ### Removed
@@ -554,6 +565,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- VERSIONS -->
 
 [Unreleased]: https://github.com/dusk-network/rusk/tree/master/web-wallet
+[1.3.0]: https://github.com/dusk-network/rusk/tree/web-wallet-v1.3.0
 [1.2.0]: https://github.com/dusk-network/rusk/tree/web-wallet-v1.2.0
 [1.1.0]: https://github.com/dusk-network/rusk/tree/web-wallet-v1.1.0
 [1.0.0]: https://github.com/dusk-network/rusk/tree/web-wallet-v1.0.0

--- a/web-wallet/package-lock.json
+++ b/web-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-wallet",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-wallet",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@floating-ui/dom": "1.6.5",

--- a/web-wallet/package.json
+++ b/web-wallet/package.json
@@ -33,7 +33,7 @@
     "typecheck:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch --fail-on-warnings"
   },
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "dependencies": {
     "@floating-ui/dom": "1.6.5",
     "@mdi/js": "7.4.47",


### PR DESCRIPTION
Resolves #3435

## 1.3.0 - 2025-01-28

### Added

- Add support for partial unstake/claim rewards [#3009]
- Add "Unstake" flow validation [#3009]
- Store the wallet creation block height and show it in settings [#3381]

### Changed

- Change Review step label to "Overview" (Send flow) [#3387]

### Removed

- Remove gas settings from Overview step (Stake/Unstake flows) [#3009]

### Fixed

- Fix creation of a new wallet causing the sync to start from genesis [#3362]