### PR TITLE
Improve State Transition error logs

### DIFF
--- a/consensus/src/operations.rs
+++ b/consensus/src/operations.rs
@@ -81,7 +81,7 @@ pub trait Operations: Send + Sync {
         prev_commit: StateRoot,
         blk: &Block,
         voters: &[Voter],
-    ) -> Result<VerificationOutput, VstError>;
+    ) -> Result<VerificationOutput, OperationError>;
 
     async fn execute_state_transition(
         &self,

--- a/consensus/src/proposal/block_generator.rs
+++ b/consensus/src/proposal/block_generator.rs
@@ -146,8 +146,8 @@ impl<T: Operations> Generator<T> {
                 );
                 Ok(blk)
             }
-            Err(e) => Err(crate::errors::OperationError::InvalidEST(
-                anyhow::anyhow!("Cannot create new block {e}",),
+            Err(e) => Err(crate::errors::OperationError::BlockCreation(
+                format!("{e}",),
             )),
         }
     }

--- a/consensus/src/proposal/step.rs
+++ b/consensus/src/proposal/step.rs
@@ -104,8 +104,8 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
                             Self::wait_until_next_slot(tip_timestamp).await;
                             return msg;
                         }
-                        Err(e) => {
-                            error!("invalid candidate generated due to {:?}", e)
+                        Err(err) => {
+                            error!(event = "Failed to store candidate", ?err)
                         }
                         _ => {}
                     };

--- a/consensus/src/validation/step.rs
+++ b/consensus/src/validation/step.rs
@@ -18,7 +18,7 @@ use tracing::{debug, error, info, Instrument};
 
 use crate::commons::{Database, RoundUpdate};
 use crate::config::is_emergency_iter;
-use crate::errors::VstError;
+use crate::errors::{HeaderError, OperationError};
 use crate::execution_ctx::ExecutionCtx;
 use crate::msg_handler::StepOutcome;
 use crate::operations::{Operations, Voter};
@@ -100,7 +100,10 @@ impl<T: Operations + 'static, D: Database> ValidationStep<T, D> {
                     .verify_faults(header.height, candidate.faults())
                     .await
                 {
-                    error!(event = "invalid faults", ?err);
+                    error!(
+                        event = "Candidate verification failed",
+                        reason = %err
+                    );
                     Vote::Invalid(header.hash)
                 } else {
                     match Self::call_vst(
@@ -169,26 +172,27 @@ impl<T: Operations + 'static, D: Database> ValidationStep<T, D> {
         candidate: &Block,
         voters: &[Voter],
         executor: &Arc<T>,
-    ) -> Result<(), VstError> {
+    ) -> Result<(), OperationError> {
         let output = executor
             .verify_state_transition(prev_commit, candidate, voters)
             .await?;
 
-        // Ensure the `event_bloom` and `state_root` returned
-        // from the VST call are the
-        // ones we expect to have with the
-        // current candidate block.
+        // Check the header against `event_bloom` and `state_root` from VST
         if output.event_bloom != candidate.header().event_bloom {
-            return Err(VstError::MismatchEventBloom(
-                Box::new(output.event_bloom),
-                Box::new(candidate.header().event_bloom),
+            return Err(OperationError::InvalidHeader(
+                HeaderError::EventBloomMismatch(
+                    Box::new(output.event_bloom),
+                    Box::new(candidate.header().event_bloom),
+                ),
             ));
         }
 
         if output.state_root != candidate.header().state_hash {
-            return Err(VstError::MismatchStateHash(
-                output.state_root,
-                candidate.header().state_hash,
+            return Err(OperationError::InvalidHeader(
+                HeaderError::StateRootMismatch(
+                    output.state_root,
+                    candidate.header().state_hash,
+                ),
             ));
         }
 

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -338,9 +338,7 @@ impl<DB: database::DB, VM: vm::VMExecution> Operations for Executor<DB, VM> {
         let db = self.db.read().await;
         let (executed_txs, discarded_txs, verification_output) = db
             .view(|view| {
-                let txs = view.mempool_txs_sorted_by_fee().map_err(|err| {
-                    anyhow::anyhow!("failed to get mempool txs: {}", err)
-                })?;
+                let txs = view.mempool_txs_sorted_by_fee();
                 let ret = vm.execute_state_transition(&params, txs).map_err(
                     |err| anyhow::anyhow!("failed to call EST {}", err),
                 )?;

--- a/node/src/database.rs
+++ b/node/src/database.rs
@@ -177,17 +177,17 @@ pub trait Mempool {
     /// Get an iterator over the mempool transactions sorted by gas price
     fn mempool_txs_sorted_by_fee(
         &self,
-    ) -> Result<Box<dyn Iterator<Item = Transaction> + '_>>;
+    ) -> Box<dyn Iterator<Item = Transaction> + '_>;
 
     /// Get an iterator over the mempool transactions hash by gas price
     fn mempool_txs_ids_sorted_by_fee(
         &self,
-    ) -> Result<Box<dyn Iterator<Item = (u64, [u8; 32])> + '_>>;
+    ) -> Box<dyn Iterator<Item = (u64, [u8; 32])> + '_>;
 
     /// Get an iterator over the mempool transactions hash by gas price (asc)
     fn mempool_txs_ids_sorted_by_low_fee(
         &self,
-    ) -> Result<Box<dyn Iterator<Item = (u64, [u8; 32])> + '_>>;
+    ) -> Box<dyn Iterator<Item = (u64, [u8; 32])> + '_>;
 
     /// Get all transactions hashes.
     fn mempool_txs_ids(&self) -> Result<Vec<[u8; 32]>>;

--- a/node/src/database/rocksdb.rs
+++ b/node/src/database/rocksdb.rs
@@ -973,26 +973,26 @@ impl<'db, DB: DBAccess> Mempool for DBTransaction<'db, DB> {
 
     fn mempool_txs_sorted_by_fee(
         &self,
-    ) -> Result<Box<dyn Iterator<Item = Transaction> + '_>> {
+    ) -> Box<dyn Iterator<Item = Transaction> + '_> {
         let iter = MemPoolIterator::new(&self.inner, self.fees_cf, self);
 
-        Ok(Box::new(iter))
+        Box::new(iter)
     }
 
     fn mempool_txs_ids_sorted_by_fee(
         &self,
-    ) -> Result<Box<dyn Iterator<Item = (u64, [u8; 32])> + '_>> {
+    ) -> Box<dyn Iterator<Item = (u64, [u8; 32])> + '_> {
         let iter = MemPoolFeeIterator::new(&self.inner, self.fees_cf, true);
 
-        Ok(Box::new(iter))
+        Box::new(iter)
     }
 
     fn mempool_txs_ids_sorted_by_low_fee(
         &self,
-    ) -> Result<Box<dyn Iterator<Item = (u64, [u8; 32])> + '_>> {
+    ) -> Box<dyn Iterator<Item = (u64, [u8; 32])> + '_> {
         let iter = MemPoolFeeIterator::new(&self.inner, self.fees_cf, false);
 
-        Ok(Box::new(iter))
+        Box::new(iter)
     }
 
     /// Get all expired transactions hashes.
@@ -1494,9 +1494,7 @@ mod tests {
             .unwrap();
 
             db.view(|txn| {
-                let txs = txn
-                    .mempool_txs_sorted_by_fee()
-                    .expect("iter should return");
+                let txs = txn.mempool_txs_sorted_by_fee();
 
                 let mut last_fee = u64::MAX;
                 for t in txs {
@@ -1575,7 +1573,6 @@ mod tests {
             db.view(|txn| {
                 let txs = txn
                     .mempool_txs_sorted_by_fee()
-                    .expect("should return all txs")
                     .map(|t| t.gas_price())
                     .sum::<u64>();
 

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -276,7 +276,7 @@ impl MempoolSrv {
             if txs_count >= max_mempool_txn_count {
                 // Get the lowest fee transaction to delete
                 let (lowest_price, to_delete) = view
-                    .mempool_txs_ids_sorted_by_low_fee()?
+                    .mempool_txs_ids_sorted_by_low_fee()
                     .next()
                     .ok_or(anyhow::anyhow!("Cannot get lowest fee tx"))?;
 

--- a/node/src/vm.rs
+++ b/node/src/vm.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_consensus::errors::VstError;
+use dusk_consensus::errors::StateTransitionError;
 use dusk_consensus::operations::{CallParams, VerificationOutput, Voter};
 use dusk_consensus::user::provisioners::Provisioners;
 use dusk_consensus::user::stake::Stake;
@@ -21,18 +21,17 @@ pub trait VMExecution: Send + Sync + 'static {
         &self,
         params: &CallParams,
         txs: I,
-    ) -> anyhow::Result<(
-        Vec<SpentTransaction>,
-        Vec<Transaction>,
-        VerificationOutput,
-    )>;
+    ) -> Result<
+        (Vec<SpentTransaction>, Vec<Transaction>, VerificationOutput),
+        StateTransitionError,
+    >;
 
     fn verify_state_transition(
         &self,
         prev_root: [u8; 32],
         blk: &Block,
         voters: &[Voter],
-    ) -> Result<VerificationOutput, VstError>;
+    ) -> Result<VerificationOutput, StateTransitionError>;
 
     fn accept(
         &self,

--- a/rusk/src/lib/http/chain.rs
+++ b/rusk/src/lib/http/chain.rs
@@ -215,7 +215,7 @@ impl RuskNode {
                 .read()
                 .await
                 .view(|t| -> anyhow::Result<Vec<u64>> {
-                    Ok(t.mempool_txs_ids_sorted_by_fee()?
+                    Ok(t.mempool_txs_ids_sorted_by_fee()
                         .take(max_transactions)
                         .map(|(gas_price, _)| gas_price)
                         .collect())

--- a/rusk/src/lib/http/chain/graphql/tx.rs
+++ b/rusk/src/lib/http/chain/graphql/tx.rs
@@ -59,7 +59,7 @@ pub async fn mempool<'a>(
 ) -> FieldResult<Vec<Transaction<'a>>> {
     let (db, _) = ctx.data::<DBContext>()?;
     db.read().await.view(|db| {
-        let txs = db.mempool_txs_sorted_by_fee()?.map(|t| t.into()).collect();
+        let txs = db.mempool_txs_sorted_by_fee().map(|t| t.into()).collect();
         Ok(txs)
     })
 }

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -31,7 +31,7 @@ use dusk_vm::{
 #[cfg(feature = "archive")]
 use node::archive::Archive;
 use node_data::events::contract::ContractTxEvent;
-use node_data::ledger::{Hash, Slash, SpentTransaction, Transaction};
+use node_data::ledger::{to_str, Hash, Slash, SpentTransaction, Transaction};
 use parking_lot::RwLock;
 use rusk_profile::to_rusk_state_id_path;
 use tokio::sync::broadcast;
@@ -109,6 +109,14 @@ impl Rusk {
         let prev_state_root = params.prev_state_root;
 
         let voters = &params.voters_pubkey[..];
+
+        info!(
+            event = "Start EST",
+            height = block_height,
+            prev_state = to_str(&prev_state_root),
+            gas_limit = block_gas_limit,
+            ?to_slash
+        );
 
         let mut session =
             self.new_block_session(block_height, prev_state_root)?;
@@ -264,6 +272,15 @@ impl Rusk {
         slashing: Vec<Slash>,
         voters: &[Voter],
     ) -> Result<(Vec<SpentTransaction>, VerificationOutput)> {
+        info!(
+            event = "Start VST",
+            block_hash = to_str(&block_hash),
+            height = block_height,
+            prev_state = to_str(&prev_commit),
+            gas_limit = block_gas_limit,
+            to_slash = ?slashing
+        );
+
         let session = self.new_block_session(block_height, prev_commit)?;
         let execution_config = self.vm_config.to_execution_config(block_height);
 

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -37,8 +37,6 @@ impl VMExecution for Rusk {
         Vec<Transaction>,
         VerificationOutput,
     )> {
-        info!("Received execute_state_transition request");
-
         let (txs, discarded_txs, verification_output) =
             self.execute_transactions(params, txs).map_err(|inner| {
                 anyhow::anyhow!("Cannot execute txs: {inner}!!")
@@ -53,7 +51,6 @@ impl VMExecution for Rusk {
         blk: &Block,
         voters: &[Voter],
     ) -> Result<VerificationOutput, VstError> {
-        info!("Received verify_state_transition request");
         let generator = blk.header().generator_bls_pubkey;
         let generator = BlsPublicKey::from_slice(&generator.0)
             .map_err(VstError::InvalidGenerator)?;

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -7,7 +7,7 @@
 mod config;
 mod query;
 
-use dusk_consensus::errors::VstError;
+use dusk_consensus::errors::StateTransitionError;
 use node_data::events::contract::ContractTxEvent;
 use tracing::{debug, info};
 
@@ -32,14 +32,17 @@ impl VMExecution for Rusk {
         &self,
         params: &CallParams,
         txs: I,
-    ) -> anyhow::Result<(
-        Vec<SpentTransaction>,
-        Vec<Transaction>,
-        VerificationOutput,
-    )> {
+    ) -> Result<
+        (Vec<SpentTransaction>, Vec<Transaction>, VerificationOutput),
+        StateTransitionError,
+    > {
         let (txs, discarded_txs, verification_output) =
-            self.execute_transactions(params, txs).map_err(|inner| {
-                anyhow::anyhow!("Cannot execute txs: {inner}!!")
+            self.execute_transactions(params, txs).map_err(|err| {
+                if let crate::Error::TipChanged = err {
+                    StateTransitionError::TipChanged
+                } else {
+                    StateTransitionError::ExecutionError(format!("{err}"))
+                }
             })?;
 
         Ok((txs, discarded_txs, verification_output))
@@ -50,13 +53,13 @@ impl VMExecution for Rusk {
         prev_commit: [u8; 32],
         blk: &Block,
         voters: &[Voter],
-    ) -> Result<VerificationOutput, VstError> {
+    ) -> Result<VerificationOutput, StateTransitionError> {
         let generator = blk.header().generator_bls_pubkey;
         let generator = BlsPublicKey::from_slice(&generator.0)
-            .map_err(VstError::InvalidGenerator)?;
+            .map_err(StateTransitionError::InvalidGenerator)?;
 
-        let slashing =
-            Slash::from_block(blk).map_err(VstError::InvalidSlash)?;
+        let slashing = Slash::from_block(blk)
+            .map_err(StateTransitionError::InvalidSlash)?;
 
         let (_, verification_output) = self
             .verify_transactions(
@@ -71,9 +74,9 @@ impl VMExecution for Rusk {
             )
             .map_err(|inner| {
                 if let crate::Error::TipChanged = inner {
-                    VstError::TipChanged
+                    StateTransitionError::TipChanged
                 } else {
-                    VstError::Generic(format!("Cannot verify txs: {inner}!!"))
+                    StateTransitionError::VerificationError(format!("{inner}"))
                 }
             })?;
 


### PR DESCRIPTION
- Updates `OperationError`, `HeaderError`, and `VstError`
- Rename `VstError` to `StateTransitionError`
- Updates some Consensus logs
- Reduce log level of `TipChanged` errors from `ERROR` to `WARN`
- Change `execute_state_transition` to return `StateTransitionError` instead of `anyhow::Error`
- Improve EST and VST start logs
- Remove unnecessary `Result` from `mempool_txs_sorted_by_fee`, `mempool_txs_ids_sorted_by_fee`, `mempool_txs_ids_sorted_by_low_fee`

New log examples:
```
#EST
{"timestamp":"2025-04-10T09:35:28.432994Z","level":"INFO","event":"Start EST","height":9,"prev_state":"3b0099f04178207e...ddd94ce17215c35c","gas_limit":5000000000,"to_slash":"[]","target":"rusk::node::rusk","spans":[{"iter":0,"name":"Proposal","pk":"shAky1Dnjxdhy1Hs","round":9,"name":"main"}]}

#VST
{"timestamp":"2025-04-10T09:35:25.364022Z","level":"INFO","event":"Start VST","block_hash":"adb3121044df5b07...04ebd05718d03698","height":8,"prev_state":"0039c34e3cc54bfc...acfac6d5ff663a85","gas_limit":5000000000,"to_slash":"[]","target":"rusk::node::rusk","spans":[{"iter":0,"name":"Validation","pk":"shB6W4UWipm3JQQg","round":8,"name":"main"},{"hash":"adb3121044df5b07...04ebd05718d03698","name":"validation"}]}

# Tip change during Block creation
{"timestamp":"2025-04-10T09:26:27.095276Z","level":"WARN","event":"Stopped block generation","reason":"EST failed: Chain tip updated during operation","target":"dusk_consensus::validation::step","spans":[{"iter":1,"name":"Proposal","pk":"shAky1Dnjxdhy1Hs","round":23,"name":"main"},{"hash":"d661382f6b95a446...48ea5cd8ea3c2027","name":"proposal"}]}

# Tip change during Validation vote
{"timestamp":"2025-04-10T09:38:00.266266Z","level":"WARN","event":"Skipping Validation vote","reason":"VST failed: Chain tip updated during operation","target":"dusk_consensus::validation::step","spans":[{"iter":1,"name":"Validation","pk":"shAky1Dnjxdhy1Hs","round":23,"name":"main"},{"hash":"d661382f6b95a446...48ea5cd8ea3c2027","name":"validation"}]}
```
---
Tests:
 - [x] Local node
 - [x] Local cluster
 - [x] Testnet