### PR TITLE
Check transaction size before adding to mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-core 1.2.1",
  "dusk-merkle",
- "dusk-node-data 1.2.0",
+ "dusk-node-data",
  "hex",
  "num-bigint",
  "rand 0.8.5",
@@ -1749,7 +1749,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-consensus",
  "dusk-core 1.2.1",
- "dusk-node-data 1.2.0",
+ "dusk-node-data",
  "dusk-wallet-core 1.1.0",
  "fake",
  "hex",
@@ -1771,33 +1771,6 @@ dependencies = [
  "thiserror",
  "time-util",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "dusk-node-data"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae940a1e0bc70154b013294c796d49c9679c9a9a57ee4ae80b5985b113a56ad"
-dependencies = [
- "aes 0.7.5",
- "anyhow",
- "async-channel",
- "base64 0.22.1",
- "block-modes",
- "bs58",
- "chrono",
- "dusk-bytes",
- "dusk-core 1.2.1",
- "fake",
- "hex",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_with",
- "sha2 0.10.8",
- "sha3",
- "thiserror",
  "tracing",
 ]
 
@@ -1881,7 +1854,7 @@ dependencies = [
  "dusk-core 1.2.1",
  "dusk-data-driver",
  "dusk-node",
- "dusk-node-data 1.2.0",
+ "dusk-node-data",
  "dusk-stake-contract-dd",
  "dusk-transfer-contract-dd",
  "dusk-vm 1.2.0",
@@ -4585,7 +4558,7 @@ dependencies = [
  "dirs",
  "dusk-bytes",
  "dusk-core 1.2.1",
- "dusk-node-data 1.2.0",
+ "dusk-node-data",
  "dusk-wallet-core 1.1.0",
  "flume 0.10.14",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ dusk-vm = "1.2.0"
 # dusk-vm = { version = "1.2.1-alpha.1", path = "./vm/" }
 # node = { version = "1.2.0", package = "dusk-node" }
 node = { version = "1.2.1-alpha.1", path = "./node/", package = "dusk-node" }
-node-data = { version = "1.2.0", package = "dusk-node-data" }
-# node-data = { version = "1.2.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
+# node-data = { version = "1.2.0", package = "dusk-node-data" }
+node-data = { version = "1.2.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 rusk-prover = "1.1.0"

--- a/consensus/src/proposal/block_generator.rs
+++ b/consensus/src/proposal/block_generator.rs
@@ -89,11 +89,7 @@ impl<T: Operations> Generator<T> {
             ..Default::default()
         };
 
-        let header_size = blk_header.size().map_err(|e| {
-            crate::errors::OperationError::InvalidEST(anyhow::anyhow!(
-                "Cannot get header size {e}. This should be a bug"
-            ))
-        })?;
+        let header_size = blk_header.size();
 
         // We always write the faults len in a u32
         let mut faults_size = u32::SIZE;

--- a/node-data/CHANGELOG.md
+++ b/node-data/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make Transaction `size` method infallible
+- Make Header `size` method infallible
+
 ## [1.2.0] - 2025-03-20
 
 ### Removed

--- a/node-data/src/ledger/header.rs
+++ b/node-data/src/ledger/header.rs
@@ -71,10 +71,10 @@ impl Default for Header {
 }
 
 impl Header {
-    pub fn size(&self) -> io::Result<usize> {
+    pub fn size(&self) -> usize {
         let mut buf = vec![];
-        self.write(&mut buf)?;
-        Ok(buf.len())
+        self.write(&mut buf).expect("write to vec should not fail");
+        buf.len()
     }
 }
 

--- a/node-data/src/ledger/transaction.rs
+++ b/node-data/src/ledger/transaction.rs
@@ -4,8 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::io;
-
 use dusk_bytes::Serializable as DuskSerializable;
 use dusk_core::signatures::bls::PublicKey as AccountPublicKey;
 use dusk_core::transfer::moonlight::Transaction as MoonlightTransaction;
@@ -25,13 +23,13 @@ pub struct Transaction {
 }
 
 impl Transaction {
-    pub fn size(&self) -> io::Result<usize> {
+    pub fn size(&self) -> usize {
         match self.size {
-            Some(size) => Ok(size),
+            Some(size) => size,
             None => {
                 let mut buf = vec![];
-                self.write(&mut buf)?;
-                Ok(buf.len())
+                self.write(&mut buf).expect("write to vec should not fail");
+                buf.len()
             }
         }
     }

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add transaction serialization check
+- Add max transaction size check
 
 ## [1.2.0] - 2025-03-20
 

--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `Content-Type: application/json` support for `/on/contracts` endpoint
 - Add transaction serialization check
+- Add max transaction size check
 
 ## [1.2.0] - 2025-03-20
 

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -149,16 +149,7 @@ impl Rusk {
             }
 
             let tx_id = hex::encode(unspent_tx.id());
-            let tx_size = unspent_tx.size().unwrap_or_default();
-
-            if tx_size == 0 {
-                info!(
-                    event = "Skipping transaction",
-                    reason = "error while calculating length",
-                    tx_id
-                );
-                continue;
-            }
+            let tx_size = unspent_tx.size();
 
             if tx_size > block_space_left {
                 info!(


### PR DESCRIPTION
- Make `Transaction` and `Header`'s `size` method infallible
- Checks transactions do not exceed the maximum size (MAX_BLOCK_SIZE - MIN_HEADER_SIZE) available in a block