### PR TITLE
rusk: release `1.2.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-node-data"
-version = "1.1.1-alpha.1"
+version = "1.2.0"
 dependencies = [
  "aes 0.7.5",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,7 +1952,7 @@ dependencies = [
  "rkyv",
  "rusk-profile 1.0.1",
  "rusk-prover 1.1.0",
- "rusk-recovery",
+ "rusk-recovery 1.0.3",
  "rustc_tools_util",
  "rustls-pemfile",
  "semver",
@@ -4541,6 +4541,35 @@ dependencies = [
  "rand 0.8.5",
  "rusk-profile 1.0.1",
  "tracing",
+]
+
+[[package]]
+name = "rusk-recovery"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e42cccdbd038aa1d17c4eb053a4817813adf2c6d68ea392bcc20efee1de78bc"
+dependencies = [
+ "bs58",
+ "cargo_toml",
+ "dusk-bytes",
+ "dusk-core 1.2.1",
+ "dusk-plonk",
+ "dusk-vm 1.2.0",
+ "ff",
+ "flate2",
+ "hex",
+ "http_req",
+ "rand 0.8.5",
+ "reqwest",
+ "rusk-profile 1.0.1",
+ "serde",
+ "serde_derive",
+ "tar",
+ "tokio",
+ "toml",
+ "tracing",
+ "url",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-node"
-version = "1.1.1-alpha.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,39 @@ dependencies = [
 [[package]]
 name = "dusk-node"
 version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21c4785a846a6bdffe001df37d7e7bda02322faa3fc3039348a8b6ea1ef04ab"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "async-trait",
+ "dusk-bytes",
+ "dusk-consensus 1.2.0",
+ "dusk-core 1.2.1",
+ "dusk-node-data 1.2.0",
+ "hex",
+ "humantime-serde",
+ "kadcast",
+ "memory-stats",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "native-tls",
+ "rkyv",
+ "rocksdb",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smallvec",
+ "sqlx",
+ "thiserror",
+ "time-util",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dusk-node"
+version = "1.2.1-alpha.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1898,7 +1931,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-consensus 1.2.0",
  "dusk-core 1.2.1",
- "dusk-node",
+ "dusk-node 1.2.0",
  "dusk-node-data 1.2.0",
  "dusk-vm 1.2.0",
  "dusk-wallet-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,7 +1934,7 @@ dependencies = [
  "dusk-node 1.2.0",
  "dusk-node-data 1.2.0",
  "dusk-vm 1.2.0",
- "dusk-wallet-core",
+ "dusk-wallet-core 1.1.0",
  "ff",
  "futures",
  "futures-util",
@@ -2030,6 +2030,25 @@ dependencies = [
  "piecrust",
  "rand 0.8.5",
  "rkyv",
+]
+
+[[package]]
+name = "dusk-wallet-core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4533c6298486bf3378dc0cd231613811a8973a037f6d94975f32d6e3a0f07f4f"
+dependencies = [
+ "blake3",
+ "bytecheck",
+ "dlmalloc",
+ "dusk-bytes",
+ "dusk-core 1.2.1",
+ "ff",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rkyv",
+ "sha2 0.10.8",
+ "zeroize",
 ]
 
 [[package]]
@@ -4616,7 +4635,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-core 1.2.1",
  "dusk-node-data 1.2.0",
- "dusk-wallet-core",
+ "dusk-wallet-core 1.1.0",
  "flume 0.10.14",
  "futures",
  "hex",
@@ -5272,7 +5291,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-core 1.2.1",
  "dusk-vm 1.2.0",
- "dusk-wallet-core",
+ "dusk-wallet-core 1.1.0",
  "ff",
  "rand 0.8.5",
  "rkyv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-consensus"
-version = "1.0.2-alpha.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,7 +1852,7 @@ dependencies = [
  "dusk-core 1.2.1",
  "dusk-node",
  "dusk-node-data",
- "dusk-vm",
+ "dusk-vm 1.2.0",
  "dusk-wallet-core",
  "ff",
  "futures",
@@ -1921,6 +1921,22 @@ dependencies = [
 [[package]]
 name = "dusk-vm"
 version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b332ca40ea76474cb0a07f4758b1a767481abf9172134a5c6f47d8f2f9de9196"
+dependencies = [
+ "blake2b_simd",
+ "blake3",
+ "dusk-bytes",
+ "dusk-core 1.2.1",
+ "dusk-poseidon",
+ "lru",
+ "piecrust",
+ "rkyv",
+]
+
+[[package]]
+name = "dusk-vm"
+version = "1.2.1-alpha.1"
 dependencies = [
  "blake2b_simd",
  "blake3",
@@ -4422,7 +4438,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-core 1.2.1",
  "dusk-plonk",
- "dusk-vm",
+ "dusk-vm 1.2.0",
  "ff",
  "flate2",
  "hex",
@@ -5112,7 +5128,7 @@ dependencies = [
  "criterion",
  "dusk-bytes",
  "dusk-core 1.2.1",
- "dusk-vm",
+ "dusk-vm 1.2.0",
  "dusk-wallet-core",
  "ff",
  "rand 0.8.5",
@@ -5595,7 +5611,7 @@ version = "0.10.1"
 dependencies = [
  "dusk-bytes",
  "dusk-core 1.2.1",
- "dusk-vm",
+ "dusk-vm 1.2.0",
  "ff",
  "rand 0.8.5",
  "ringbuffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-rusk"
-version = "1.1.2-alpha.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1869,7 +1869,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rkyv",
- "rusk-profile",
+ "rusk-profile 1.0.1",
  "rusk-prover",
  "rusk-recovery",
  "rustc_tools_util",
@@ -4402,6 +4402,23 @@ dependencies = [
 
 [[package]]
 name = "rusk-profile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "096be7f24357ebde8859b56c423b694278d4d151ab055b14d445dfd749efed69"
+dependencies = [
+ "blake3",
+ "console",
+ "dirs",
+ "hex",
+ "serde",
+ "sha2 0.10.8",
+ "toml",
+ "tracing",
+ "version_check",
+]
+
+[[package]]
+name = "rusk-profile"
 version = "1.0.2-alpha.1"
 dependencies = [
  "blake3",
@@ -4425,7 +4442,7 @@ dependencies = [
  "hex",
  "once_cell",
  "rand 0.8.5",
- "rusk-profile",
+ "rusk-profile 1.0.1",
  "tracing",
 ]
 
@@ -4445,7 +4462,7 @@ dependencies = [
  "http_req",
  "rand 0.8.5",
  "reqwest",
- "rusk-profile",
+ "rusk-profile 1.0.1",
  "serde",
  "serde_derive",
  "tar",
@@ -5616,7 +5633,7 @@ dependencies = [
  "rand 0.8.5",
  "ringbuffer",
  "rkyv",
- "rusk-profile",
+ "rusk-profile 1.0.1",
  "rusk-prover",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-core"
-version = "1.2.1-alpha.1"
+version = "1.2.1"
 dependencies = [
  "ark-bn254",
  "ark-groth16",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,6 +1777,7 @@ dependencies = [
  "memory-stats",
  "metrics",
  "metrics-exporter-prometheus",
+ "native-tls",
  "rand 0.8.5",
  "rkyv",
  "rocksdb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 name = "alice"
 version = "0.3.0"
 dependencies = [
- "dusk-core",
+ "dusk-core 1.2.1",
 ]
 
 [[package]]
@@ -767,7 +767,7 @@ version = "0.3.0"
 dependencies = [
  "bytecheck",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.2.1",
  "rkyv",
 ]
 
@@ -887,7 +887,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "charlie"
 version = "0.3.0"
 dependencies = [
- "dusk-core",
+ "dusk-core 1.2.1",
  "rkyv",
 ]
 
@@ -1626,7 +1626,7 @@ dependencies = [
  "async-trait",
  "criterion",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.2.1",
  "dusk-merkle",
  "dusk-node-data",
  "hex",
@@ -1641,6 +1641,35 @@ dependencies = [
 [[package]]
 name = "dusk-core"
 version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e65402ac9372ed205c58c5061a683a95d834fffe52efb8b240a5b2e0d682d22d"
+dependencies = [
+ "ark-bn254",
+ "ark-groth16",
+ "ark-relations",
+ "ark-serialize",
+ "bls12_381-bls 0.5.0",
+ "bytecheck",
+ "dusk-bls12_381 0.14.2",
+ "dusk-bytes",
+ "dusk-jubjub",
+ "dusk-plonk",
+ "dusk-poseidon",
+ "ff",
+ "jubjub-schnorr",
+ "phoenix-circuits",
+ "phoenix-core",
+ "piecrust-uplink",
+ "poseidon-merkle",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "dusk-core"
+version = "1.2.2-alpha.1"
 dependencies = [
  "ark-bn254",
  "ark-groth16",
@@ -1719,7 +1748,7 @@ dependencies = [
  "criterion",
  "dusk-bytes",
  "dusk-consensus",
- "dusk-core",
+ "dusk-core 1.2.1",
  "dusk-node-data",
  "fake",
  "hex",
@@ -1755,7 +1784,7 @@ dependencies = [
  "bs58",
  "chrono",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.2.1",
  "fake",
  "hex",
  "rand 0.8.5",
@@ -1820,7 +1849,7 @@ dependencies = [
  "dirs",
  "dusk-bytes",
  "dusk-consensus",
- "dusk-core",
+ "dusk-core 1.2.1",
  "dusk-node",
  "dusk-node-data",
  "dusk-vm",
@@ -1874,7 +1903,7 @@ name = "dusk-stake-contract-dd"
 version = "0.0.1-alpha.1"
 dependencies = [
  "dlmalloc",
- "dusk-core",
+ "dusk-core 1.2.1",
  "dusk-data-driver",
  "wasm-bindgen",
 ]
@@ -1884,7 +1913,7 @@ name = "dusk-transfer-contract-dd"
 version = "0.0.1-alpha.1"
 dependencies = [
  "dlmalloc",
- "dusk-core",
+ "dusk-core 1.2.1",
  "dusk-data-driver",
  "wasm-bindgen",
 ]
@@ -1896,7 +1925,7 @@ dependencies = [
  "blake2b_simd",
  "blake3",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.2.1",
  "dusk-poseidon",
  "ff",
  "lru",
@@ -1914,7 +1943,7 @@ dependencies = [
  "bytecheck",
  "dlmalloc",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.2.1",
  "ff",
  "hex",
  "hkdf",
@@ -2604,7 +2633,7 @@ name = "host_fn"
 version = "0.2.0"
 dependencies = [
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.2.1",
 ]
 
 [[package]]
@@ -4375,7 +4404,7 @@ name = "rusk-prover"
 version = "1.1.1-alpha.1"
 dependencies = [
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.2.1",
  "dusk-plonk",
  "hex",
  "once_cell",
@@ -4391,7 +4420,7 @@ dependencies = [
  "bs58",
  "cargo_toml",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.2.1",
  "dusk-plonk",
  "dusk-vm",
  "ff",
@@ -4426,7 +4455,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.2.1",
  "dusk-node-data",
  "dusk-wallet-core",
  "flume 0.10.14",
@@ -5082,7 +5111,7 @@ version = "0.8.0"
 dependencies = [
  "criterion",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.2.1",
  "dusk-vm",
  "dusk-wallet-core",
  "ff",
@@ -5565,7 +5594,7 @@ name = "transfer-contract"
 version = "0.10.1"
 dependencies = [
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.2.1",
  "dusk-vm",
  "ff",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-vm"
-version = "1.1.1-alpha.1"
+version = "1.2.0"
 dependencies = [
  "blake2b_simd",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-rusk"
-version = "1.2.0"
+version = "1.2.1-alpha.1"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,6 +1621,26 @@ dependencies = [
 [[package]]
 name = "dusk-consensus"
 version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ee3ebb760c676a9881b017139b7b478c0f3451bab19e4805ab97c8912114a5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "dusk-bytes",
+ "dusk-core 1.2.1",
+ "dusk-merkle",
+ "dusk-node-data 1.2.0",
+ "hex",
+ "num-bigint",
+ "sha3",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dusk-consensus"
+version = "1.2.1-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1747,7 +1767,7 @@ dependencies = [
  "async-trait",
  "criterion",
  "dusk-bytes",
- "dusk-consensus",
+ "dusk-consensus 1.2.0",
  "dusk-core 1.2.1",
  "dusk-node-data 1.2.0",
  "fake",
@@ -1875,7 +1895,7 @@ dependencies = [
  "criterion",
  "dirs",
  "dusk-bytes",
- "dusk-consensus",
+ "dusk-consensus 1.2.0",
  "dusk-core 1.2.1",
  "dusk-node",
  "dusk-node-data 1.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,7 +1870,7 @@ dependencies = [
  "reqwest",
  "rkyv",
  "rusk-profile 1.0.1",
- "rusk-prover",
+ "rusk-prover 1.1.0",
  "rusk-recovery",
  "rustc_tools_util",
  "rustls-pemfile",
@@ -4434,6 +4434,22 @@ dependencies = [
 
 [[package]]
 name = "rusk-prover"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469cbbdd11c2fde62fabe5ca710eb274d36aa01941a12625ac1b6c97320568db"
+dependencies = [
+ "dusk-bytes",
+ "dusk-core 1.2.1",
+ "dusk-plonk",
+ "hex",
+ "once_cell",
+ "rand 0.8.5",
+ "rusk-profile 1.0.1",
+ "tracing",
+]
+
+[[package]]
+name = "rusk-prover"
 version = "1.1.1-alpha.1"
 dependencies = [
  "dusk-bytes",
@@ -5150,7 +5166,7 @@ dependencies = [
  "ff",
  "rand 0.8.5",
  "rkyv",
- "rusk-prover",
+ "rusk-prover 1.1.0",
 ]
 
 [[package]]
@@ -5634,7 +5650,7 @@ dependencies = [
  "ringbuffer",
  "rkyv",
  "rusk-profile 1.0.1",
- "rusk-prover",
+ "rusk-prover 1.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-core 1.2.1",
  "dusk-merkle",
- "dusk-node-data",
+ "dusk-node-data 1.2.0",
  "hex",
  "num-bigint",
  "rand 0.8.5",
@@ -1749,7 +1749,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-consensus",
  "dusk-core 1.2.1",
- "dusk-node-data",
+ "dusk-node-data 1.2.0",
  "fake",
  "hex",
  "humantime-serde",
@@ -1775,6 +1775,33 @@ dependencies = [
 [[package]]
 name = "dusk-node-data"
 version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae940a1e0bc70154b013294c796d49c9679c9a9a57ee4ae80b5985b113a56ad"
+dependencies = [
+ "aes 0.7.5",
+ "anyhow",
+ "async-channel",
+ "base64 0.22.1",
+ "block-modes",
+ "bs58",
+ "chrono",
+ "dusk-bytes",
+ "dusk-core 1.2.1",
+ "fake",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.8",
+ "sha3",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "dusk-node-data"
+version = "1.2.1-alpha.1"
 dependencies = [
  "aes 0.7.5",
  "anyhow",
@@ -1851,7 +1878,7 @@ dependencies = [
  "dusk-consensus",
  "dusk-core 1.2.1",
  "dusk-node",
- "dusk-node-data",
+ "dusk-node-data 1.2.0",
  "dusk-vm 1.2.0",
  "dusk-wallet-core",
  "ff",
@@ -4505,7 +4532,7 @@ dependencies = [
  "dirs",
  "dusk-bytes",
  "dusk-core 1.2.1",
- "dusk-node-data",
+ "dusk-node-data 1.2.0",
  "dusk-wallet-core",
  "flume 0.10.14",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ resolver = "2"
 # dusk-consensus = "1.0.1"
 dusk-consensus = { version = "1.0.2-alpha.1", path = "./consensus/" }
 # dusk-core = "1.1.0"
-dusk-core = { version = "1.2.1-alpha.1", path = "./core/" }
+dusk-core = { version = "1.2.1", path = "./core/" }
 # dusk-vm = "1.1.0"
 dusk-vm = { version = "1.1.1-alpha.1", path = "./vm/" }
 # node = { version = "1.1.0", package = "dusk-node" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ resolver = "2"
 # Workspace internal dependencies
 # dusk-consensus = "1.0.1"
 dusk-consensus = { version = "1.0.2-alpha.1", path = "./consensus/" }
-# dusk-core = "1.1.0"
-dusk-core = { version = "1.2.1", path = "./core/" }
+dusk-core = "1.2.1"
+# dusk-core = { version = "1.2.2-alpha.1", path = "./core/" }
 # dusk-vm = "1.1.0"
 dusk-vm = { version = "1.1.1-alpha.1", path = "./vm/" }
 # node = { version = "1.1.0", package = "dusk-node" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ lru = "0.12.4"
 memory-stats = "1.2"
 metrics = "0.22.3"
 metrics-exporter-prometheus = "0.14"
+native-tls = { version = "<0.2.14" } # 0.2.14 requires rustc 1.80.0
 num-bigint = { version = "0.4.6", default-features = false }
 once_cell = "1.19"
 open = "2.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ dusk-consensus = { version = "1.0.2-alpha.1", path = "./consensus/" }
 dusk-core = "1.2.1"
 # dusk-core = { version = "1.2.2-alpha.1", path = "./core/" }
 # dusk-vm = "1.1.0"
-dusk-vm = { version = "1.1.1-alpha.1", path = "./vm/" }
+dusk-vm = { version = "1.2.0", path = "./vm/" }
 # node = { version = "1.1.0", package = "dusk-node" }
 node = { version = "1.1.1-alpha.1", path = "./node/", package = "dusk-node" }
 # node-data = { version = "1.1.0", package = "dusk-node-data" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ dusk-vm = "1.2.0"
 # dusk-vm = { version = "1.2.1-alpha.1", path = "./vm/" }
 # node = { version = "1.1.0", package = "dusk-node" }
 node = { version = "1.1.1-alpha.1", path = "./node/", package = "dusk-node" }
-# node-data = { version = "1.1.0", package = "dusk-node-data" }
-node-data = { version = "1.2.0", path = "./node-data/", package = "dusk-node-data" }
+node-data = { version = "1.2.0", package = "dusk-node-data" }
+# node-data = { version = "1.2.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 rusk-prover = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ rusk-prover = "1.1.0"
 # rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
 rusk-recovery = "1.0.3"
 # rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
-# wallet-core = { version = "1.1.0", package = "dusk-wallet-core" }
-wallet-core = { version = "1.1.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
+wallet-core = { version = "1.1.0", package = "dusk-wallet-core" }
+# wallet-core = { version = "1.1.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 
 dusk-data-driver = { version = "0.0.1-alpha.1", path = "./data-drivers/data-driver" }
 dusk-transfer-contract-dd = { version = "0.0.1-alpha.1", path = "./data-drivers/transfer-contract" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ resolver = "2"
 
 [workspace.dependencies]
 # Workspace internal dependencies
-# dusk-consensus = "1.0.1"
-dusk-consensus = { version = "1.2.0", path = "./consensus/" }
+dusk-consensus = "1.2.0"
+# dusk-consensus = { version = "1.2.1-alpha.1", path = "./consensus/" }
 dusk-core = "1.2.1"
 # dusk-core = { version = "1.2.2-alpha.1", path = "./core/" }
 dusk-vm = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ node = { version = "1.1.1-alpha.1", path = "./node/", package = "dusk-node" }
 node-data = { version = "1.1.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
-# rusk-prover = "1.1.0"
-rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
+rusk-prover = "1.1.0"
+# rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
 # rusk-recovery = "1.0.3"
 rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
 # wallet-core = { version = "1.1.0", package = "dusk-wallet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ dusk-core = "1.2.1"
 dusk-vm = "1.2.0"
 # dusk-vm = { version = "1.2.1-alpha.1", path = "./vm/" }
 # node = { version = "1.1.0", package = "dusk-node" }
-node = { version = "1.1.1-alpha.1", path = "./node/", package = "dusk-node" }
+node = { version = "1.2.0", path = "./node/", package = "dusk-node" }
 node-data = { version = "1.2.0", package = "dusk-node-data" }
 # node-data = { version = "1.2.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 rusk-prover = "1.1.0"
 # rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
-# rusk-recovery = "1.0.3"
-rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
+rusk-recovery = "1.0.3"
+# rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
 # wallet-core = { version = "1.1.0", package = "dusk-wallet-core" }
 wallet-core = { version = "1.1.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ resolver = "2"
 [workspace.dependencies]
 # Workspace internal dependencies
 # dusk-consensus = "1.0.1"
-dusk-consensus = { version = "1.0.2-alpha.1", path = "./consensus/" }
+dusk-consensus = { version = "1.2.0", path = "./consensus/" }
 dusk-core = "1.2.1"
 # dusk-core = { version = "1.2.2-alpha.1", path = "./core/" }
 dusk-vm = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ resolver = "2"
 dusk-consensus = { version = "1.0.2-alpha.1", path = "./consensus/" }
 dusk-core = "1.2.1"
 # dusk-core = { version = "1.2.2-alpha.1", path = "./core/" }
-# dusk-vm = "1.1.0"
-dusk-vm = { version = "1.2.0", path = "./vm/" }
+dusk-vm = "1.2.0"
+# dusk-vm = { version = "1.2.1-alpha.1", path = "./vm/" }
 # node = { version = "1.1.0", package = "dusk-node" }
 node = { version = "1.1.1-alpha.1", path = "./node/", package = "dusk-node" }
 # node-data = { version = "1.1.0", package = "dusk-node-data" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ dusk-vm = "1.2.0"
 # node = { version = "1.1.0", package = "dusk-node" }
 node = { version = "1.1.1-alpha.1", path = "./node/", package = "dusk-node" }
 # node-data = { version = "1.1.0", package = "dusk-node-data" }
-node-data = { version = "1.1.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
+node-data = { version = "1.2.0", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 rusk-prover = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ dusk-vm = "1.2.0"
 node = { version = "1.1.1-alpha.1", path = "./node/", package = "dusk-node" }
 # node-data = { version = "1.1.0", package = "dusk-node-data" }
 node-data = { version = "1.1.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
-# rusk-profile = "1.0.1"
-rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
+rusk-profile = "1.0.1"
+# rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 # rusk-prover = "1.1.0"
 rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
 # rusk-recovery = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ dusk-core = "1.2.1"
 # dusk-core = { version = "1.2.2-alpha.1", path = "./core/" }
 dusk-vm = "1.2.0"
 # dusk-vm = { version = "1.2.1-alpha.1", path = "./vm/" }
-# node = { version = "1.1.0", package = "dusk-node" }
-node = { version = "1.2.0", path = "./node/", package = "dusk-node" }
+node = { version = "1.2.0", package = "dusk-node" }
+# node = { version = "1.2.1-alpha.1", path = "./node/", package = "dusk-node" }
 node-data = { version = "1.2.0", package = "dusk-node-data" }
 # node-data = { version = "1.2.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"

--- a/consensus/CHANGELOG.md
+++ b/consensus/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-03-20
+
 ### Fixed
 
 - Fix `MismatchHeight` error message
@@ -18,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `dusk-consensus` release
 
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-consensus-1.0.1...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-consensus-1.2.0...HEAD
+[1.2.0]: https://github.com/dusk-network/rusk/compare/dusk-consensus-1.0.1...dusk-consensus-1.2.0
 [1.0.1]: https://github.com/dusk-network/rusk/compare/consensus-1.0.0...dusk-consensus-1.0.1
 [0.1.0]: https://github.com/dusk-network/rusk/tree/consensus-1.0.0
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-consensus"
-version = "1.0.2-alpha.1"
+version = "1.2.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/rusk"
 description = "Implementation of Dusk Succinct Attestation consensus protocol"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-consensus"
-version = "1.2.0"
+version = "1.2.1-alpha.1"
 edition = "2021"
 repository = "https://github.com/dusk-network/rusk"
 description = "Implementation of Dusk Succinct Attestation consensus protocol"

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2025-03-20
+
 ### Added
 
 - Add Serde JSON support for genesis contract args [#3533]
@@ -46,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3341]: https://github.com/dusk-network/rusk/issues/3341
 [#2773]: https://github.com/dusk-network/rusk/issues/2773
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-core-1.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-core-1.2.1...HEAD
+[1.2.1]: https://github.com/dusk-network/rusk/compare/dusk-core-1.1.0...dusk-core-1.2.1
 [1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-core-1.0.0...dusk-core-1.1.0
 [1.0.0]: https://github.com/dusk-network/rusk/compare/dusk-core-0.1.0...dusk-core-1.0.0
 [0.1.0]: https://github.com/dusk-network/rusk/tree/dusk-core-0.1.0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-core"
-version = "1.2.1-alpha.1"
+version = "1.2.1"
 edition = "2021"
 
 description = "Types used for interacting with Dusk's transfer and stake contracts."

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-core"
-version = "1.2.1"
+version = "1.2.2-alpha.1"
 edition = "2021"
 
 description = "Types used for interacting with Dusk's transfer and stake contracts."

--- a/node-data/CHANGELOG.md
+++ b/node-data/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-03-20
+
 ### Removed
 
 - Remove `WrappedContractId` [#3503]
@@ -40,7 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3359]: https://github.com/dusk-network/rusk/issues/3359
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.2.0...HEAD
+[1.2.0]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.1.0...dusk-node-data-1.2.0
 [1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.0.1...dusk-node-data-1.1.0
 [1.0.1]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.0.0...dusk-node-data-1.0.1
 [1.0.0]: https://github.com/dusk-network/rusk/tree/dusk-node-data-1.0.0

--- a/node-data/Cargo.toml
+++ b/node-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-node-data"
-version = "1.1.1-alpha.1"
+version = "1.2.0"
 edition = "2021"
 
 description = "Types used for interacting with Dusk node."

--- a/node-data/Cargo.toml
+++ b/node-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-node-data"
-version = "1.2.0"
+version = "1.2.1-alpha.1"
 edition = "2021"
 
 description = "Types used for interacting with Dusk node."

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-03-20
+
 ### Added
 
 - Add `create_if_missing` field to `DatabaseOptions`
@@ -46,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3407]: https://github.com/dusk-network/rusk/issues/3407
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-node-1.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-node-1.2.0...HEAD
+[1.2.0]: https://github.com/dusk-network/rusk/compare/dusk-node-1.1.0...dusk-node-1.2.0
 [1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-node-1.0.1...dusk-node-1.1.0
 [1.0.1]: https://github.com/dusk-network/rusk/compare/node-1.0.0...dusk-node-1.0.1
 [1.0.0]: https://github.com/dusk-network/rusk/tree/node-1.0.0

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -19,6 +19,7 @@ async-trait = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 async-channel = { workspace = true }
 time-util = { workspace = true, features = ["chrono"] }
+native-tls = { workspace = true } # 0.2.14 requires rustc 1.80.0
 
 rkyv = { workspace = true }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-node"
-version = "1.1.1-alpha.1"
+version = "1.2.0"
 edition = "2021"
 autobins = false
 repository = "https://github.com/dusk-network/rusk"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-node"
-version = "1.2.0"
+version = "1.2.1-alpha.1"
 edition = "2021"
 autobins = false
 repository = "https://github.com/dusk-network/rusk"

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -30,6 +30,8 @@ use tokio::sync::RwLock;
 use tokio::task::JoinSet;
 use tracing::{error, info, warn};
 
+use native_tls as _; // Required to satisfy unused_crate_dependencies
+
 /// Filter is used by Network implementor to filter messages before re-routing
 /// them. It's like the middleware in HTTP pipeline.
 ///

--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-03-20
+
 ### Added
 
 - Add simulate transaction API [#1225]
@@ -391,7 +393,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#290]: https://github.com/dusk-network/rusk/issues/290
 
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.1.1...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.2.0...HEAD
+[1.2.0]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.1.1...dusk-rusk-1.2.0
 [1.1.1]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.1.0...dusk-rusk-1.1.1
 [1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.0.2...dusk-rusk-1.1.0
 [1.0.2]: https://github.com/dusk-network/rusk/compare/rusk-1.0.1...dusk-rusk-1.0.2

--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change plonk verification to use embed verification data by default [#3507]
 - Change responses for moonlight gql endpoints (archive node) [#3512]
 - Change `prover` feature to include `recovery-keys` feature [#3507]
+- Change `piecrust` dependency to `0.28.0`
 
 ## [1.1.1] - 2025-02-21
 

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-rusk"
-version = "1.2.0"
+version = "1.2.1-alpha.1"
 edition = "2021"
 autobins = false
 

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-rusk"
-version = "1.1.2-alpha.1"
+version = "1.2.0"
 edition = "2021"
 autobins = false
 

--- a/vm/CHANGELOG.md
+++ b/vm/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-03-20
+
 ### Changed
 
 - Change piecrust version requirement to `0.28.0`
@@ -41,7 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 [#3437]: https://github.com/dusk-network/rusk/issues/3437
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-vm-1.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-vm-1.2.0...HEAD
+[1.2.0]: https://github.com/dusk-network/rusk/compare/dusk-vm-1.1.0...dusk-vm-1.2.0
 [1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-vm-1.0.0...dusk-vm-1.1.0
 [1.0.0]: https://github.com/dusk-network/rusk/compare/dusk-vm-0.1.0...dusk-vm-1.0.0
 [0.1.0]: https://github.com/dusk-network/rusk/tree/dusk-vm-0.1.0

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-vm"
-version = "1.2.0"
+version = "1.2.1-alpha.1"
 edition = "2021"
 
 repository = "https://github.com/dusk-network/rusk"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-vm"
-version = "1.1.1-alpha.1"
+version = "1.2.0"
 edition = "2021"
 
 repository = "https://github.com/dusk-network/rusk"


### PR DESCRIPTION
## [1.2.0] - 2025-03-20

### Added

- Add Serde JSON support for genesis contract args [#3533]
- Add `create_if_missing` field to `DatabaseOptions`
- Add support for `RUSK_EXT_CHAIN` env
- Add simulate transaction API [#1225]

### Changed

- Change piecrust version requirement to `0.28.0`
- Change `piecrust-uplink` version to `0.18.0`
- Change plonk verification to use embed verification data by default [#3507]
- Change responses for moonlight gql endpoints (archive node) [#3512]
- Change `prover` feature to include `recovery-keys` feature [#3507]

### Fixed

- Fix `MismatchHeight` error message

### Removed

- Remove `WrappedContractId` [#3503]


[1.2.0]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.1.1...dusk-rusk-1.2.0