### PR TITLE
rusk: add `vm_config` section to `/on/node/info`

### DIFF
--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `[vm]` config section [#3341]
 - Add CONTRACT_TO_ACCOUNT inflow case on archive moonlight filtering [#3494]
 - Add Dockerfile for persistent state builds [#1080]
+- Add `vm_config` section to `/on/node/info` [#3341]
 
 ### Changed
 

--- a/rusk/src/lib/http/chain.rs
+++ b/rusk/src/lib/http/chain.rs
@@ -183,6 +183,10 @@ impl RuskNode {
         info.insert("chain_id", n_conf.kadcast_id.into());
         info.insert("kadcast_address", n_conf.public_address.into());
 
+        let vm_conf = self.inner().vm_handler().read().await.vm_config.clone();
+        let vm_conf = serde_json::to_value(vm_conf).unwrap_or_default();
+        info.insert("vm_config", vm_conf);
+
         Ok(ResponseData::new(serde_json::to_value(&info)?))
     }
 


### PR DESCRIPTION
This is also required to give users a feedback about their upgrade using `ruskquery info`

Example response
```json
{
    "bootstrapping_nodes": [],
    "chain_id": null,
    "kadcast_address": "127.0.0.1:9000",
    "version": "1.1.0-rc.2",
    "version_build": "1.1.0-rc.2 (bca9a01a 2025-02-13)",
    "vm_config": {
        "block_gas_limit": 3000000000,
        "features": {
            "ABI_PUBLIC_SENDER": 100,
            "key": 50
        },
        "gas_per_deploy_byte": 100,
        "generation_timeout": "3s",
        "min_deploy_points": 5000000,
        "min_deployment_gas_price": 2000
    }
}
```

See also #3341