### PR TITLE
explorer: Add "nonce" to transaction details page

### DIFF
--- a/explorer/CHANGELOG.md
+++ b/explorer/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to
 ### Added
 
 - Add Tokens page [#3415]
-- Add current balance (Account page) [#3564]
+- Add "nonce" to transaction details page (Public transactions) [#3578]
 
 ### Changed
 
@@ -172,6 +172,7 @@ and this project adheres to
 [#3454]: https://github.com/dusk-network/rusk/issues/3454
 [#3545]: https://github.com/dusk-network/rusk/issues/3454
 [#3564]: https://github.com/dusk-network/rusk/issues/3564
+[#3578]: https://github.com/dusk-network/rusk/issues/3578
 
 <!-- VERSIONS -->
 

--- a/explorer/src/lib/components/__tests__/__snapshots__/TransactionDetails.spec.js.snap
+++ b/explorer/src/lib/components/__tests__/__snapshots__/TransactionDetails.spec.js.snap
@@ -417,6 +417,7 @@ exports[`Transaction Details > renders the Transaction Details component 1`] = `
       >
         290766
       </dd>
+      
       <dt
         class="details-list__term"
       >
@@ -930,6 +931,7 @@ exports[`Transaction Details > renders the Transaction Details component with th
       >
         290766
       </dd>
+      
       <dt
         class="details-list__term"
       >
@@ -1451,6 +1453,7 @@ exports[`Transaction Details > renders the Transaction Details component with th
       >
         290766
       </dd>
+      
       <dt
         class="details-list__term"
       >

--- a/explorer/src/lib/components/transaction-details/TransactionDetails.svelte
+++ b/explorer/src/lib/components/transaction-details/TransactionDetails.svelte
@@ -229,6 +229,14 @@
       <svelte:fragment slot="definition">{data.gasspent}</svelte:fragment>
     </ListItem>
 
+    <!-- NONCE -->
+    {#if data.txtype.toLowerCase() === "moonlight" && jsonPayload?.nonce}
+      <ListItem tooltipText="The number of transactions sent from this address">
+        <svelte:fragment slot="term">nonce</svelte:fragment>
+        <svelte:fragment slot="definition">{jsonPayload.nonce}</svelte:fragment>
+      </ListItem>
+    {/if}
+
     <!-- MEMO -->
     <ListItem tooltipText="Transaction reference and additional notes">
       <svelte:fragment slot="term">

--- a/explorer/src/routes/transactions/transaction/__tests__/__snapshots__/page.spec.js.snap
+++ b/explorer/src/routes/transactions/transaction/__tests__/__snapshots__/page.spec.js.snap
@@ -385,6 +385,7 @@ exports[`Transaction Details > should render the Transaction details page and qu
         >
           290766
         </dd>
+        
         <dt
           class="details-list__term"
         >


### PR DESCRIPTION
<img width="621" alt="Screenshot 2025-03-26 at 1 12 05" src="https://github.com/user-attachments/assets/8d458c24-6e45-439c-84d8-f9b6c6787035" />
