### PR TITLE
consensus: Do not include Validation SV in case of NoQuorum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,26 +1620,6 @@ dependencies = [
 
 [[package]]
 name = "dusk-consensus"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ee3ebb760c676a9881b017139b7b478c0f3451bab19e4805ab97c8912114a5"
-dependencies = [
- "anyhow",
- "async-trait",
- "dusk-bytes",
- "dusk-core 1.2.1",
- "dusk-merkle",
- "dusk-node-data 1.2.0",
- "hex",
- "num-bigint",
- "sha3",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "dusk-consensus"
 version = "1.2.1-alpha.1"
 dependencies = [
  "anyhow",
@@ -1760,39 +1740,6 @@ dependencies = [
 
 [[package]]
 name = "dusk-node"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21c4785a846a6bdffe001df37d7e7bda02322faa3fc3039348a8b6ea1ef04ab"
-dependencies = [
- "anyhow",
- "async-channel",
- "async-trait",
- "dusk-bytes",
- "dusk-consensus 1.2.0",
- "dusk-core 1.2.1",
- "dusk-node-data 1.2.0",
- "hex",
- "humantime-serde",
- "kadcast",
- "memory-stats",
- "metrics",
- "metrics-exporter-prometheus",
- "native-tls",
- "rkyv",
- "rocksdb",
- "serde",
- "serde_json",
- "serde_with",
- "smallvec",
- "sqlx",
- "thiserror",
- "time-util",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "dusk-node"
 version = "1.2.1-alpha.1"
 dependencies = [
  "anyhow",
@@ -1800,7 +1747,7 @@ dependencies = [
  "async-trait",
  "criterion",
  "dusk-bytes",
- "dusk-consensus 1.2.0",
+ "dusk-consensus",
  "dusk-core 1.2.1",
  "dusk-node-data 1.2.0",
  "fake",
@@ -1929,9 +1876,9 @@ dependencies = [
  "criterion",
  "dirs",
  "dusk-bytes",
- "dusk-consensus 1.2.0",
+ "dusk-consensus",
  "dusk-core 1.2.1",
- "dusk-node 1.2.0",
+ "dusk-node",
  "dusk-node-data 1.2.0",
  "dusk-vm 1.2.0",
  "dusk-wallet-core 1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,14 @@ resolver = "2"
 
 [workspace.dependencies]
 # Workspace internal dependencies
-dusk-consensus = "1.2.0"
-# dusk-consensus = { version = "1.2.1-alpha.1", path = "./consensus/" }
+# dusk-consensus = "1.2.0"
+dusk-consensus = { version = "1.2.1-alpha.1", path = "./consensus/" }
 dusk-core = "1.2.1"
 # dusk-core = { version = "1.2.2-alpha.1", path = "./core/" }
 dusk-vm = "1.2.0"
 # dusk-vm = { version = "1.2.1-alpha.1", path = "./vm/" }
-node = { version = "1.2.0", package = "dusk-node" }
-# node = { version = "1.2.1-alpha.1", path = "./node/", package = "dusk-node" }
+# node = { version = "1.2.0", package = "dusk-node" }
+node = { version = "1.2.1-alpha.1", path = "./node/", package = "dusk-node" }
 node-data = { version = "1.2.0", package = "dusk-node-data" }
 # node-data = { version = "1.2.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"

--- a/consensus/CHANGELOG.md
+++ b/consensus/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix invalid Quorum message with NoQuorum result [#3543]
+- Fix `Quorum discarded` messages
+
+### Changed
+
+- Change `set_step_votes` to return an Attestation instead of a Quorum message
+- Remove `build_quorum_msg` from `AttInfoRegistry`
+
 ## [1.2.0] - 2025-03-20
 
 ### Fixed
@@ -19,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First `dusk-consensus` release
 
+<!-- Issues -->
+[#3543]: https://github.com/dusk-network/rusk/issues/3543
 
 [Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-consensus-1.2.0...HEAD
 [1.2.0]: https://github.com/dusk-network/rusk/compare/dusk-consensus-1.0.1...dusk-consensus-1.2.0

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -133,8 +133,7 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
                 future_msgs.lock().await.remove_msgs_by_round(ru.round - 1);
             }
 
-            let sv_registry =
-                Arc::new(Mutex::new(AttInfoRegistry::new(ru.clone())));
+            let sv_registry = Arc::new(Mutex::new(AttInfoRegistry::new()));
 
             let proposal_handler = Arc::new(Mutex::new(
                 proposal::handler::ProposalHandler::new(db.clone()),

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -220,11 +220,6 @@ impl MsgHandler for RatificationHandler {
             quorum_reached,
             &generator.expect("There must be a valid generator"),
         ) {
-            // INFO: we set Validation SV to our local result to always include
-            // a quorum-reaching (if any) SV even if the Ratification result is
-            // NoQuorum
-            let validation_sv = *self.validation_result.sv();
-
             let ch = ConsensusHeader {
                 prev_block_hash: ru.hash(),
                 round: ru.round,


### PR DESCRIPTION
Fix #3543

Changes:
 - Do not overwrite Validation StepVotes with local ones when building the Quorum message
   - This behavior was intended to allow tracing a quorum in Validation even when the Ratification outcome is NoQuorum; however, Validation signatures cannot be verified by other nodes because the Attestation only includes the resutl (i.e., the winning vote) of the Ratification step.
   - This also eliminate a duplicate construction of the Quorum message
 - Refactor AttestationRegistry:
   - change `set_step_votes` to return an Attestation instead of a Quorum message
   - Delete duplicate `build_quorum_msg`
   - remove unnecessary (now) RoundUpdate clone
   - update logs
 - Fix some duplicate and wrong Discarded Quorum log messages