### PR TITLE
node: change finalization order to support new piecrust

### DIFF
--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -61,6 +61,7 @@ pub struct ChainSrv<N: Network, DB: database::DB, VM: vm::VMExecution> {
     event_sender: Sender<Event>,
     genesis_timestamp: u64,
     dusk_key: BlsPublicKey,
+    finality_activation: u64,
     #[cfg(feature = "archive")]
     archive: Archive,
 }
@@ -98,6 +99,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution>
             self.max_consensus_queue_size,
             self.event_sender.clone(),
             self.dusk_key,
+            self.finality_activation,
         )
         .await?;
 
@@ -257,6 +259,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> ChainSrv<N, DB, VM> {
         event_sender: Sender<Event>,
         genesis_timestamp: u64,
         dusk_key: BlsPublicKey,
+        finality_activation: u64,
         #[cfg(feature = "archive")] archive: Archive,
     ) -> Self {
         info!(
@@ -272,6 +275,7 @@ impl<N: Network, DB: database::DB, VM: vm::VMExecution> ChainSrv<N, DB, VM> {
             event_sender,
             genesis_timestamp,
             dusk_key,
+            finality_activation,
             #[cfg(feature = "archive")]
             archive,
         }

--- a/rusk/src/lib/builder/node.rs
+++ b/rusk/src/lib/builder/node.rs
@@ -203,6 +203,10 @@ impl RuskNodeBuilder {
         let archive = Archive::create_or_open(self.db_path.clone()).await;
 
         let min_gas_limit = self.min_gas_limit.unwrap_or(DEFAULT_MIN_GAS_LIMIT);
+        let finality_activation = self
+            .vm_config
+            .feature(crate::node::FEATURE_ABI_PUBLIC_SENDER)
+            .unwrap_or(u64::MAX);
 
         let rusk = Rusk::new(
             self.state_dir,
@@ -236,6 +240,7 @@ impl RuskNodeBuilder {
             node_sender.clone(),
             self.genesis_timestamp,
             *crate::DUSK_CONSENSUS_KEY,
+            finality_activation,
             #[cfg(feature = "archive")]
             archive.clone(),
         );

--- a/rusk/src/lib/node.rs
+++ b/rusk/src/lib/node.rs
@@ -19,7 +19,7 @@ use node::network::Kadcast;
 use node::LongLivedService;
 use parking_lot::RwLock;
 use tokio::sync::broadcast;
-pub use vm::RuskVmConfig;
+pub use vm::*;
 
 use crate::http::RuesEvent;
 pub(crate) use events::ChainEventStreamer;

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -24,6 +24,7 @@ use node_data::bls::PublicKey;
 use node_data::ledger::{Block, Slash, SpentTransaction, Transaction};
 
 use super::Rusk;
+pub use config::feature::*;
 pub use config::Config as RuskVmConfig;
 
 impl VMExecution for Rusk {

--- a/rusk/src/lib/node/vm/config.rs
+++ b/rusk/src/lib/node/vm/config.rs
@@ -58,6 +58,10 @@ impl Default for Config {
     }
 }
 
+pub(crate) mod feature {
+    pub const FEATURE_ABI_PUBLIC_SENDER: &str = "ABI_PUBLIC_SENDER";
+}
+
 impl Config {
     pub fn new() -> Self {
         Self {
@@ -115,8 +119,8 @@ impl Config {
 
     /// Create a new `Config` with the given parameters.
     pub fn to_execution_config(&self, block_height: u64) -> ExecutionConfig {
-        let with_public_sender = self
-            .feature("ABI_PUBLIC_SENDER")
+        let with_public_sender: bool = self
+            .feature(feature::FEATURE_ABI_PUBLIC_SENDER)
             .map(|activation| activation >= block_height)
             .unwrap_or_default();
         ExecutionConfig {


### PR DESCRIPTION
Change the finalization order according to the ABI_SENDER feature activation

See also #3341 