### PR TITLE
rusk: change `prover` to include `recovery-keys` feature 

### DIFF
--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change plonk verification to use embed verification data by default [#3507]
 - Change responses for moonlight gql endpoints (archive node) [#3512]
+- Change `prover` feature to include `recovery-keys` feature [#3507]
 
 ## [1.1.1] - 2025-02-21
 

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -99,15 +99,14 @@ rustc_tools_util = { workspace = true }
 default = [
     "ephemeral",
     "recovery-state",
-    "recovery-keys",
     "prover",
     "chain",
     "http-wasm",
 ]
-ephemeral = ["dep:rusk-recovery", "dep:tempfile", "recovery-state", "chain"]
+ephemeral = ["recovery-state", "chain"]
 recovery-state = ["rusk-recovery/state", "dep:tempfile"]
 recovery-keys = ["rusk-recovery/keys"]
-prover = ["dep:rusk-prover"]
+prover = ["dep:rusk-prover", "recovery-keys"]
 testwallet = ["dep:futures"]
 chain = ["dep:node", "dep:dusk-consensus", "dep:node-data"]
 archive = ["chain", "node/archive", "dusk-core/serde"]

--- a/rusk/Makefile
+++ b/rusk/Makefile
@@ -59,7 +59,7 @@ bench: ## Run the benchmarks
 run:
 	@cargo r --release --bin rusk
 
-recovery-keys: ## Build circuit keys
+recovery-keys: ## Build prover keys
 	@cargo r \
 		--no-default-features \
 		--features recovery-keys \


### PR DESCRIPTION
See also #3507