### PR TITLE
rusk-wallet: fix contract call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 name = "alice"
 version = "0.3.0"
 dependencies = [
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
 ]
 
 [[package]]
@@ -767,7 +767,7 @@ version = "0.3.0"
 dependencies = [
  "bytecheck",
  "dusk-bytes",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "rkyv",
 ]
 
@@ -887,7 +887,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "charlie"
 version = "0.3.0"
 dependencies = [
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "rkyv",
 ]
 
@@ -1626,7 +1626,7 @@ dependencies = [
  "async-trait",
  "criterion",
  "dusk-bytes",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "dusk-merkle",
  "dusk-node-data",
  "hex",
@@ -1663,8 +1663,6 @@ dependencies = [
  "poseidon-merkle",
  "rand 0.8.5",
  "rkyv",
- "serde",
- "serde_with",
 ]
 
 [[package]]
@@ -1748,9 +1746,9 @@ dependencies = [
  "criterion",
  "dusk-bytes",
  "dusk-consensus",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "dusk-node-data",
- "dusk-wallet-core 1.1.0",
+ "dusk-wallet-core",
  "fake",
  "hex",
  "humantime-serde",
@@ -1786,7 +1784,7 @@ dependencies = [
  "bs58",
  "chrono",
  "dusk-bytes",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "fake",
  "hex",
  "rand 0.8.5",
@@ -1851,14 +1849,14 @@ dependencies = [
  "dirs",
  "dusk-bytes",
  "dusk-consensus",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "dusk-data-driver",
  "dusk-node",
  "dusk-node-data",
  "dusk-stake-contract-dd",
  "dusk-transfer-contract-dd",
- "dusk-vm 1.2.0",
- "dusk-wallet-core 1.1.0",
+ "dusk-vm 1.2.1-alpha.1",
+ "dusk-wallet-core",
  "ff",
  "futures",
  "futures-util",
@@ -1875,7 +1873,7 @@ dependencies = [
  "reqwest",
  "rkyv",
  "rusk-profile 1.0.1",
- "rusk-prover 1.1.0",
+ "rusk-prover",
  "rusk-recovery 1.0.3",
  "rustc_tools_util",
  "rustls-pemfile",
@@ -1908,7 +1906,7 @@ name = "dusk-stake-contract-dd"
 version = "0.0.1-alpha.1"
 dependencies = [
  "dlmalloc",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "dusk-data-driver",
  "wasm-bindgen",
 ]
@@ -1918,7 +1916,7 @@ name = "dusk-transfer-contract-dd"
 version = "0.0.1-alpha.1"
 dependencies = [
  "dlmalloc",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "dusk-data-driver",
  "wasm-bindgen",
 ]
@@ -1946,7 +1944,7 @@ dependencies = [
  "blake2b_simd",
  "blake3",
  "dusk-bytes",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "dusk-poseidon",
  "ff",
  "lru",
@@ -1958,32 +1956,13 @@ dependencies = [
 
 [[package]]
 name = "dusk-wallet-core"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4533c6298486bf3378dc0cd231613811a8973a037f6d94975f32d6e3a0f07f4f"
-dependencies = [
- "blake3",
- "bytecheck",
- "dlmalloc",
- "dusk-bytes",
- "dusk-core 1.2.1",
- "ff",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rkyv",
- "sha2 0.10.8",
- "zeroize",
-]
-
-[[package]]
-name = "dusk-wallet-core"
 version = "1.1.1-alpha.1"
 dependencies = [
  "blake3",
  "bytecheck",
  "dlmalloc",
  "dusk-bytes",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "ff",
  "hex",
  "hkdf",
@@ -2673,7 +2652,7 @@ name = "host_fn"
 version = "0.2.0"
 dependencies = [
  "dusk-bytes",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
 ]
 
 [[package]]
@@ -4468,26 +4447,10 @@ dependencies = [
 
 [[package]]
 name = "rusk-prover"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469cbbdd11c2fde62fabe5ca710eb274d36aa01941a12625ac1b6c97320568db"
-dependencies = [
- "dusk-bytes",
- "dusk-core 1.2.1",
- "dusk-plonk",
- "hex",
- "once_cell",
- "rand 0.8.5",
- "rusk-profile 1.0.1",
- "tracing",
-]
-
-[[package]]
-name = "rusk-prover"
 version = "1.1.1-alpha.1"
 dependencies = [
  "dusk-bytes",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "dusk-plonk",
  "hex",
  "once_cell",
@@ -4532,9 +4495,9 @@ dependencies = [
  "bs58",
  "cargo_toml",
  "dusk-bytes",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "dusk-plonk",
- "dusk-vm 1.2.0",
+ "dusk-vm 1.2.1-alpha.1",
  "ff",
  "flate2",
  "hex",
@@ -4568,9 +4531,9 @@ dependencies = [
  "crossterm",
  "dirs",
  "dusk-bytes",
- "dusk-core 1.2.1",
+ "dusk-core 1.2.2-alpha.1",
  "dusk-node-data",
- "dusk-wallet-core 1.1.0",
+ "dusk-wallet-core",
  "flume 0.10.14",
  "futures",
  "hex",
@@ -5226,13 +5189,13 @@ version = "0.8.0"
 dependencies = [
  "criterion",
  "dusk-bytes",
- "dusk-core 1.2.1",
- "dusk-vm 1.2.0",
- "dusk-wallet-core 1.1.0",
+ "dusk-core 1.2.2-alpha.1",
+ "dusk-vm 1.2.1-alpha.1",
+ "dusk-wallet-core",
  "ff",
  "rand 0.8.5",
  "rkyv",
- "rusk-prover 1.1.0",
+ "rusk-prover",
 ]
 
 [[package]]
@@ -5709,14 +5672,14 @@ name = "transfer-contract"
 version = "0.10.1"
 dependencies = [
  "dusk-bytes",
- "dusk-core 1.2.1",
- "dusk-vm 1.2.0",
+ "dusk-core 1.2.2-alpha.1",
+ "dusk-vm 1.2.1-alpha.1",
  "ff",
  "rand 0.8.5",
  "ringbuffer",
  "rkyv",
  "rusk-profile 1.0.1",
- "rusk-prover 1.1.0",
+ "rusk-prover",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,22 +36,22 @@ resolver = "2"
 # Workspace internal dependencies
 # dusk-consensus = "1.2.0"
 dusk-consensus = { version = "1.2.1-alpha.1", path = "./consensus/" }
-dusk-core = "1.2.1"
-# dusk-core = { version = "1.2.2-alpha.1", path = "./core/" }
-dusk-vm = "1.2.0"
-# dusk-vm = { version = "1.2.1-alpha.1", path = "./vm/" }
+# dusk-core = "1.2.1"
+dusk-core = { version = "1.2.2-alpha.1", path = "./core/" }
+# dusk-vm = "1.2.0"
+dusk-vm = { version = "1.2.1-alpha.1", path = "./vm/" }
 # node = { version = "1.2.0", package = "dusk-node" }
 node = { version = "1.2.1-alpha.1", path = "./node/", package = "dusk-node" }
 # node-data = { version = "1.2.0", package = "dusk-node-data" }
 node-data = { version = "1.2.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
-rusk-prover = "1.1.0"
-# rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
+# rusk-prover = "1.1.0"
+rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
 rusk-recovery = "1.0.3"
 # rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
-wallet-core = { version = "1.1.0", package = "dusk-wallet-core" }
-# wallet-core = { version = "1.1.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
+# wallet-core = { version = "1.1.0", package = "dusk-wallet-core" }
+wallet-core = { version = "1.1.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 
 dusk-data-driver = { version = "0.0.1-alpha.1", path = "./data-drivers/data-driver" }
 dusk-transfer-contract-dd = { version = "0.0.1-alpha.1", path = "./data-drivers/transfer-contract" }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ContractCall::new_raw` [#3602]
+
 ## [1.2.1] - 2025-03-20
 
 ### Added

--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Add
+### Added
 
 - Add deploy contract output (display the new contractId)
 
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change key derivation to PBKDF2 and wallet encryption to AES-GCM [#3391]
 - Change default deploy gas limit to be accepted by std mempool
 
-### Fix
+### Fixed
 
 - Fix wrong lower limit for stake operation when performing topup [#3394]
 - Fix `is_synced()` method in the wallet to avoid overflow [#3593]
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2025-01-20
 
-### Add
+### Added
 
 - Add gas cost calculation to contract deploy [#2768]
 - Add more information to `stake-info` [#2659]
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename all instances of recovery phrase to mnemonic phrase [#2839]
 - Rename Shielded account to be aligned with the Web wallet [#3263]
 
-### Fix
+### Fixed
 
 - Fix phoenix balance update [#2488]
 - Fix stake info for inactive stakes with rewards [#2766]

--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change dependency declaration to not require strict equal [#3405]
 - Change key derivation to PBKDF2 and wallet encryption to AES-GCM [#3391]
+- Change default deploy gas limit to be accepted by std mempool
 
 ### Fix
 

--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Add
+
+- Add deploy contract output (display the new contractId)
+
 ### Changed
 
 - Change dependency declaration to not require strict equal [#3405]

--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `is_synced()` method in the wallet to avoid overflow [#3593]
 - Fix transaction history deserialization [#3598]
 - Fix contract init parsing [#3602]
+- Fix contract call non-interactive parsing [#3602]
 
 ## [0.1.0] - 2025-01-20
 

--- a/rusk-wallet/src/bin/command.rs
+++ b/rusk-wallet/src/bin/command.rs
@@ -245,8 +245,8 @@ pub(crate) enum Command {
         code: PathBuf,
 
         /// Arguments for init function (hex encoded rkyv serialized data)
-        #[arg(short, long, default_value_t = String::new())]
-        init_args: String,
+        #[arg(short, long, default_value = "", value_parser = parse_hex)]
+        init_args: std::vec::Vec<u8>, /* Fully qualify it due to https://github.com/clap-rs/clap/issues/4481#issuecomment-1314475143 */
 
         /// Nonce used for the deploy transaction
         #[arg(short, long)]
@@ -626,7 +626,6 @@ impl Command {
                     .map_err(|_| Error::InvalidWasmContractPath)?;
 
                 let gas = Gas::new(gas_limit).with_price(gas_price);
-                let init_args = hex::decode(init_args)?;
 
                 let contract_id =
                     wallet.get_contract_id(addr_idx, &code, deploy_nonce)?;

--- a/rusk-wallet/src/bin/interactive.rs
+++ b/rusk-wallet/src/bin/interactive.rs
@@ -460,7 +460,7 @@ fn confirm(cmd: &Command, wallet: &Wallet<WalletFile>) -> anyhow::Result<bool> {
 
             println!("   > Pay with {}", sender.preview());
             println!("   > Code len = {}", code_len);
-            println!("   > Init args = {}", init_args);
+            println!("   > Init args = {}", hex::encode(init_args));
             println!("   > Deploy nonce = {}", deploy_nonce);
             println!("   > Max fee = {} DUSK", Dusk::from(max_fee));
             println!("   > Calculated Contract Id = {}", contract_id);

--- a/rusk-wallet/src/bin/interactive.rs
+++ b/rusk-wallet/src/bin/interactive.rs
@@ -452,7 +452,7 @@ fn confirm(cmd: &Command, wallet: &Wallet<WalletFile>) -> anyhow::Result<bool> {
 
             let contract_id = wallet.get_contract_id(
                 sender_index,
-                code_bytes,
+                &code_bytes,
                 *deploy_nonce,
             )?;
 

--- a/rusk-wallet/src/bin/io/prompt.rs
+++ b/rusk-wallet/src/bin/io/prompt.rs
@@ -324,9 +324,9 @@ pub(crate) fn request_gas_price(
     )
 }
 
-pub(crate) fn request_init_args() -> anyhow::Result<String> {
+pub(crate) fn request_init_args() -> anyhow::Result<Vec<u8>> {
     const MAX_INIT_SIZE: usize = 32 * 1024;
-    Ok(Text::new("Introduce init args:")
+    let init = Text::new("Introduce init args:")
         .with_help_message("Hex encoded rkyv serialized data")
         .with_validator(move |input: &str| {
             let error = match hex::decode(input) {
@@ -339,7 +339,12 @@ pub(crate) fn request_init_args() -> anyhow::Result<String> {
                 Validation::Invalid(error.into())
             }))
         })
-        .prompt()?)
+        .prompt()?;
+    let init = hex::decode(init).map_err(|e| {
+        anyhow::anyhow!("Expecting hex, this should be a bug: {e}")
+    })?;
+
+    Ok(init)
 }
 
 pub(crate) fn request_str(

--- a/rusk-wallet/src/bin/main.rs
+++ b/rusk-wallet/src/bin/main.rs
@@ -445,6 +445,17 @@ async fn exec() -> anyhow::Result<()> {
 
                     println!("{tx_id}");
                 }
+                RunResult::DeployTx(hash, contract_id) => {
+                    let tx_id = hex::encode(hash.to_bytes());
+                    let contract_id = hex::encode(contract_id.as_bytes());
+                    println!("Deploying {contract_id}",);
+
+                    // Wait for transaction confirmation from network
+                    let gql = GraphQL::new(settings.state, status::headless)?;
+                    gql.wait_for(&tx_id).await?;
+
+                    println!("{tx_id}");
+                }
                 RunResult::StakeInfo(info, reward) => {
                     let rewards = Dusk::from(info.reward);
                     if reward {

--- a/rusk-wallet/src/gas.rs
+++ b/rusk-wallet/src/gas.rs
@@ -18,7 +18,8 @@ pub const MIN_LIMIT: u64 = 100_000;
 pub const DEFAULT_LIMIT_TRANSFER: u64 = 2_500_000;
 
 /// The default gas limit for a contract deployment
-pub const DEFAULT_LIMIT_DEPLOYMENT: u64 = 15_000_000_000;
+pub const DEFAULT_LIMIT_DEPLOYMENT: u64 =
+    1024 * 1024 * 100 + DEFAULT_LIMIT_TRANSFER; //1MB at 100gas per byte + transfer limit
 
 /// The default gas limit for contract calls
 pub const DEFAULT_LIMIT_CALL: u64 = 2_000_000_000;

--- a/rusk-wallet/src/wallet.rs
+++ b/rusk-wallet/src/wallet.rs
@@ -541,7 +541,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
     pub fn get_contract_id(
         &self,
         profile_idx: u8,
-        bytes: Vec<u8>,
+        bytes: &[u8],
         nonce: u64,
     ) -> Result<[u8; CONTRACT_ID_BYTES], Error> {
         let owner = self.public_key(profile_idx)?.to_bytes();
@@ -549,7 +549,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let mut hasher = blake2b_simd::Params::new()
             .hash_length(CONTRACT_ID_BYTES)
             .to_state();
-        hasher.update(bytes.as_ref());
+        hasher.update(bytes);
         hasher.update(&nonce.to_le_bytes()[..]);
         hasher.update(owner.as_ref());
         hasher


### PR DESCRIPTION
- Fix contract call non-interactive parsing
- Fix contract call double rkyv for fn_args
- Add output ContractId when deploying a wasm
- Change default deploy gas limit to be accepted by std mempool

Follow up of #3603 