### PR TITLE
explorer: Right-align provisioner rewards with uniform decimal digits

### DIFF
--- a/explorer/CHANGELOG.md
+++ b/explorer/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 
 ### Changed
 
+- Changed provisioner rewards column to be more readable
+
 ### Removed
 
 ### Fixed

--- a/explorer/src/lib/components/__tests__/__snapshots__/BlocksCard.spec.js.snap
+++ b/explorer/src/lib/components/__tests__/__snapshots__/BlocksCard.spec.js.snap
@@ -43,28 +43,28 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             class="table__row"
           >
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               Block
             </th>
             
              
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               Gas
             </th>
             
              
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               Txn(s)
             </th>
             
              
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               Rewards (Dusk)
             </th>
@@ -80,7 +80,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -99,7 +99,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="block__fee-avg-label"
@@ -121,14 +121,14 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               16
             </td>
@@ -140,7 +140,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -159,7 +159,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="block__fee-avg-label"
@@ -181,14 +181,14 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               16
             </td>
@@ -200,7 +200,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -219,7 +219,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="block__fee-avg-label"
@@ -241,14 +241,14 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               16
             </td>
@@ -260,7 +260,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -279,7 +279,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="block__fee-avg-label"
@@ -301,14 +301,14 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               16
             </td>
@@ -320,7 +320,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -339,7 +339,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="block__fee-avg-label"
@@ -361,14 +361,14 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               16
             </td>
@@ -380,7 +380,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -399,7 +399,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="block__fee-avg-label"
@@ -421,14 +421,14 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               16
             </td>
@@ -440,7 +440,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -459,7 +459,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="block__fee-avg-label"
@@ -481,14 +481,14 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               16
             </td>
@@ -500,7 +500,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -519,7 +519,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="block__fee-avg-label"
@@ -541,14 +541,14 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               16
             </td>
@@ -560,7 +560,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -579,7 +579,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="block__fee-avg-label"
@@ -601,14 +601,14 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               16
             </td>
@@ -620,7 +620,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -639,7 +639,7 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="block__fee-avg-label"
@@ -661,14 +661,14 @@ exports[`Blocks Card > should disable the \`Show More\` button if there is no mo
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               16
             </td>

--- a/explorer/src/lib/components/__tests__/__snapshots__/BlocksTable.spec.js.snap
+++ b/explorer/src/lib/components/__tests__/__snapshots__/BlocksTable.spec.js.snap
@@ -14,28 +14,28 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         class="table__row"
       >
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Block
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Gas
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Txn(s)
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Rewards (Dusk)
         </th>
@@ -51,7 +51,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -70,7 +70,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="block__fee-avg-label"
@@ -92,14 +92,14 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           16
         </td>
@@ -111,7 +111,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -130,7 +130,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="block__fee-avg-label"
@@ -152,14 +152,14 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           16
         </td>
@@ -171,7 +171,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -190,7 +190,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="block__fee-avg-label"
@@ -212,14 +212,14 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           16
         </td>
@@ -231,7 +231,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -250,7 +250,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="block__fee-avg-label"
@@ -272,14 +272,14 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           16
         </td>
@@ -291,7 +291,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -310,7 +310,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="block__fee-avg-label"
@@ -332,14 +332,14 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           16
         </td>
@@ -351,7 +351,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -370,7 +370,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="block__fee-avg-label"
@@ -392,14 +392,14 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           16
         </td>
@@ -411,7 +411,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -430,7 +430,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="block__fee-avg-label"
@@ -452,14 +452,14 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           16
         </td>
@@ -471,7 +471,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -490,7 +490,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="block__fee-avg-label"
@@ -512,14 +512,14 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           16
         </td>
@@ -531,7 +531,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -550,7 +550,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="block__fee-avg-label"
@@ -572,14 +572,14 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           16
         </td>
@@ -591,7 +591,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -610,7 +610,7 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="block__fee-avg-label"
@@ -632,14 +632,14 @@ exports[`Blocks Table > should render the \`BlocksTable\` component 1`] = `
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           16
         </td>

--- a/explorer/src/lib/components/__tests__/__snapshots__/ProvisionersCard.spec.js.snap
+++ b/explorer/src/lib/components/__tests__/__snapshots__/ProvisionersCard.spec.js.snap
@@ -43,37 +43,37 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               Staking Address
             </th>
             
              
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               Owner
             </th>
             
              
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               Stake
             </th>
             
              
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               Slashes
             </th>
             
              
             <th
-              class="table__header-cell"
+              class="table__header-cell align-right"
             >
-              Accumulated Reward (DUSK)
+              Accumulated Reward
             </th>
             
           </tr>
@@ -87,14 +87,14 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               m6dy2gz3jC...tW82FWtnpf
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-neutral"
@@ -107,7 +107,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__stake-data-label"
@@ -141,7 +141,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__slash-data-label"
@@ -164,9 +164,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-right"
             >
-              7,121.257296087
+              <span
+                data-tooltip-id="main-tooltip"
+                data-tooltip-place="top"
+                data-tooltip-text="7,121.257296087 DUSK"
+                data-tooltip-type="info"
+              >
+                7,121
+                .
+                <span
+                  class="decimal-shadow"
+                >
+                  26
+                </span>
+              </span>
             </td>
             
              
@@ -176,14 +189,14 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               m9dVuRgr3C...94r33pFQyz
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-neutral"
@@ -196,7 +209,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__stake-data-label"
@@ -230,7 +243,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__slash-data-label"
@@ -253,9 +266,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-right"
             >
-              6,923.840604194
+              <span
+                data-tooltip-id="main-tooltip"
+                data-tooltip-place="top"
+                data-tooltip-text="6,923.840604194 DUSK"
+                data-tooltip-type="info"
+              >
+                6,923
+                .
+                <span
+                  class="decimal-shadow"
+                >
+                  84
+                </span>
+              </span>
             </td>
             
              
@@ -265,14 +291,14 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               mHGvQ9Xdjz...iTfxTvgn7f
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-neutral"
@@ -285,7 +311,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__stake-data-label"
@@ -319,7 +345,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__slash-data-label"
@@ -342,9 +368,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-right"
             >
-              89.505343279
+              <span
+                data-tooltip-id="main-tooltip"
+                data-tooltip-place="top"
+                data-tooltip-text="89.505343279 DUSK"
+                data-tooltip-type="info"
+              >
+                89
+                .
+                <span
+                  class="decimal-shadow"
+                >
+                  51
+                </span>
+              </span>
             </td>
             
              
@@ -354,14 +393,14 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               mLx5HUo5Ph...BrRgEzoka8
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-neutral"
@@ -374,7 +413,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__stake-data-label"
@@ -408,7 +447,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__slash-data-label"
@@ -431,9 +470,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-right"
             >
-              29.633646022
+              <span
+                data-tooltip-id="main-tooltip"
+                data-tooltip-place="top"
+                data-tooltip-text="29.633646022 DUSK"
+                data-tooltip-type="info"
+              >
+                29
+                .
+                <span
+                  class="decimal-shadow"
+                >
+                  63
+                </span>
+              </span>
             </td>
             
              
@@ -443,14 +495,14 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               mTgXDqkyVa...gAseybAsfU
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-neutral"
@@ -463,7 +515,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__stake-data-label"
@@ -497,7 +549,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__slash-data-label"
@@ -520,9 +572,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-right"
             >
-              7,518.756679536
+              <span
+                data-tooltip-id="main-tooltip"
+                data-tooltip-place="top"
+                data-tooltip-text="7,518.756679536 DUSK"
+                data-tooltip-type="info"
+              >
+                7,518
+                .
+                <span
+                  class="decimal-shadow"
+                >
+                  76
+                </span>
+              </span>
             </td>
             
              
@@ -532,14 +597,14 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               mUJHMDEBiT...FHNxRNhoAA
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-neutral"
@@ -552,7 +617,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__stake-data-label"
@@ -586,7 +651,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__slash-data-label"
@@ -609,9 +674,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-right"
             >
-              73.800637305
+              <span
+                data-tooltip-id="main-tooltip"
+                data-tooltip-place="top"
+                data-tooltip-text="73.800637305 DUSK"
+                data-tooltip-type="info"
+              >
+                73
+                .
+                <span
+                  class="decimal-shadow"
+                >
+                  80
+                </span>
+              </span>
             </td>
             
              
@@ -621,14 +699,14 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               mUUpjnXow2...SfzQcywzaW
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-neutral"
@@ -641,7 +719,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__stake-data-label"
@@ -675,7 +753,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__slash-data-label"
@@ -698,9 +776,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-right"
             >
-              7,653.541671166
+              <span
+                data-tooltip-id="main-tooltip"
+                data-tooltip-place="top"
+                data-tooltip-text="7,653.541671166 DUSK"
+                data-tooltip-type="info"
+              >
+                7,653
+                .
+                <span
+                  class="decimal-shadow"
+                >
+                  54
+                </span>
+              </span>
             </td>
             
              
@@ -710,14 +801,14 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               mWvq9EWD9b...oU7BY2oEDe
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-neutral"
@@ -730,7 +821,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__stake-data-label"
@@ -764,7 +855,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__slash-data-label"
@@ -787,9 +878,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-right"
             >
-              1.613840782
+              <span
+                data-tooltip-id="main-tooltip"
+                data-tooltip-place="top"
+                data-tooltip-text="1.613840782 DUSK"
+                data-tooltip-type="info"
+              >
+                1
+                .
+                <span
+                  class="decimal-shadow"
+                >
+                  61
+                </span>
+              </span>
             </td>
             
              
@@ -799,14 +903,14 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               mXKJ97xTtr...JgkCK2o7x4
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-neutral"
@@ -819,7 +923,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__stake-data-label"
@@ -853,7 +957,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__slash-data-label"
@@ -876,9 +980,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-right"
             >
-              7,512.060104659
+              <span
+                data-tooltip-id="main-tooltip"
+                data-tooltip-place="top"
+                data-tooltip-text="7,512.060104659 DUSK"
+                data-tooltip-type="info"
+              >
+                7,512
+                .
+                <span
+                  class="decimal-shadow"
+                >
+                  06
+                </span>
+              </span>
             </td>
             
              
@@ -888,14 +1005,14 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               mdXsA3Ee1Y...K8VZPimZ2J
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-neutral"
@@ -908,7 +1025,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__stake-data-label"
@@ -942,7 +1059,7 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="provisioners-table__slash-data-label"
@@ -965,9 +1082,22 @@ exports[`Provisioners Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-right"
             >
-              7,973.118109253
+              <span
+                data-tooltip-id="main-tooltip"
+                data-tooltip-place="top"
+                data-tooltip-text="7,973.118109253 DUSK"
+                data-tooltip-type="info"
+              >
+                7,973
+                .
+                <span
+                  class="decimal-shadow"
+                >
+                  12
+                </span>
+              </span>
             </td>
             
              

--- a/explorer/src/lib/components/__tests__/__snapshots__/ProvisionersTable.spec.js.snap
+++ b/explorer/src/lib/components/__tests__/__snapshots__/ProvisionersTable.spec.js.snap
@@ -14,37 +14,37 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         class="table__row"
       >
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Staking Address
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Owner
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Stake
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Slashes
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-right"
         >
-          Accumulated Reward (DUSK)
+          Accumulated Reward
         </th>
         
       </tr>
@@ -58,14 +58,14 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           m6dy2gz3jC...tW82FWtnpf
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-neutral"
@@ -78,7 +78,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__stake-data-label"
@@ -112,7 +112,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__slash-data-label"
@@ -135,9 +135,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-right"
         >
-          7,121.257296087
+          <span
+            data-tooltip-id="main-tooltip"
+            data-tooltip-place="top"
+            data-tooltip-text="7,121.257296087 DUSK"
+            data-tooltip-type="info"
+          >
+            7,121
+            .
+            <span
+              class="decimal-shadow"
+            >
+              26
+            </span>
+          </span>
         </td>
         
          
@@ -147,14 +160,14 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           m9dVuRgr3C...94r33pFQyz
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-neutral"
@@ -167,7 +180,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__stake-data-label"
@@ -201,7 +214,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__slash-data-label"
@@ -224,9 +237,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-right"
         >
-          6,923.840604194
+          <span
+            data-tooltip-id="main-tooltip"
+            data-tooltip-place="top"
+            data-tooltip-text="6,923.840604194 DUSK"
+            data-tooltip-type="info"
+          >
+            6,923
+            .
+            <span
+              class="decimal-shadow"
+            >
+              84
+            </span>
+          </span>
         </td>
         
          
@@ -236,14 +262,14 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           mHGvQ9Xdjz...iTfxTvgn7f
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-neutral"
@@ -256,7 +282,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__stake-data-label"
@@ -290,7 +316,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__slash-data-label"
@@ -313,9 +339,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-right"
         >
-          89.505343279
+          <span
+            data-tooltip-id="main-tooltip"
+            data-tooltip-place="top"
+            data-tooltip-text="89.505343279 DUSK"
+            data-tooltip-type="info"
+          >
+            89
+            .
+            <span
+              class="decimal-shadow"
+            >
+              51
+            </span>
+          </span>
         </td>
         
          
@@ -325,14 +364,14 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           mLx5HUo5Ph...BrRgEzoka8
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-neutral"
@@ -345,7 +384,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__stake-data-label"
@@ -379,7 +418,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__slash-data-label"
@@ -402,9 +441,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-right"
         >
-          29.633646022
+          <span
+            data-tooltip-id="main-tooltip"
+            data-tooltip-place="top"
+            data-tooltip-text="29.633646022 DUSK"
+            data-tooltip-type="info"
+          >
+            29
+            .
+            <span
+              class="decimal-shadow"
+            >
+              63
+            </span>
+          </span>
         </td>
         
          
@@ -414,14 +466,14 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           mTgXDqkyVa...gAseybAsfU
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-neutral"
@@ -434,7 +486,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__stake-data-label"
@@ -468,7 +520,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__slash-data-label"
@@ -491,9 +543,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-right"
         >
-          7,518.756679536
+          <span
+            data-tooltip-id="main-tooltip"
+            data-tooltip-place="top"
+            data-tooltip-text="7,518.756679536 DUSK"
+            data-tooltip-type="info"
+          >
+            7,518
+            .
+            <span
+              class="decimal-shadow"
+            >
+              76
+            </span>
+          </span>
         </td>
         
          
@@ -503,14 +568,14 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           mUJHMDEBiT...FHNxRNhoAA
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-neutral"
@@ -523,7 +588,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__stake-data-label"
@@ -557,7 +622,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__slash-data-label"
@@ -580,9 +645,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-right"
         >
-          73.800637305
+          <span
+            data-tooltip-id="main-tooltip"
+            data-tooltip-place="top"
+            data-tooltip-text="73.800637305 DUSK"
+            data-tooltip-type="info"
+          >
+            73
+            .
+            <span
+              class="decimal-shadow"
+            >
+              80
+            </span>
+          </span>
         </td>
         
          
@@ -592,14 +670,14 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           mUUpjnXow2...SfzQcywzaW
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-neutral"
@@ -612,7 +690,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__stake-data-label"
@@ -646,7 +724,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__slash-data-label"
@@ -669,9 +747,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-right"
         >
-          7,653.541671166
+          <span
+            data-tooltip-id="main-tooltip"
+            data-tooltip-place="top"
+            data-tooltip-text="7,653.541671166 DUSK"
+            data-tooltip-type="info"
+          >
+            7,653
+            .
+            <span
+              class="decimal-shadow"
+            >
+              54
+            </span>
+          </span>
         </td>
         
          
@@ -681,14 +772,14 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           mWvq9EWD9b...oU7BY2oEDe
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-neutral"
@@ -701,7 +792,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__stake-data-label"
@@ -735,7 +826,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__slash-data-label"
@@ -758,9 +849,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-right"
         >
-          1.613840782
+          <span
+            data-tooltip-id="main-tooltip"
+            data-tooltip-place="top"
+            data-tooltip-text="1.613840782 DUSK"
+            data-tooltip-type="info"
+          >
+            1
+            .
+            <span
+              class="decimal-shadow"
+            >
+              61
+            </span>
+          </span>
         </td>
         
          
@@ -770,14 +874,14 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           mXKJ97xTtr...JgkCK2o7x4
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-neutral"
@@ -790,7 +894,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__stake-data-label"
@@ -824,7 +928,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__slash-data-label"
@@ -847,9 +951,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-right"
         >
-          7,512.060104659
+          <span
+            data-tooltip-id="main-tooltip"
+            data-tooltip-place="top"
+            data-tooltip-text="7,512.060104659 DUSK"
+            data-tooltip-type="info"
+          >
+            7,512
+            .
+            <span
+              class="decimal-shadow"
+            >
+              06
+            </span>
+          </span>
         </td>
         
          
@@ -859,14 +976,14 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           mdXsA3Ee1Y...K8VZPimZ2J
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-neutral"
@@ -879,7 +996,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__stake-data-label"
@@ -913,7 +1030,7 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="provisioners-table__slash-data-label"
@@ -936,9 +1053,22 @@ exports[`Provisioners Table > should render the \`ProvisionersTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-right"
         >
-          7,973.118109253
+          <span
+            data-tooltip-id="main-tooltip"
+            data-tooltip-place="top"
+            data-tooltip-text="7,973.118109253 DUSK"
+            data-tooltip-type="info"
+          >
+            7,973
+            .
+            <span
+              class="decimal-shadow"
+            >
+              12
+            </span>
+          </span>
         </td>
         
          

--- a/explorer/src/lib/components/__tests__/__snapshots__/Table.spec.js.snap
+++ b/explorer/src/lib/components/__tests__/__snapshots__/Table.spec.js.snap
@@ -18,13 +18,13 @@ exports[`Table > renders the TableBody component 1`] = `
 
 exports[`Table > renders the TableCell component 1`] = `
 <td
-  class="table__data-cell"
+  class="table__data-cell align-left"
 />
 `;
 
 exports[`Table > renders the TableCell component as a head cell 1`] = `
 <th
-  class="table__header-cell"
+  class="table__header-cell align-left"
 />
 `;
 

--- a/explorer/src/lib/components/__tests__/__snapshots__/TransactionsCard.spec.js.snap
+++ b/explorer/src/lib/components/__tests__/__snapshots__/TransactionsCard.spec.js.snap
@@ -84,35 +84,35 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               ID
             </th>
             
              
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               Gas
             </th>
             
              
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               Fee (DUSK)
             </th>
             
              
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               Status
             </th>
             
              
             <th
-              class="table__header-cell"
+              class="table__header-cell align-left"
             >
               Type
             </th>
@@ -128,7 +128,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -147,7 +147,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="transaction__fee-price-label"
@@ -169,14 +169,14 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0.008221117
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -187,7 +187,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <div
                 class="transaction-type"
@@ -223,7 +223,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -242,7 +242,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="transaction__fee-price-label"
@@ -264,14 +264,14 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0.008221117
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -282,7 +282,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <div
                 class="transaction-type"
@@ -318,7 +318,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -337,7 +337,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="transaction__fee-price-label"
@@ -359,14 +359,14 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0.008220846
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -377,7 +377,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <div
                 class="transaction-type"
@@ -413,7 +413,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -432,7 +432,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="transaction__fee-price-label"
@@ -454,14 +454,14 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0.008221266
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -472,7 +472,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <div
                 class="transaction-type"
@@ -508,7 +508,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -527,7 +527,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="transaction__fee-price-label"
@@ -549,14 +549,14 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0.008220422
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -567,7 +567,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <div
                 class="transaction-type"
@@ -603,7 +603,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -622,7 +622,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="transaction__fee-price-label"
@@ -644,14 +644,14 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0.008220926
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -662,7 +662,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <div
                 class="transaction-type"
@@ -698,7 +698,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -717,7 +717,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="transaction__fee-price-label"
@@ -739,14 +739,14 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0.008221243
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -757,7 +757,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <div
                 class="transaction-type"
@@ -793,7 +793,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -812,7 +812,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="transaction__fee-price-label"
@@ -834,14 +834,14 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0.008220934
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -852,7 +852,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <div
                 class="transaction-type"
@@ -888,7 +888,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -907,7 +907,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="transaction__fee-price-label"
@@ -929,14 +929,14 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0.008220989
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -947,7 +947,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <div
                 class="transaction-type"
@@ -983,7 +983,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             class="table__row"
           >
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <a
                 class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1002,7 +1002,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <b
                 class="transaction__fee-price-label"
@@ -1024,14 +1024,14 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               0.008221018
             </td>
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <span
                 class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -1042,7 +1042,7 @@ exports[`Transactions Card > should disable the \`Show More\` button if there is
             
              
             <td
-              class="table__data-cell"
+              class="table__data-cell align-left"
             >
               <div
                 class="transaction-type"

--- a/explorer/src/lib/components/__tests__/__snapshots__/TransactionsTable.spec.js.snap
+++ b/explorer/src/lib/components/__tests__/__snapshots__/TransactionsTable.spec.js.snap
@@ -14,35 +14,35 @@ exports[`Transactions Table > should pass additional class names to the rendered
         class="table__row"
       >
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           ID
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Gas
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Fee (DUSK)
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Status
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Type
         </th>
@@ -58,7 +58,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -77,7 +77,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -99,14 +99,14 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221117
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -117,7 +117,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -153,7 +153,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -172,7 +172,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -194,14 +194,14 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221117
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -212,7 +212,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -248,7 +248,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -267,7 +267,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -289,14 +289,14 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220846
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -307,7 +307,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -343,7 +343,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -362,7 +362,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -384,14 +384,14 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221266
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -402,7 +402,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -438,7 +438,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -457,7 +457,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -479,14 +479,14 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220422
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -497,7 +497,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -533,7 +533,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -552,7 +552,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -574,14 +574,14 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220926
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -592,7 +592,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -628,7 +628,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -647,7 +647,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -669,14 +669,14 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221243
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -687,7 +687,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -723,7 +723,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -742,7 +742,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -764,14 +764,14 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220934
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -782,7 +782,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -818,7 +818,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -837,7 +837,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -859,14 +859,14 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220989
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -877,7 +877,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -913,7 +913,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -932,7 +932,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -954,14 +954,14 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221018
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -972,7 +972,7 @@ exports[`Transactions Table > should pass additional class names to the rendered
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -1023,7 +1023,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           ID
         </th>
@@ -1031,21 +1031,21 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
          
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Fee (DUSK)
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Status
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Type
         </th>
@@ -1061,7 +1061,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1081,14 +1081,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
          
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221117
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -1099,7 +1099,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -1135,7 +1135,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1155,14 +1155,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
          
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221117
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -1173,7 +1173,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -1209,7 +1209,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1229,14 +1229,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
          
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220846
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -1247,7 +1247,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -1283,7 +1283,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1303,14 +1303,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
          
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221266
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -1321,7 +1321,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -1357,7 +1357,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1377,14 +1377,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
          
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220422
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -1395,7 +1395,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -1431,7 +1431,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1451,14 +1451,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
          
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220926
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -1469,7 +1469,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -1505,7 +1505,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1525,14 +1525,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
          
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221243
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -1543,7 +1543,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -1579,7 +1579,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1599,14 +1599,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
          
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220934
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -1617,7 +1617,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -1653,7 +1653,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1673,14 +1673,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
          
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220989
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -1691,7 +1691,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -1727,7 +1727,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1747,14 +1747,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
          
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221018
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -1765,7 +1765,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -1816,35 +1816,35 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           ID
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Gas
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Fee (DUSK)
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Status
         </th>
         
          
         <th
-          class="table__header-cell"
+          class="table__header-cell align-left"
         >
           Type
         </th>
@@ -1860,7 +1860,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1879,7 +1879,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -1901,14 +1901,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221117
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -1919,7 +1919,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -1955,7 +1955,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -1974,7 +1974,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -1996,14 +1996,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221117
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2014,7 +2014,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -2050,7 +2050,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2069,7 +2069,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -2091,14 +2091,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220846
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2109,7 +2109,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -2145,7 +2145,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2164,7 +2164,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -2186,14 +2186,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221266
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2204,7 +2204,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -2240,7 +2240,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2259,7 +2259,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -2281,14 +2281,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220422
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2299,7 +2299,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -2335,7 +2335,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2354,7 +2354,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -2376,14 +2376,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220926
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2394,7 +2394,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -2430,7 +2430,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2449,7 +2449,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -2471,14 +2471,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221243
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2489,7 +2489,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -2525,7 +2525,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2544,7 +2544,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -2566,14 +2566,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220934
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2584,7 +2584,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -2620,7 +2620,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2639,7 +2639,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -2661,14 +2661,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008220989
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2679,7 +2679,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"
@@ -2715,7 +2715,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         class="table__row"
       >
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <a
             class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2734,7 +2734,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <b
             class="transaction__fee-price-label"
@@ -2756,14 +2756,14 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           0.008221018
         </td>
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <span
             class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2774,7 +2774,7 @@ exports[`Transactions Table > should render the \`TransactionsTable\` component 
         
          
         <td
-          class="table__data-cell"
+          class="table__data-cell align-left"
         >
           <div
             class="transaction-type"

--- a/explorer/src/lib/components/provisioners-table/ProvisionersTable.svelte
+++ b/explorer/src/lib/components/provisioners-table/ProvisionersTable.svelte
@@ -27,6 +27,8 @@
 
   const numberFormatter = createValueFormatter("en");
 
+  const fixedNumberFormatter = createValueFormatter("en", 2, 2);
+
   $: classes = makeClassName(["provisioners-table", className]);
 </script>
 
@@ -37,7 +39,7 @@
       <TableCell type="th">Owner</TableCell>
       <TableCell type="th">Stake</TableCell>
       <TableCell type="th">Slashes</TableCell>
-      <TableCell type="th">Accumulated Reward (DUSK)</TableCell>
+      <TableCell type="th" align="right">Accumulated Reward</TableCell>
     </TableRow>
   </TableHead>
   <TableBody>
@@ -73,7 +75,21 @@
           <b class="provisioners-table__slash-data-label">Hard:</b>
           {numberFormatter(provisioner.hard_faults)}
         </TableCell>
-        <TableCell>{numberFormatter(luxToDusk(provisioner.reward))}</TableCell>
+        {@const parts = fixedNumberFormatter(
+          luxToDusk(provisioner.reward)
+        ).split(".")}
+        <TableCell align="right">
+          <span
+            data-tooltip-id="main-tooltip"
+            data-tooltip-place="top"
+            data-tooltip-type="info"
+            data-tooltip-text="{numberFormatter(
+              luxToDusk(provisioner.reward)
+            )} DUSK"
+          >
+            {parts[0]}.<span class="decimal-shadow">{parts[1]}</span>
+          </span>
+        </TableCell>
       </TableRow>
     {/each}
   </TableBody>

--- a/explorer/src/lib/components/table/Table.css
+++ b/explorer/src/lib/components/table/Table.css
@@ -31,6 +31,19 @@
   font-size: 0.75rem;
 }
 
+.table__header-cell.align-left,
+.table__data-cell.align-left {
+  text-align: left;
+}
+.table__header-cell.align-center,
+.table__data-cell.align-center {
+  text-align: center;
+}
+.table__header-cell.align-right,
+.table__data-cell.align-right {
+  text-align: right;
+}
+
 .table__row:hover {
   background-color: var(--on-primary-color);
 }

--- a/explorer/src/lib/components/table/TableCell.svelte
+++ b/explorer/src/lib/components/table/TableCell.svelte
@@ -1,11 +1,19 @@
 <script>
+  import { makeClassName } from "$lib/dusk/string";
+
   /** @type {"td" | "th"} */
   export let type = "td";
+
+  /** @type {"left" | "center" | "right" | Undefined} */
+  export let align = "left";
 </script>
 
 <svelte:element
   this={type}
-  class={type === "td" ? "table__data-cell" : "table__header-cell"}
+  class={makeClassName([
+    type === "td" ? "table__data-cell" : "table__header-cell",
+    align ? `align-${align}` : "",
+  ])}
 >
   <slot />
 </svelte:element>

--- a/explorer/src/lib/dusk/value/createValueFormatter.js
+++ b/explorer/src/lib/dusk/value/createValueFormatter.js
@@ -2,12 +2,18 @@
  * Creates a locale aware currency formatter for fiat or DUSK
  *
  * @param {String} locale A BCP 47 language tag
+ * @param {Number} minFractionDigits The minimum fraction digits that should display
+ * @param {Number} maxFractionDigits The maximum fraction digits that should display
  * @returns {(value: number | bigint) => string}
  */
-const createFormatter = (locale) => {
+const createFormatter = (
+  locale,
+  minFractionDigits = 0,
+  maxFractionDigits = 9
+) => {
   const formatter = new Intl.NumberFormat(locale, {
-    maximumFractionDigits: 9,
-    minimumFractionDigits: 0,
+    maximumFractionDigits: maxFractionDigits,
+    minimumFractionDigits: minFractionDigits,
   });
 
   return (value) => formatter.format(value);

--- a/explorer/src/routes/__tests__/__snapshots__/page.spec.js.snap
+++ b/explorer/src/routes/__tests__/__snapshots__/page.spec.js.snap
@@ -1856,28 +1856,28 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   Block
                 </th>
                 
                  
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   Gas
                 </th>
                 
                  
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   Txn(s)
                 </th>
                 
                  
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   Rewards (Dusk)
                 </th>
@@ -1893,7 +1893,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -1912,7 +1912,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -1934,14 +1934,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -1953,7 +1953,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -1972,7 +1972,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -1994,14 +1994,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2013,7 +2013,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2032,7 +2032,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2054,14 +2054,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2073,7 +2073,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2092,7 +2092,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2114,14 +2114,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2133,7 +2133,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2152,7 +2152,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2174,14 +2174,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2193,7 +2193,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2212,7 +2212,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2234,14 +2234,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2253,7 +2253,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2272,7 +2272,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2294,14 +2294,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2313,7 +2313,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2332,7 +2332,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2354,14 +2354,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2373,7 +2373,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2392,7 +2392,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2414,14 +2414,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2433,7 +2433,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2452,7 +2452,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2474,14 +2474,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2493,7 +2493,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2512,7 +2512,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2534,14 +2534,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2553,7 +2553,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2572,7 +2572,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2594,14 +2594,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2613,7 +2613,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2632,7 +2632,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2654,14 +2654,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2673,7 +2673,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2692,7 +2692,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2714,14 +2714,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2733,7 +2733,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2752,7 +2752,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="block__fee-avg-label"
@@ -2774,14 +2774,14 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   16
                 </td>
@@ -2840,7 +2840,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   ID
                 </th>
@@ -2848,21 +2848,21 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   Fee (DUSK)
                 </th>
                 
                  
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   Status
                 </th>
                 
                  
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   Type
                 </th>
@@ -2878,7 +2878,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2898,14 +2898,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.008221117
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2916,7 +2916,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -2952,7 +2952,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2972,14 +2972,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.008221117
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2990,7 +2990,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3026,7 +3026,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3046,14 +3046,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.008220846
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3064,7 +3064,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3100,7 +3100,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3120,14 +3120,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.008221266
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3138,7 +3138,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3174,7 +3174,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3194,14 +3194,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.000215552
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3212,7 +3212,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3248,7 +3248,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3268,14 +3268,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.000215617
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3286,7 +3286,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3322,7 +3322,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3342,14 +3342,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.000214413
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3360,7 +3360,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3396,7 +3396,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3416,14 +3416,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.000291769
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3434,7 +3434,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3470,7 +3470,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3490,14 +3490,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.008220926
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3508,7 +3508,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3544,7 +3544,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3564,14 +3564,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.008221243
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3582,7 +3582,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3618,7 +3618,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3638,14 +3638,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.008220934
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3656,7 +3656,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3692,7 +3692,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3712,14 +3712,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.008220989
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3730,7 +3730,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3766,7 +3766,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3786,14 +3786,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.008221018
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3804,7 +3804,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3840,7 +3840,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3860,14 +3860,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.008220865
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3878,7 +3878,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -3914,7 +3914,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3934,14 +3934,14 @@ exports[`home page > should render the home page, start polling for the latest c
                  
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.008221367
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3952,7 +3952,7 @@ exports[`home page > should render the home page, start polling for the latest c
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"

--- a/explorer/src/routes/blocks/__tests__/__snapshots__/page.spec.js.snap
+++ b/explorer/src/routes/blocks/__tests__/__snapshots__/page.spec.js.snap
@@ -2035,28 +2035,28 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 Block
               </th>
               
                
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 Gas
               </th>
               
                
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 Txn(s)
               </th>
               
                
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 Rewards (Dusk)
               </th>
@@ -2072,7 +2072,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2091,7 +2091,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2113,14 +2113,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2132,7 +2132,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2151,7 +2151,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2173,14 +2173,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2192,7 +2192,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2211,7 +2211,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2233,14 +2233,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2252,7 +2252,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2271,7 +2271,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2293,14 +2293,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2312,7 +2312,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2331,7 +2331,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2353,14 +2353,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2372,7 +2372,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2391,7 +2391,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2413,14 +2413,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2432,7 +2432,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2451,7 +2451,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2473,14 +2473,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2492,7 +2492,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2511,7 +2511,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2533,14 +2533,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2552,7 +2552,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2571,7 +2571,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2593,14 +2593,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2612,7 +2612,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2631,7 +2631,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2653,14 +2653,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2672,7 +2672,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2691,7 +2691,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2713,14 +2713,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2732,7 +2732,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2751,7 +2751,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2773,14 +2773,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2792,7 +2792,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2811,7 +2811,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2833,14 +2833,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2852,7 +2852,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2871,7 +2871,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2893,14 +2893,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>
@@ -2912,7 +2912,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface block__link"
@@ -2931,7 +2931,7 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="block__fee-avg-label"
@@ -2953,14 +2953,14 @@ exports[`Blocks page > should render the Blocks page, start polling for blocks a
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 16
               </td>

--- a/explorer/src/routes/blocks/block/__tests__/__snapshots__/page.spec.js.snap
+++ b/explorer/src/routes/blocks/block/__tests__/__snapshots__/page.spec.js.snap
@@ -552,35 +552,35 @@ exports[`Block Details > should render the Block Details page and query the nece
                 class="table__row"
               >
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   ID
                 </th>
                 
                  
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   Gas
                 </th>
                 
                  
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   Fee (DUSK)
                 </th>
                 
                  
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   Status
                 </th>
                 
                  
                 <th
-                  class="table__header-cell"
+                  class="table__header-cell align-left"
                 >
                   Type
                 </th>
@@ -596,7 +596,7 @@ exports[`Block Details > should render the Block Details page and query the nece
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -615,7 +615,7 @@ exports[`Block Details > should render the Block Details page and query the nece
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="transaction__fee-price-label"
@@ -637,14 +637,14 @@ exports[`Block Details > should render the Block Details page and query the nece
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.000290866
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -655,7 +655,7 @@ exports[`Block Details > should render the Block Details page and query the nece
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"
@@ -691,7 +691,7 @@ exports[`Block Details > should render the Block Details page and query the nece
                 class="table__row"
               >
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <a
                     class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -710,7 +710,7 @@ exports[`Block Details > should render the Block Details page and query the nece
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <b
                     class="transaction__fee-price-label"
@@ -732,14 +732,14 @@ exports[`Block Details > should render the Block Details page and query the nece
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   0.000289852
                 </td>
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <span
                     class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -750,7 +750,7 @@ exports[`Block Details > should render the Block Details page and query the nece
                 
                  
                 <td
-                  class="table__data-cell"
+                  class="table__data-cell align-left"
                 >
                   <div
                     class="transaction-type"

--- a/explorer/src/routes/provisioners/__tests__/__snapshots__/page.spec.js.snap
+++ b/explorer/src/routes/provisioners/__tests__/__snapshots__/page.spec.js.snap
@@ -4142,37 +4142,37 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 Staking Address
               </th>
               
                
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 Owner
               </th>
               
                
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 Stake
               </th>
               
                
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 Slashes
               </th>
               
                
               <th
-                class="table__header-cell"
+                class="table__header-cell align-right"
               >
-                Accumulated Reward (DUSK)
+                Accumulated Reward
               </th>
               
             </tr>
@@ -4186,14 +4186,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 m6dy2gz3jC...tW82FWtnpf
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -4206,7 +4206,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -4240,7 +4240,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -4263,9 +4263,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                7,121.257296087
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="7,121.257296087 DUSK"
+                  data-tooltip-type="info"
+                >
+                  7,121
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    26
+                  </span>
+                </span>
               </td>
               
                
@@ -4275,14 +4288,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 m9dVuRgr3C...94r33pFQyz
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -4295,7 +4308,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -4329,7 +4342,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -4352,9 +4365,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                6,923.840604194
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="6,923.840604194 DUSK"
+                  data-tooltip-type="info"
+                >
+                  6,923
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    84
+                  </span>
+                </span>
               </td>
               
                
@@ -4364,14 +4390,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 mHGvQ9Xdjz...iTfxTvgn7f
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -4384,7 +4410,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -4418,7 +4444,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -4441,9 +4467,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                89.505343279
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="89.505343279 DUSK"
+                  data-tooltip-type="info"
+                >
+                  89
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    51
+                  </span>
+                </span>
               </td>
               
                
@@ -4453,14 +4492,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 mLx5HUo5Ph...BrRgEzoka8
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -4473,7 +4512,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -4507,7 +4546,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -4530,9 +4569,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                29.633646022
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="29.633646022 DUSK"
+                  data-tooltip-type="info"
+                >
+                  29
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    63
+                  </span>
+                </span>
               </td>
               
                
@@ -4542,14 +4594,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 mTgXDqkyVa...gAseybAsfU
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -4562,7 +4614,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -4596,7 +4648,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -4619,9 +4671,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                7,518.756679536
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="7,518.756679536 DUSK"
+                  data-tooltip-type="info"
+                >
+                  7,518
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    76
+                  </span>
+                </span>
               </td>
               
                
@@ -4631,14 +4696,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 mUJHMDEBiT...FHNxRNhoAA
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -4651,7 +4716,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -4685,7 +4750,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -4708,9 +4773,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                73.800637305
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="73.800637305 DUSK"
+                  data-tooltip-type="info"
+                >
+                  73
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    80
+                  </span>
+                </span>
               </td>
               
                
@@ -4720,14 +4798,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 mUUpjnXow2...SfzQcywzaW
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -4740,7 +4818,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -4774,7 +4852,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -4797,9 +4875,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                7,653.541671166
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="7,653.541671166 DUSK"
+                  data-tooltip-type="info"
+                >
+                  7,653
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    54
+                  </span>
+                </span>
               </td>
               
                
@@ -4809,14 +4900,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 mWvq9EWD9b...oU7BY2oEDe
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -4829,7 +4920,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -4863,7 +4954,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -4886,9 +4977,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                1.613840782
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="1.613840782 DUSK"
+                  data-tooltip-type="info"
+                >
+                  1
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    61
+                  </span>
+                </span>
               </td>
               
                
@@ -4898,14 +5002,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 mXKJ97xTtr...JgkCK2o7x4
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -4918,7 +5022,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -4952,7 +5056,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -4975,9 +5079,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                7,512.060104659
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="7,512.060104659 DUSK"
+                  data-tooltip-type="info"
+                >
+                  7,512
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    06
+                  </span>
+                </span>
               </td>
               
                
@@ -4987,14 +5104,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 mdXsA3Ee1Y...K8VZPimZ2J
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -5007,7 +5124,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -5041,7 +5158,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -5064,9 +5181,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                7,973.118109253
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="7,973.118109253 DUSK"
+                  data-tooltip-type="info"
+                >
+                  7,973
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    12
+                  </span>
+                </span>
               </td>
               
                
@@ -5076,14 +5206,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 mdca2ea2Kp...ji7SxM2zBD
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -5096,7 +5226,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -5130,7 +5260,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -5153,9 +5283,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                7,091.398997002
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="7,091.398997002 DUSK"
+                  data-tooltip-type="info"
+                >
+                  7,091
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    40
+                  </span>
+                </span>
               </td>
               
                
@@ -5165,14 +5308,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 mgmcqkk1VF...xddxLvEDVP
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -5185,7 +5328,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -5219,7 +5362,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -5242,9 +5385,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                7,373.189839389
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="7,373.189839389 DUSK"
+                  data-tooltip-type="info"
+                >
+                  7,373
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    19
+                  </span>
+                </span>
               </td>
               
                
@@ -5254,14 +5410,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 mvft6AXjR1...frxEyudvx2
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -5274,7 +5430,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -5308,7 +5464,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -5331,9 +5487,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                104,743.439448879
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="104,743.439448879 DUSK"
+                  data-tooltip-type="info"
+                >
+                  104,743
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    44
+                  </span>
+                </span>
               </td>
               
                
@@ -5343,14 +5512,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 mvsVWvCaiH...cdeSzHCUUb
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -5363,7 +5532,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -5397,7 +5566,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -5420,9 +5589,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                75.58825915
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="75.58825915 DUSK"
+                  data-tooltip-type="info"
+                >
+                  75
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    59
+                  </span>
+                </span>
               </td>
               
                
@@ -5432,14 +5614,14 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 n2DPucZgNz...95PUxRwtD1
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-neutral"
@@ -5452,7 +5634,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__stake-data-label"
@@ -5486,7 +5668,7 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="provisioners-table__slash-data-label"
@@ -5509,9 +5691,22 @@ exports[`Provisioners page > should render the Provisioners page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-right"
               >
-                7,127.318018509
+                <span
+                  data-tooltip-id="main-tooltip"
+                  data-tooltip-place="top"
+                  data-tooltip-text="7,127.318018509 DUSK"
+                  data-tooltip-type="info"
+                >
+                  7,127
+                  .
+                  <span
+                    class="decimal-shadow"
+                  >
+                    32
+                  </span>
+                </span>
               </td>
               
                

--- a/explorer/src/routes/transactions/__tests__/__snapshots__/page.spec.js.snap
+++ b/explorer/src/routes/transactions/__tests__/__snapshots__/page.spec.js.snap
@@ -2590,35 +2590,35 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 ID
               </th>
               
                
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 Gas
               </th>
               
                
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 Fee (DUSK)
               </th>
               
                
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 Status
               </th>
               
                
               <th
-                class="table__header-cell"
+                class="table__header-cell align-left"
               >
                 Type
               </th>
@@ -2634,7 +2634,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2653,7 +2653,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -2675,14 +2675,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008221117
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2693,7 +2693,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -2729,7 +2729,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2748,7 +2748,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -2770,14 +2770,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008221117
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2788,7 +2788,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -2824,7 +2824,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2843,7 +2843,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -2865,14 +2865,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008220846
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2883,7 +2883,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -2919,7 +2919,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -2938,7 +2938,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -2960,14 +2960,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008221266
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -2978,7 +2978,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -3014,7 +3014,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3033,7 +3033,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -3055,14 +3055,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008220422
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3073,7 +3073,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -3109,7 +3109,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3128,7 +3128,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -3150,14 +3150,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008220926
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3168,7 +3168,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -3204,7 +3204,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3223,7 +3223,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -3245,14 +3245,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008221243
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3263,7 +3263,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -3299,7 +3299,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3318,7 +3318,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -3340,14 +3340,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008220934
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3358,7 +3358,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -3394,7 +3394,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3413,7 +3413,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -3435,14 +3435,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008220989
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3453,7 +3453,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -3489,7 +3489,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3508,7 +3508,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -3530,14 +3530,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008221018
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3548,7 +3548,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -3584,7 +3584,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3603,7 +3603,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -3625,14 +3625,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008220865
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3643,7 +3643,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -3679,7 +3679,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3698,7 +3698,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -3720,14 +3720,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008221367
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3738,7 +3738,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -3774,7 +3774,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3793,7 +3793,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -3815,14 +3815,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008220508
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3833,7 +3833,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -3869,7 +3869,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3888,7 +3888,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -3910,14 +3910,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008220823
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -3928,7 +3928,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"
@@ -3964,7 +3964,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               class="table__row"
             >
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <a
                   class="dusk-anchor dusk-anchor--on-surface transaction__link"
@@ -3983,7 +3983,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <b
                   class="transaction__fee-price-label"
@@ -4005,14 +4005,14 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 0.008220485
               </td>
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <span
                   class="dusk-badge dusk-badge--variant-success transaction-status"
@@ -4023,7 +4023,7 @@ exports[`Transactions page > should render the Transactions page, start polling 
               
                
               <td
-                class="table__data-cell"
+                class="table__data-cell align-left"
               >
                 <div
                   class="transaction-type"

--- a/explorer/src/style/main.css
+++ b/explorer/src/style/main.css
@@ -84,3 +84,7 @@ svg {
     padding: 0 1.25rem;
   }
 }
+
+.decimal-shadow {
+  opacity: 0.5;
+}


### PR DESCRIPTION
I'd like to propose some cosmetic enhancements to the explorer, starting with this. This commit changes the *Accumulated Reward* column in the provisioners table so that:

1 - It is right-aligned. Numeric values are usually right-aligned for easier comparison.

2 - It forces the number of decimal places to always be 2. The current version can have fluctuating decimal places, making it harder to read the table as each row's decimal point shuffles around. This also helps with the "easier comparison" from before.

3 - Make the decimal digits less visible compared to the whole number. This is a personal preference and a few people on Discord agreed that it looked nicer :)

Let me know what you think.

![image](https://github.com/user-attachments/assets/e835df0b-f663-4a6d-bb76-6d8bae1be3cc)
![image](https://github.com/user-attachments/assets/5dce6b00-1ff0-41ac-b8ca-96334d10dd92)


