### PR TITLE
rusk: release `1.1.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1937,7 +1937,7 @@ dependencies = [
  "rkyv",
  "rusk-profile 1.0.1",
  "rusk-prover",
- "rusk-recovery",
+ "rusk-recovery 1.0.3",
  "rustc_tools_util",
  "rustls-pemfile",
  "semver",
@@ -4487,6 +4487,35 @@ dependencies = [
 [[package]]
 name = "rusk-recovery"
 version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e42cccdbd038aa1d17c4eb053a4817813adf2c6d68ea392bcc20efee1de78bc"
+dependencies = [
+ "bs58",
+ "cargo_toml",
+ "dusk-bytes",
+ "dusk-core 1.1.0",
+ "dusk-plonk",
+ "dusk-vm 1.1.0",
+ "ff",
+ "flate2",
+ "hex",
+ "http_req",
+ "rand 0.8.5",
+ "reqwest",
+ "rusk-profile 1.0.1",
+ "serde",
+ "serde_derive",
+ "tar",
+ "tokio",
+ "toml",
+ "tracing",
+ "url",
+ "zip",
+]
+
+[[package]]
+name = "rusk-recovery"
+version = "1.0.4-alpha.1"
 dependencies = [
  "bs58",
  "cargo_toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-vm"
-version = "1.0.1-alpha.1"
+version = "1.1.0"
 dependencies = [
  "blake2b_simd",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,6 +1620,26 @@ dependencies = [
 
 [[package]]
 name = "dusk-consensus"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba93b03b0dc35598763c039973c77c12f51475fc31ac20a9add5faa03e0bdde"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "dusk-bytes",
+ "dusk-core 1.1.0",
+ "dusk-merkle",
+ "dusk-node-data 1.1.0",
+ "hex",
+ "num-bigint",
+ "sha3",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dusk-consensus"
 version = "1.0.2-alpha.1"
 dependencies = [
  "anyhow",
@@ -1735,7 +1755,7 @@ dependencies = [
  "async-trait",
  "criterion",
  "dusk-bytes",
- "dusk-consensus",
+ "dusk-consensus 1.0.1",
  "dusk-core 1.1.0",
  "dusk-node-data 1.1.0",
  "fake",
@@ -1862,7 +1882,7 @@ dependencies = [
  "criterion",
  "dirs",
  "dusk-bytes",
- "dusk-consensus",
+ "dusk-consensus 1.0.1",
  "dusk-core 1.1.0",
  "dusk-node",
  "dusk-node-data 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-wallet-core"
-version = "1.0.2-alpha.1"
+version = "1.1.0"
 dependencies = [
  "blake3",
  "bytecheck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,6 +1749,38 @@ dependencies = [
 [[package]]
 name = "dusk-node"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0441c97b1730ba96bd6eda42a8bfdfb40d4e6727a45a65924752a16f6ae69fad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "async-trait",
+ "dusk-bytes",
+ "dusk-consensus 1.0.1",
+ "dusk-core 1.1.0",
+ "dusk-node-data 1.1.0",
+ "hex",
+ "humantime-serde",
+ "kadcast",
+ "memory-stats",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "rkyv",
+ "rocksdb",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smallvec",
+ "sqlx",
+ "thiserror",
+ "time-util",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dusk-node"
+version = "1.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1884,7 +1916,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-consensus 1.0.1",
  "dusk-core 1.1.0",
- "dusk-node",
+ "dusk-node 1.1.0",
  "dusk-node-data 1.1.0",
  "dusk-vm 1.1.0",
  "dusk-wallet-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,7 +1935,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rkyv",
- "rusk-profile",
+ "rusk-profile 1.0.1",
  "rusk-prover",
  "rusk-recovery",
  "rustc_tools_util",
@@ -4440,6 +4440,23 @@ dependencies = [
 
 [[package]]
 name = "rusk-profile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "096be7f24357ebde8859b56c423b694278d4d151ab055b14d445dfd749efed69"
+dependencies = [
+ "blake3",
+ "console",
+ "dirs",
+ "hex",
+ "serde",
+ "sha2 0.10.8",
+ "toml",
+ "tracing",
+ "version_check",
+]
+
+[[package]]
+name = "rusk-profile"
 version = "1.0.2-alpha.1"
 dependencies = [
  "blake3",
@@ -4463,7 +4480,7 @@ dependencies = [
  "hex",
  "once_cell",
  "rand 0.8.5",
- "rusk-profile",
+ "rusk-profile 1.0.1",
  "tracing",
 ]
 
@@ -4483,7 +4500,7 @@ dependencies = [
  "http_req",
  "rand 0.8.5",
  "reqwest",
- "rusk-profile",
+ "rusk-profile 1.0.1",
  "serde",
  "serde_derive",
  "tar",
@@ -5656,7 +5673,7 @@ dependencies = [
  "rand 0.8.5",
  "ringbuffer",
  "rkyv",
- "rusk-profile",
+ "rusk-profile 1.0.1",
  "rusk-prover",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,7 +1936,7 @@ dependencies = [
  "reqwest",
  "rkyv",
  "rusk-profile 1.0.1",
- "rusk-prover",
+ "rusk-prover 1.1.0",
  "rusk-recovery 1.0.3",
  "rustc_tools_util",
  "rustls-pemfile",
@@ -4473,6 +4473,22 @@ dependencies = [
 [[package]]
 name = "rusk-prover"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469cbbdd11c2fde62fabe5ca710eb274d36aa01941a12625ac1b6c97320568db"
+dependencies = [
+ "dusk-bytes",
+ "dusk-core 1.1.0",
+ "dusk-plonk",
+ "hex",
+ "once_cell",
+ "rand 0.8.5",
+ "rusk-profile 1.0.1",
+ "tracing",
+]
+
+[[package]]
+name = "rusk-prover"
+version = "1.1.1-alpha.1"
 dependencies = [
  "dusk-bytes",
  "dusk-core 1.1.0",
@@ -5217,7 +5233,7 @@ dependencies = [
  "ff",
  "rand 0.8.5",
  "rkyv",
- "rusk-prover",
+ "rusk-prover 1.1.0",
 ]
 
 [[package]]
@@ -5703,7 +5719,7 @@ dependencies = [
  "ringbuffer",
  "rkyv",
  "rusk-profile 1.0.1",
- "rusk-prover",
+ "rusk-prover 1.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,7 +1839,7 @@ dependencies = [
  "dusk-core 1.1.0",
  "dusk-node",
  "dusk-node-data",
- "dusk-vm",
+ "dusk-vm 1.1.0",
  "dusk-wallet-core",
  "ff",
  "futures",
@@ -1889,6 +1889,22 @@ dependencies = [
 [[package]]
 name = "dusk-vm"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd93de74b9906727d9d58af528e34650a37b9d7edee6116b4bf24682370cffe"
+dependencies = [
+ "blake2b_simd",
+ "blake3",
+ "dusk-bytes",
+ "dusk-core 1.1.0",
+ "dusk-poseidon",
+ "lru",
+ "piecrust",
+ "rkyv",
+]
+
+[[package]]
+name = "dusk-vm"
+version = "1.1.1-alpha.1"
 dependencies = [
  "blake2b_simd",
  "blake3",
@@ -4381,7 +4397,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-core 1.1.0",
  "dusk-plonk",
- "dusk-vm",
+ "dusk-vm 1.1.0",
  "ff",
  "flate2",
  "hex",
@@ -5071,7 +5087,7 @@ dependencies = [
  "criterion",
  "dusk-bytes",
  "dusk-core 1.1.0",
- "dusk-vm",
+ "dusk-vm 1.1.0",
  "dusk-wallet-core",
  "ff",
  "rand 0.8.5",
@@ -5556,7 +5572,7 @@ version = "0.10.1"
 dependencies = [
  "dusk-bytes",
  "dusk-core 1.1.0",
- "dusk-vm",
+ "dusk-vm 1.1.0",
  "ff",
  "rand 0.8.5",
  "ringbuffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-node"
-version = "1.0.2-alpha.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "rusk-recovery"
-version = "1.0.3-alpha.1"
+version = "1.0.3"
 dependencies = [
  "bs58",
  "cargo_toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-rusk"
-version = "1.1.0-rc.2"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-core"
-version = "1.0.1-alpha.1"
+version = "1.1.0"
 dependencies = [
  "ark-bn254",
  "ark-groth16",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-core 1.1.0",
  "dusk-merkle",
- "dusk-node-data",
+ "dusk-node-data 1.1.0",
  "hex",
  "num-bigint",
  "rand 0.8.5",
@@ -1737,7 +1737,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-consensus",
  "dusk-core 1.1.0",
- "dusk-node-data",
+ "dusk-node-data 1.1.0",
  "fake",
  "hex",
  "humantime-serde",
@@ -1763,6 +1763,33 @@ dependencies = [
 [[package]]
 name = "dusk-node-data"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9898926e038094f5b0a23af0f61ea0271fedbb86d9cbb3b9c5d9eb47f02f41d"
+dependencies = [
+ "aes 0.7.5",
+ "anyhow",
+ "async-channel",
+ "base64 0.22.1",
+ "block-modes",
+ "bs58",
+ "chrono",
+ "dusk-bytes",
+ "dusk-core 1.1.0",
+ "fake",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.8",
+ "sha3",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "dusk-node-data"
+version = "1.1.1-alpha.1"
 dependencies = [
  "aes 0.7.5",
  "anyhow",
@@ -1838,7 +1865,7 @@ dependencies = [
  "dusk-consensus",
  "dusk-core 1.1.0",
  "dusk-node",
- "dusk-node-data",
+ "dusk-node-data 1.1.0",
  "dusk-vm 1.1.0",
  "dusk-wallet-core",
  "ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,7 +1919,7 @@ dependencies = [
  "dusk-node 1.1.0",
  "dusk-node-data 1.1.0",
  "dusk-vm 1.1.0",
- "dusk-wallet-core",
+ "dusk-wallet-core 1.1.0",
  "ff",
  "futures",
  "futures-util",
@@ -2001,6 +2001,25 @@ dependencies = [
 [[package]]
 name = "dusk-wallet-core"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4533c6298486bf3378dc0cd231613811a8973a037f6d94975f32d6e3a0f07f4f"
+dependencies = [
+ "blake3",
+ "bytecheck",
+ "dlmalloc",
+ "dusk-bytes",
+ "dusk-core 1.1.0",
+ "ff",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rkyv",
+ "sha2 0.10.8",
+ "zeroize",
+]
+
+[[package]]
+name = "dusk-wallet-core"
+version = "1.1.1-alpha.1"
 dependencies = [
  "blake3",
  "bytecheck",
@@ -4573,7 +4592,7 @@ dependencies = [
  "dirs",
  "dusk-bytes",
  "dusk-core 1.1.0",
- "dusk-wallet-core",
+ "dusk-wallet-core 1.1.0",
  "flume 0.10.14",
  "futures",
  "hex",
@@ -5229,7 +5248,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-core 1.1.0",
  "dusk-vm 1.1.0",
- "dusk-wallet-core",
+ "dusk-wallet-core 1.1.0",
  "ff",
  "rand 0.8.5",
  "rkyv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 name = "alice"
 version = "0.3.0"
 dependencies = [
- "dusk-core",
+ "dusk-core 1.1.0",
 ]
 
 [[package]]
@@ -767,7 +767,7 @@ version = "0.3.0"
 dependencies = [
  "bytecheck",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.1.0",
  "rkyv",
 ]
 
@@ -887,7 +887,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "charlie"
 version = "0.3.0"
 dependencies = [
- "dusk-core",
+ "dusk-core 1.1.0",
  "rkyv",
 ]
 
@@ -1626,7 +1626,7 @@ dependencies = [
  "async-trait",
  "criterion",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.1.0",
  "dusk-merkle",
  "dusk-node-data",
  "hex",
@@ -1641,6 +1641,33 @@ dependencies = [
 [[package]]
 name = "dusk-core"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f59efed0e9cae4161db7ab01609e59177c6b416282e37c75287ea2a165a31be"
+dependencies = [
+ "ark-bn254",
+ "ark-groth16",
+ "ark-relations",
+ "ark-serialize",
+ "bls12_381-bls 0.5.0",
+ "bytecheck",
+ "dusk-bls12_381 0.14.1",
+ "dusk-bytes",
+ "dusk-jubjub",
+ "dusk-plonk",
+ "dusk-poseidon",
+ "ff",
+ "jubjub-schnorr",
+ "phoenix-circuits",
+ "phoenix-core",
+ "piecrust-uplink",
+ "poseidon-merkle",
+ "rand 0.8.5",
+ "rkyv",
+]
+
+[[package]]
+name = "dusk-core"
+version = "1.1.1-alpha.1"
 dependencies = [
  "ark-bn254",
  "ark-groth16",
@@ -1709,7 +1736,7 @@ dependencies = [
  "criterion",
  "dusk-bytes",
  "dusk-consensus",
- "dusk-core",
+ "dusk-core 1.1.0",
  "dusk-node-data",
  "fake",
  "hex",
@@ -1745,7 +1772,7 @@ dependencies = [
  "bs58",
  "chrono",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.1.0",
  "fake",
  "hex",
  "rand 0.8.5",
@@ -1809,7 +1836,7 @@ dependencies = [
  "dirs",
  "dusk-bytes",
  "dusk-consensus",
- "dusk-core",
+ "dusk-core 1.1.0",
  "dusk-node",
  "dusk-node-data",
  "dusk-vm",
@@ -1866,7 +1893,7 @@ dependencies = [
  "blake2b_simd",
  "blake3",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.1.0",
  "dusk-poseidon",
  "ff",
  "lru",
@@ -1884,7 +1911,7 @@ dependencies = [
  "bytecheck",
  "dlmalloc",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.1.0",
  "ff",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -2567,7 +2594,7 @@ name = "host_fn"
 version = "0.2.0"
 dependencies = [
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.1.0",
 ]
 
 [[package]]
@@ -4336,7 +4363,7 @@ name = "rusk-prover"
 version = "1.0.2-alpha.1"
 dependencies = [
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.1.0",
  "dusk-plonk",
  "hex",
  "once_cell",
@@ -4352,7 +4379,7 @@ dependencies = [
  "bs58",
  "cargo_toml",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.1.0",
  "dusk-plonk",
  "dusk-vm",
  "ff",
@@ -4388,7 +4415,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.1.0",
  "dusk-wallet-core",
  "flume 0.10.14",
  "futures",
@@ -5043,7 +5070,7 @@ version = "0.8.0"
 dependencies = [
  "criterion",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.1.0",
  "dusk-vm",
  "dusk-wallet-core",
  "ff",
@@ -5528,7 +5555,7 @@ name = "transfer-contract"
 version = "0.10.1"
 dependencies = [
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.1.0",
  "dusk-vm",
  "ff",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-node-data"
-version = "1.0.2-alpha.1"
+version = "1.1.0"
 dependencies = [
  "aes 0.7.5",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-rusk"
-version = "1.1.0"
+version = "1.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4472,7 +4472,7 @@ dependencies = [
 
 [[package]]
 name = "rusk-prover"
-version = "1.0.2-alpha.1"
+version = "1.1.0"
 dependencies = [
  "dusk-bytes",
  "dusk-core 1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ node-data = { version = "1.1.0", package = "dusk-node-data" }
 rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 # rusk-prover = "1.0.1"
-rusk-prover = { version = "1.0.2-alpha.1", path = "./rusk-prover/" }
+rusk-prover = { version = "1.1.0", path = "./rusk-prover/" }
 rusk-recovery = "1.0.3"
 # rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
 # wallet-core = { version = "1.0.1", package = "dusk-wallet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ resolver = "2"
 dusk-consensus = { version = "1.0.2-alpha.1", path = "./consensus/" }
 dusk-core = "1.1.0"
 # dusk-core = { version = "1.1.0", path = "./core/" }
-# dusk-vm = "1.0.0"
-dusk-vm = { version = "1.1.0", path = "./vm/" }
+dusk-vm = "1.1.0"
+# dusk-vm = { version = "1.1.0", path = "./vm/" }
 # node = { version = "1.0.1", package = "dusk-node" }
 node = { version = "1.0.2-alpha.1", path = "./node/", package = "dusk-node" }
 # node-data = { version = "1.0.1", package = "dusk-node-data" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ resolver = "2"
 
 [workspace.dependencies]
 # Workspace internal dependencies
-# dusk-consensus = "1.0.1"
-dusk-consensus = { version = "1.0.2-alpha.1", path = "./consensus/" }
+dusk-consensus = "1.0.1"
+# dusk-consensus = { version = "1.0.2-alpha.1", path = "./consensus/" }
 dusk-core = "1.1.0"
 # dusk-core = { version = "1.1.0", path = "./core/" }
 dusk-vm = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ dusk-vm = "1.1.0"
 # node = { version = "1.0.1", package = "dusk-node" }
 node = { version = "1.0.2-alpha.1", path = "./node/", package = "dusk-node" }
 # node-data = { version = "1.0.1", package = "dusk-node-data" }
-node-data = { version = "1.0.2-alpha.1", path = "./node-data/", package = "dusk-node-data" }
+node-data = { version = "1.1.0", path = "./node-data/", package = "dusk-node-data" }
 # rusk-profile = "1.0.1"
 rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 # rusk-prover = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ dusk-core = "1.1.0"
 # dusk-core = { version = "1.1.0", path = "./core/" }
 dusk-vm = "1.1.0"
 # dusk-vm = { version = "1.1.0", path = "./vm/" }
-# node = { version = "1.0.1", package = "dusk-node" }
-node = { version = "1.1.0", path = "./node/", package = "dusk-node" }
+node = { version = "1.1.0", package = "dusk-node" }
+# node = { version = "1.1.0", path = "./node/", package = "dusk-node" }
 node-data = { version = "1.1.0", package = "dusk-node-data" }
 # node-data = { version = "1.1.0", path = "./node-data/", package = "dusk-node-data" }
 # rusk-profile = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ dusk-core = "1.1.0"
 dusk-vm = "1.1.0"
 # dusk-vm = { version = "1.1.0", path = "./vm/" }
 # node = { version = "1.0.1", package = "dusk-node" }
-node = { version = "1.0.2-alpha.1", path = "./node/", package = "dusk-node" }
+node = { version = "1.1.0", path = "./node/", package = "dusk-node" }
 node-data = { version = "1.1.0", package = "dusk-node-data" }
 # node-data = { version = "1.1.0", path = "./node-data/", package = "dusk-node-data" }
 # rusk-profile = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rusk-prover = "1.1.0"
 rusk-recovery = "1.0.3"
 # rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
 # wallet-core = { version = "1.0.1", package = "dusk-wallet-core" }
-wallet-core = { version = "1.0.2-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
+wallet-core = { version = "1.1.0", path = "./wallet-core/", package = "dusk-wallet-core" }
 
 # Dusk dependencies outside the workspace
 bls12_381-bls = { version = "0.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ rusk-prover = "1.1.0"
 # rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
 rusk-recovery = "1.0.3"
 # rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
-# wallet-core = { version = "1.0.1", package = "dusk-wallet-core" }
-wallet-core = { version = "1.1.0", path = "./wallet-core/", package = "dusk-wallet-core" }
+wallet-core = { version = "1.1.0", package = "dusk-wallet-core" }
+# wallet-core = { version = "1.1.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 
 # Dusk dependencies outside the workspace
 bls12_381-bls = { version = "0.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = "2"
 # dusk-consensus = "1.0.1"
 dusk-consensus = { version = "1.0.2-alpha.1", path = "./consensus/" }
 # dusk-core = "1.0.0"
-dusk-core = { version = "1.0.1-alpha.1", path = "./core/" }
+dusk-core = { version = "1.1.0", path = "./core/" }
 # dusk-vm = "1.0.0"
 dusk-vm = { version = "1.0.1-alpha.1", path = "./vm/" }
 # node = { version = "1.0.1", package = "dusk-node" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ node = { version = "1.1.0", package = "dusk-node" }
 # node = { version = "1.1.0", path = "./node/", package = "dusk-node" }
 node-data = { version = "1.1.0", package = "dusk-node-data" }
 # node-data = { version = "1.1.0", path = "./node-data/", package = "dusk-node-data" }
-# rusk-profile = "1.0.1"
-rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
+rusk-profile = "1.0.1"
+# rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 # rusk-prover = "1.0.1"
 rusk-prover = { version = "1.0.2-alpha.1", path = "./rusk-prover/" }
 # rusk-recovery = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ dusk-consensus = { version = "1.0.2-alpha.1", path = "./consensus/" }
 dusk-core = "1.1.0"
 # dusk-core = { version = "1.1.0", path = "./core/" }
 # dusk-vm = "1.0.0"
-dusk-vm = { version = "1.0.1-alpha.1", path = "./vm/" }
+dusk-vm = { version = "1.1.0", path = "./vm/" }
 # node = { version = "1.0.1", package = "dusk-node" }
 node = { version = "1.0.2-alpha.1", path = "./node/", package = "dusk-node" }
 # node-data = { version = "1.0.1", package = "dusk-node-data" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ node-data = { version = "1.1.0", package = "dusk-node-data" }
 # node-data = { version = "1.1.0", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
-# rusk-prover = "1.0.1"
-rusk-prover = { version = "1.1.0", path = "./rusk-prover/" }
+rusk-prover = "1.1.0"
+# rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
 rusk-recovery = "1.0.3"
 # rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
 # wallet-core = { version = "1.0.1", package = "dusk-wallet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 # rusk-prover = "1.0.1"
 rusk-prover = { version = "1.0.2-alpha.1", path = "./rusk-prover/" }
-# rusk-recovery = "1.0.2"
-rusk-recovery = { version = "1.0.3", path = "./rusk-recovery/" }
+rusk-recovery = "1.0.3"
+# rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
 # wallet-core = { version = "1.0.1", package = "dusk-wallet-core" }
 wallet-core = { version = "1.0.2-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ dusk-vm = "1.1.0"
 # dusk-vm = { version = "1.1.0", path = "./vm/" }
 # node = { version = "1.0.1", package = "dusk-node" }
 node = { version = "1.0.2-alpha.1", path = "./node/", package = "dusk-node" }
-# node-data = { version = "1.0.1", package = "dusk-node-data" }
-node-data = { version = "1.1.0", path = "./node-data/", package = "dusk-node-data" }
+node-data = { version = "1.1.0", package = "dusk-node-data" }
+# node-data = { version = "1.1.0", path = "./node-data/", package = "dusk-node-data" }
 # rusk-profile = "1.0.1"
 rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 # rusk-prover = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ rusk-profile = "1.0.1"
 # rusk-prover = "1.0.1"
 rusk-prover = { version = "1.0.2-alpha.1", path = "./rusk-prover/" }
 # rusk-recovery = "1.0.2"
-rusk-recovery = { version = "1.0.3-alpha.1", path = "./rusk-recovery/" }
+rusk-recovery = { version = "1.0.3", path = "./rusk-recovery/" }
 # wallet-core = { version = "1.0.1", package = "dusk-wallet-core" }
 wallet-core = { version = "1.0.2-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ resolver = "2"
 # Workspace internal dependencies
 # dusk-consensus = "1.0.1"
 dusk-consensus = { version = "1.0.2-alpha.1", path = "./consensus/" }
-# dusk-core = "1.0.0"
-dusk-core = { version = "1.1.0", path = "./core/" }
+dusk-core = "1.1.0"
+# dusk-core = { version = "1.1.0", path = "./core/" }
 # dusk-vm = "1.0.0"
 dusk-vm = { version = "1.0.1-alpha.1", path = "./vm/" }
 # node = { version = "1.0.1", package = "dusk-node" }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-02-14
+
 ### Changed
 
 - Change `dusk_core::transfer::moonlight::Transaction::data` fn visibility to public
@@ -35,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3341]: https://github.com/dusk-network/rusk/issues/3341
 [#2773]: https://github.com/dusk-network/rusk/issues/2773
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-core-1.0.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-core-1.1.0...HEAD
+[1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-core-1.0.0...dusk-core-1.1.0
 [1.0.0]: https://github.com/dusk-network/rusk/compare/dusk-core-0.1.0...dusk-core-1.0.0
 [0.1.0]: https://github.com/dusk-network/rusk/tree/dusk-core-0.1.0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-core"
-version = "1.0.1-alpha.1"
+version = "1.1.0"
 edition = "2021"
 
 description = "Types used for interacting with Dusk's transfer and stake contracts."

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-core"
-version = "1.1.0"
+version = "1.1.1-alpha.1"
 edition = "2021"
 
 description = "Types used for interacting with Dusk's transfer and stake contracts."

--- a/node-data/CHANGELOG.md
+++ b/node-data/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-02-14
+
 ### Added
 
 - Add PartialEq, Eq to `BlockState` [#3359]
@@ -33,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3359]: https://github.com/dusk-network/rusk/issues/3359
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.0.1...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.1.0...HEAD
+[1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.0.1...dusk-node-data-1.1.0
 [1.0.1]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.0.0...dusk-node-data-1.0.1
 [1.0.0]: https://github.com/dusk-network/rusk/tree/dusk-node-data-1.0.0

--- a/node-data/Cargo.toml
+++ b/node-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-node-data"
-version = "1.1.0"
+version = "1.1.1-alpha.1"
 edition = "2021"
 
 description = "Types used for interacting with Dusk node."

--- a/node-data/Cargo.toml
+++ b/node-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-node-data"
-version = "1.0.2-alpha.1"
+version = "1.1.0"
 edition = "2021"
 
 description = "Types used for interacting with Dusk node."

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-02-14
+
 ### Added
 
 - Add `ledger_txs` to `Ledger` trait and Backend implementation [#3491]
@@ -39,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3407]: https://github.com/dusk-network/rusk/issues/3407
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-node-1.0.1...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-node-1.1.0...HEAD
+[1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-node-1.0.1...dusk-node-1.1.0
 [1.0.1]: https://github.com/dusk-network/rusk/compare/node-1.0.0...dusk-node-1.0.1
 [1.0.0]: https://github.com/dusk-network/rusk/tree/node-1.0.0

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-node"
-version = "1.0.2-alpha.1"
+version = "1.1.0"
 edition = "2021"
 autobins = false
 repository = "https://github.com/dusk-network/rusk"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-node"
-version = "1.1.0"
+version = "1.1.1-alpha.1"
 edition = "2021"
 autobins = false
 repository = "https://github.com/dusk-network/rusk"

--- a/rusk-prover/CHANGELOG.md
+++ b/rusk-prover/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `bls12_381-bls` to 0.5 [#2773]
+- Update `dusk-bls12_381` to 0.14 [#2773]
+- Update `dusk-jubjub` to 0.15.0 [#2773]
+- Update `dusk-plonk` to 0.21.0 [#2773]
+- Update `dusk-poseidon` to 0.41 [#2773]
+- Update `jubjub-schnorr` to 0.6 [#2773]
+- Update `phoenix-circuits` to 0.6 [#2773]
+- Update `phoenix-core` to 0.34.0 [#2773]
+- Update `poseidon-merkle` to 0.8 [#2773]
+
 ## [1.0.1] - 2025-01-23
 
 ### Changed

--- a/rusk-prover/CHANGELOG.md
+++ b/rusk-prover/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-02-14
+
 ### Changed
 
 - Update `bls12_381-bls` to 0.5 [#2773]
@@ -34,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Issues -->
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-prover-1.0.1...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-prover-1.1.0...HEAD
+[1.1.0]: https://github.com/dusk-network/rusk/compare/rusk-prover-1.0.1...rusk-prover-1.1.0
 [1.0.1]: https://github.com/dusk-network/rusk/compare/rusk-prover-1.0.0...rusk-prover-1.0.1
 [1.0.0]: https://github.com/dusk-network/rusk/tree/rusk-prover-1.0.0

--- a/rusk-prover/Cargo.toml
+++ b/rusk-prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-prover"
-version = "1.0.2-alpha.1"
+version = "1.1.0"
 edition = "2021"
 autobins = false
 

--- a/rusk-prover/Cargo.toml
+++ b/rusk-prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-prover"
-version = "1.1.0"
+version = "1.1.1-alpha.1"
 edition = "2021"
 autobins = false
 

--- a/rusk-recovery/CHANGELOG.md
+++ b/rusk-recovery/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2025-02-14
+
 ### Changed
 
 - Change deprecated `tempdir` with `tempfile` dependency [#3407]
@@ -25,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3407]: https://github.com/dusk-network/rusk/issues/3407
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-recovery-1.0.2...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-recovery-1.0.3...HEAD
+[1.0.3]: https://github.com/dusk-network/rusk/compare/rusk-recovery-1.0.2...rusk-recovery-1.0.3
 [1.0.2]: https://github.com/dusk-network/rusk/compare/rusk-recovery-1.0.1...rusk-recovery-1.0.2
 [1.0.1]: https://github.com/dusk-network/rusk/tree/rusk-recovery-1.0.1

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-recovery"
-version = "1.0.3"
+version = "1.0.4-alpha.1"
 edition = "2021"
 autobins = false
 description = "Tool to restore Rusk to factory settings"

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-recovery"
-version = "1.0.3-alpha.1"
+version = "1.0.3"
 edition = "2021"
 autobins = false
 description = "Tool to restore Rusk to factory settings"

--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-02-14
+
 ### Added
 
 - Add `abi::public_sender` [#3341]
@@ -369,7 +371,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#290]: https://github.com/dusk-network/rusk/issues/290
 
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.0.2...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.1.0...HEAD
+[1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.0.2...dusk-rusk-1.1.0
 [1.0.2]: https://github.com/dusk-network/rusk/compare/rusk-1.0.1...dusk-rusk-1.0.2
 [1.0.1]: https://github.com/dusk-network/rusk/compare/rusk-1.0.0...rusk-1.0.1
 [1.0.0]: https://github.com/dusk-network/rusk/compare/v0.8.0...rusk-1.0.0

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-rusk"
-version = "1.1.0"
+version = "1.1.1-alpha.1"
 edition = "2021"
 autobins = false
 

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-rusk"
-version = "1.1.0-rc.2"
+version = "1.1.0"
 edition = "2021"
 autobins = false
 

--- a/vm/CHANGELOG.md
+++ b/vm/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-02-14
+
 ### Added
 
 - Add `PUBLIC_SENDER` available to session [#3341]
@@ -35,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 [#3437]: https://github.com/dusk-network/rusk/issues/3437
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-vm-1.0.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-vm-1.1.0...HEAD
+[1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-vm-1.0.0...dusk-vm-1.1.0
 [1.0.0]: https://github.com/dusk-network/rusk/compare/dusk-vm-0.1.0...dusk-vm-1.0.0
 [0.1.0]: https://github.com/dusk-network/rusk/tree/dusk-vm-0.1.0

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-vm"
-version = "1.0.1-alpha.1"
+version = "1.1.0"
 edition = "2021"
 
 repository = "https://github.com/dusk-network/rusk"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-vm"
-version = "1.1.0"
+version = "1.1.1-alpha.1"
 edition = "2021"
 
 repository = "https://github.com/dusk-network/rusk"

--- a/wallet-core/CHANGELOG.md
+++ b/wallet-core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-02-14
+
 ### Changed
 
 - Changed phoenix function to allow data to be passed to transaction [#3438] 
@@ -25,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3438]: https://github.com/dusk-network/rusk/issues/3438
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-wallet-core-1.0.1...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-wallet-core-1.1.0...HEAD
+[1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-wallet-core-1.0.1...dusk-wallet-core-1.1.0
 [1.0.1]: https://github.com/dusk-network/rusk/compare/wallet-core-1.0.0...dusk-wallet-core-1.0.1
 [1.0.0]: https://github.com/dusk-network/rusk/tree/wallet-core-1.0.0

--- a/wallet-core/Cargo.toml
+++ b/wallet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "1.1.0"
+version = "1.1.1-alpha.1"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"

--- a/wallet-core/Cargo.toml
+++ b/wallet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "1.0.2-alpha.1"
+version = "1.1.0"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"


### PR DESCRIPTION

## [1.1.0] - 2025-02-14

### Added

- Add `abi::public_sender` [#3341]
- Add `[vm]` config section [#3341]
- Add CONTRACT_TO_ACCOUNT inflow case on archive moonlight filtering [#3494]
- Add Dockerfile for persistent state builds [#1080]
- Add `vm_config` section to `/on/node/info` [#3341]

### Changed

- Deprecate `[chain].gas_per_deploy_byte` config [#3341]
- Deprecate `[chain].min_deployment_gas_price` config [#3341]
- Deprecate `[chain].generation_timeout` config [#3341]
- Deprecate `[chain].min_deploy_points` config [#3341]
- Deprecate `[chain].block_gas_limit` config [#3341]
- Change how Rusk controls the archive for synchronization [#3359]
- Update `bls12_381-bls` to 0.5 [#2773]
- Update `dusk-bls12_381` to 0.14 [#2773]
- Update `dusk-jubjub` to 0.15.0 [#2773]
- Update `dusk-plonk` to 0.21.0 [#2773]
- Update `dusk-poseidon` to 0.41 [#2773]
- Update `jubjub-schnorr` to 0.6 [#2773]
- Update `phoenix-circuits` to 0.6 [#2773]
- Update `phoenix-core` to 0.34.0 [#2773]
- Update `poseidon-merkle` to 0.8 [#2773]

### Fixed

- Fix node unresponsiveness when querying contracts that take too long to terminate [#3481]

### Removed

- Remove legacy event system 
- Remove archive mpsc channel & archive event forwarding [#3359]

## [1.0.2] - 2025-01-27

### Added

- Add `/on/account:<address>/status` endpoint [#3422]

### Changed

- Change dependency declaration to not require strict equal [#3405]

## [1.0.1] - 2025-01-20

### Added

- Add `Rusk-Version-Strict` header for version match
- Add support for `cargo install`

### Changed

- Change `check_rusk_version` to ignore pre-release by default
- Increase archive channel capacity from 1000 to 10000 [#3359]
- Change `/static/drivers/wallet-core.wasm` to embed version `1.0.0`



[1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.0.2...dusk-rusk-1.1.0
[1.0.2]: https://github.com/dusk-network/rusk/compare/rusk-1.0.1...dusk-rusk-1.0.2
[1.0.1]: https://github.com/dusk-network/rusk/compare/rusk-1.0.0...rusk-1.0.1