### PR TITLE
rusk: changed the gas limit for queries to the block gas limit

### DIFF
--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate `[chain].block_gas_limit` config [#3341]
 - Change how Rusk controls the archive for synchronization [#3359]
 
+### Fixed
+
+- Fix node unresponsiveness when querying contracts that take too long to terminate [#3481]
+
 ### Removed
 
 - Remove legacy event system 
@@ -321,6 +325,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add build system that generates keys for circuits and caches them.
 
 <!-- Issues -->
+[#3481]: https://github.com/dusk-network/rusk/issues/3481
 [#3359]: https://github.com/dusk-network/rusk/issues/3359
 [#3422]: https://github.com/dusk-network/rusk/issues/3422
 [#3405]: https://github.com/dusk-network/rusk/issues/3405

--- a/rusk/src/bin/config/http.rs
+++ b/rusk/src/bin/config/http.rs
@@ -79,7 +79,7 @@ impl Default for HttpConfig {
 }
 
 const fn default_feeder_call_gas() -> u64 {
-    u64::MAX
+    3 * 1_000_000_000
 }
 
 const fn default_listen() -> bool {


### PR DESCRIPTION
For https://github.com/dusk-network/rusk/issues/3481.

The issue occurred because queries are executed with a gas limit of `u64::MAX`.
This PR changes that to the block gas limit of 3_000_000_000.
When a query takes too long to execute, like in an infinite loop, the new result is a VM out of gas error.
