### PR TITLE
explorer: Fix not awaited promises in `failureToRejection` tests

### DIFF
--- a/explorer/src/lib/dusk/http/__tests__/failureToRejection.spec.js
+++ b/explorer/src/lib/dusk/http/__tests__/failureToRejection.spec.js
@@ -3,21 +3,21 @@ import { describe, expect, it } from "vitest";
 import { failureToRejection } from "..";
 
 describe("failureToRejection", () => {
-  it('should return a rejected Promise if the given Response status is not "ok"', () => {
+  it('should return a rejected Promise if the given Response status is not "ok"', async () => {
     const response = new Response("", { status: 404 });
     const result = failureToRejection(response);
 
-    expect(result).rejects.toBeInstanceOf(Error);
-    expect(result).rejects.toMatchObject({
+    await expect(result).rejects.toBeInstanceOf(Error);
+    await expect(result).rejects.toMatchObject({
       cause: response,
       message: expect.stringContaining(response.statusText),
     });
   });
 
-  it('should return a Promise that resolves to the given Response, if its status is "ok"', () => {
+  it('should return a Promise that resolves to the given Response, if its status is "ok"', async () => {
     const response = new Response("", { status: 200 });
     const result = failureToRejection(response);
 
-    expect(result).resolves.toBe(response);
+    await expect(result).resolves.toBe(response);
   });
 });


### PR DESCRIPTION
Resolves #3497