### PR TITLE
Bug-3631 | Fix tests compilation errors when archive feature is enabled

### DIFF
--- a/rusk/benches/block_ingestion.rs
+++ b/rusk/benches/block_ingestion.rs
@@ -159,7 +159,14 @@ pub fn accept_benchmark(c: &mut Criterion) {
         .expect("Cannot deserialize config");
 
     let vm_config = RuskVmConfig::new().with_block_gas_limit(BLOCK_GAS_LIMIT);
-    let rusk = new_state(&tmp, &snapshot, vm_config)
+
+    // Create a Tokio runtime for the async setup
+    let runtime =
+        tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
+
+    // Run the async new_state within block_on
+    let rusk = runtime
+        .block_on(new_state(&tmp, &snapshot, vm_config))
         .expect("Creating state should work");
 
     let phoenix_txs = load_phoenix_txs();

--- a/rusk/tests/common/wallet.rs
+++ b/rusk/tests/common/wallet.rs
@@ -27,6 +27,7 @@ use rusk::{Error, Result, Rusk};
 use test_wallet::{self as wallet, Store};
 use tracing::info;
 
+#[allow(unused_imports)]
 pub use test_wallet::Wallet;
 
 #[derive(Debug, Clone)]

--- a/rusk/tests/common/wallet/test_wallet/imp.rs
+++ b/rusk/tests/common/wallet/test_wallet/imp.rs
@@ -239,7 +239,7 @@ where
 
         let unspent_notes_and_nullifiers = note_leaves
             .into_iter()
-            .zip(nullifiers.into_iter())
+            .zip(nullifiers)
             .filter(|(_note, nullifier)| {
                 !existing_nullifiers.contains(nullifier)
             })
@@ -464,7 +464,7 @@ where
             rng,
             &sender_sk,
             &refund_pk,
-            &receiver_pk,
+            receiver_pk,
             input_notes_openings,
             root,
             transfer_value,
@@ -679,6 +679,7 @@ where
     }
 
     /// Deploy a contract using Phoenix to pay for gas.
+    #[allow(clippy::too_many_arguments)]
     pub fn phoenix_deployment<Rng: RngCore + CryptoRng>(
         &self,
         rng: &mut Rng,
@@ -978,6 +979,7 @@ where
     }
 
     /// Deploy a contract using Moonlight to pay for gas.
+    #[allow(clippy::too_many_arguments)]
     pub fn moonlight_deployment(
         &self,
         sender_index: u8,

--- a/rusk/tests/services/conversion.rs
+++ b/rusk/tests/services/conversion.rs
@@ -27,12 +27,12 @@ const INITIAL_PHOENIX_BALANCE: u64 = 10_000_000_000;
 const INITIAL_MOONLIGHT_BALANCE: u64 = 10_000_000_000;
 
 // Creates the Rusk initial state for the tests below
-fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
+async fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
     let snapshot = toml::from_str(include_str!("../config/convert.toml"))
         .expect("Cannot deserialize config");
     let vm_config = RuskVmConfig::new().with_block_gas_limit(BLOCK_GAS_LIMIT);
 
-    new_state(dir, &snapshot, vm_config)
+    new_state(dir, &snapshot, vm_config).await
 }
 
 /// Makes a transaction that converts Dusk from Phoenix to Moonlight, and
@@ -167,7 +167,7 @@ pub async fn convert_to_moonlight() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = initial_state(&tmp)?;
+    let rusk = initial_state(&tmp).await?;
 
     let cache = Arc::new(RwLock::new(HashMap::new()));
 
@@ -193,7 +193,7 @@ pub async fn convert_to_phoenix() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = initial_state(&tmp)?;
+    let rusk = initial_state(&tmp).await?;
 
     let cache = Arc::new(RwLock::new(HashMap::new()));
 

--- a/rusk/tests/services/gas_behavior.rs
+++ b/rusk/tests/services/gas_behavior.rs
@@ -36,12 +36,12 @@ const GAS_PRICE: u64 = 1;
 const DEPOSIT: u64 = 0;
 
 // Creates the Rusk initial state for the tests below
-fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
+async fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
     let snapshot = toml::from_str(include_str!("../config/gas-behavior.toml"))
         .expect("Cannot deserialize config");
     let vm_config = RuskVmConfig::new().with_block_gas_limit(BLOCK_GAS_LIMIT);
 
-    new_state(dir, &snapshot, vm_config)
+    new_state(dir, &snapshot, vm_config).await
 }
 
 const SENDER_INDEX_0: u8 = 0;
@@ -138,7 +138,7 @@ pub async fn erroring_tx_charged_full() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = initial_state(&tmp)?;
+    let rusk = initial_state(&tmp).await?;
 
     let cache = Arc::new(RwLock::new(HashMap::new()));
 

--- a/rusk/tests/services/mainnet.rs
+++ b/rusk/tests/services/mainnet.rs
@@ -22,13 +22,13 @@ use crate::common::state::new_state;
 const GENESIS_BALANCE: u64 = dusk(500_000_000.0);
 
 // Creates the Rusk initial state for the tests below
-fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
+async fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
     let snapshot = toml::from_str(include_str!(
         "../../../rusk-recovery/config/mainnet.toml"
     ))
     .expect("Cannot deserialize config");
 
-    new_state(dir, &snapshot, RuskVmConfig::default())
+    new_state(dir, &snapshot, RuskVmConfig::default()).await
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -37,7 +37,7 @@ pub async fn mainnet_genesis() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = initial_state(&tmp)?;
+    let rusk = initial_state(&tmp).await?;
     let mut total_amount = 0u64;
 
     let (sender, receiver): (Sender<Vec<u8>>, Receiver<Vec<u8>>) =

--- a/rusk/tests/services/moonlight_stake.rs
+++ b/rusk/tests/services/moonlight_stake.rs
@@ -29,12 +29,12 @@ const GAS_LIMIT: u64 = 10_000_000_000;
 const GAS_PRICE: u64 = 1;
 
 // Creates the Rusk initial state for the tests below
-fn stake_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
+async fn stake_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
     let snapshot = toml::from_str(include_str!("../config/stake.toml"))
         .expect("Cannot deserialize config");
     let vm_config = RuskVmConfig::new().with_block_gas_limit(BLOCK_GAS_LIMIT);
 
-    new_state(dir, &snapshot, vm_config)
+    new_state(dir, &snapshot, vm_config).await
 }
 
 /// Stakes an amount Dusk and produces a block with this single transaction,
@@ -134,7 +134,7 @@ pub async fn stake() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = stake_state(&tmp)?;
+    let rusk = stake_state(&tmp).await?;
 
     let cache = Arc::new(RwLock::new(HashMap::new()));
 
@@ -211,7 +211,7 @@ pub async fn reward() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = stake_state(&tmp)?;
+    let rusk = stake_state(&tmp).await?;
 
     let cache = Arc::new(RwLock::new(HashMap::new()));
 

--- a/rusk/tests/services/multi_transfer.rs
+++ b/rusk/tests/services/multi_transfer.rs
@@ -35,23 +35,23 @@ const BOB_BYTECODE: &[u8] = include_bytes!(
 );
 
 // Creates the Rusk initial state for the tests below
-fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
+async fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
     let snapshot =
         toml::from_str(include_str!("../config/multi_transfer.toml"))
             .expect("Cannot deserialize config");
     let vm_config = RuskVmConfig::new().with_block_gas_limit(BLOCK_GAS_LIMIT);
 
-    new_state(dir, &snapshot, vm_config)
+    new_state(dir, &snapshot, vm_config).await
 }
 
 // Creates the Rusk initial state for the tests below
-fn initial_state_deploy<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
+async fn initial_state_deploy<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
     let snapshot =
         toml::from_str(include_str!("../config/multi_transfer_deploy.toml"))
             .expect("Cannot deserialize config");
     let vm_config = RuskVmConfig::new().with_block_gas_limit(BLOCK_GAS_LIMIT);
 
-    new_state(dir, &snapshot, vm_config)
+    new_state(dir, &snapshot, vm_config).await
 }
 
 /// Executes three different transactions in the same block, expecting only two
@@ -361,7 +361,7 @@ pub async fn multi_transfer() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = initial_state(&tmp)?;
+    let rusk = initial_state(&tmp).await?;
 
     let cache = Arc::new(RwLock::new(HashMap::new()));
 
@@ -402,7 +402,7 @@ pub async fn multi_transfer_deploy() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = initial_state_deploy(&tmp)?;
+    let rusk = initial_state_deploy(&tmp).await?;
 
     let cache = Arc::new(RwLock::new(HashMap::new()));
 

--- a/rusk/tests/services/phoenix_stake.rs
+++ b/rusk/tests/services/phoenix_stake.rs
@@ -36,21 +36,21 @@ const GAS_PRICE: u64 = 1;
 const DEPOSIT: u64 = 0;
 
 // Creates the Rusk initial state for the tests below
-fn stake_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
+async fn stake_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
     let snapshot = toml::from_str(include_str!("../config/stake.toml"))
         .expect("Cannot deserialize config");
     let vm_config = RuskVmConfig::new().with_block_gas_limit(BLOCK_GAS_LIMIT);
 
-    new_state(dir, &snapshot, vm_config)
+    new_state(dir, &snapshot, vm_config).await
 }
 
 // Creates the Rusk initial state for the tests below
-fn slash_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
+async fn slash_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
     let snapshot = toml::from_str(include_str!("../config/slash.toml"))
         .expect("Cannot deserialize config");
     let vm_config = RuskVmConfig::new().with_block_gas_limit(BLOCK_GAS_LIMIT);
 
-    new_state(dir, &snapshot, vm_config)
+    new_state(dir, &snapshot, vm_config).await
 }
 
 /// Stakes an amount Dusk and produces a block with this single transaction,
@@ -150,7 +150,7 @@ pub async fn stake() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = stake_state(&tmp)?;
+    let rusk = stake_state(&tmp).await?;
 
     let cache = Arc::new(RwLock::new(HashMap::new()));
 
@@ -240,7 +240,7 @@ pub async fn reward() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = stake_state(&tmp)?;
+    let rusk = stake_state(&tmp).await?;
 
     let cache = Arc::new(RwLock::new(HashMap::new()));
 
@@ -277,7 +277,7 @@ pub async fn slash() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = slash_state(&tmp)?;
+    let rusk = slash_state(&tmp).await?;
 
     let cache = Arc::new(RwLock::new(HashMap::new()));
 
@@ -330,7 +330,7 @@ pub async fn slash() -> Result<()> {
     .expect("to work");
 
     let last_changes = rusk.last_provisioners_change(None).unwrap();
-    let (_, prev) = last_changes.first().expect("Something changed").clone();
+    let (_, prev) = last_changes.first().expect("Something changed");
     let prev = prev.expect("to have something");
     assert_eq!(prev.reward, dusk(3.0));
     assert_eq!(
@@ -369,7 +369,7 @@ pub async fn slash() -> Result<()> {
     .expect("to work");
 
     let last_changes = rusk.last_provisioners_change(None).unwrap();
-    let (_, prev) = last_changes.first().expect("Something changed").clone();
+    let (_, prev) = last_changes.first().expect("Something changed");
     let prev = prev.expect("to have something");
     assert_eq!(prev.reward, dusk(3.0));
     assert_eq!(
@@ -419,7 +419,7 @@ pub async fn slash() -> Result<()> {
     .expect("to work");
 
     let last_changes = rusk.last_provisioners_change(None).unwrap();
-    let (_, prev) = last_changes.first().expect("Something changed").clone();
+    let (_, prev) = last_changes.first().expect("Something changed");
     let prev = prev.expect("to have something");
     assert_eq!(prev.reward, dusk(3.0));
     assert_eq!(
@@ -461,7 +461,7 @@ pub async fn slash() -> Result<()> {
 
     //Ensure we still have previous changes, because generator procedure failed
     let last_changes = rusk.last_provisioners_change(None).unwrap();
-    let (_, prev) = last_changes.first().expect("Something changed").clone();
+    let (_, prev) = last_changes.first().expect("Something changed");
     let prev = prev.expect("to have something");
     assert_eq!(prev.reward, dusk(3.0));
     assert_eq!(

--- a/rusk/tests/services/transfer.rs
+++ b/rusk/tests/services/transfer.rs
@@ -27,12 +27,12 @@ const INITIAL_BALANCE: u64 = 10_000_000_000;
 const MAX_NOTES: u64 = 10;
 
 // Creates the Rusk initial state for the tests below
-fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
+async fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
     let snapshot = toml::from_str(include_str!("../config/transfer.toml"))
         .expect("Cannot deserialize config");
     let vm_config = RuskVmConfig::new().with_block_gas_limit(BLOCK_GAS_LIMIT);
 
-    new_state(dir, &snapshot, vm_config)
+    new_state(dir, &snapshot, vm_config).await
 }
 
 /// Transacts between two accounts on the in the same wallet and produces a
@@ -137,7 +137,7 @@ pub async fn wallet() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = initial_state(&tmp)?;
+    let rusk = initial_state(&tmp).await?;
 
     let cache = Arc::new(RwLock::new(HashMap::new()));
 

--- a/rusk/tests/services/unspendable.rs
+++ b/rusk/tests/services/unspendable.rs
@@ -36,12 +36,12 @@ const GAS_PRICE: u64 = 1;
 const DEPOSIT: u64 = 0;
 
 // Creates the Rusk initial state for the tests below
-fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
+async fn initial_state<P: AsRef<Path>>(dir: P) -> Result<Rusk> {
     let snapshot = toml::from_str(include_str!("../config/unspendable.toml"))
         .expect("Cannot deserialize config");
     let vm_config = RuskVmConfig::new().with_block_gas_limit(BLOCK_GAS_LIMIT);
 
-    new_state(dir, &snapshot, vm_config)
+    new_state(dir, &snapshot, vm_config).await
 }
 
 const SENDER_INDEX_0: u8 = 0;
@@ -167,7 +167,7 @@ pub async fn unspendable() -> Result<()> {
     logger();
 
     let tmp = tempdir().expect("Should be able to create temporary directory");
-    let rusk = initial_state(&tmp)?;
+    let rusk = initial_state(&tmp).await?;
 
     let cache = Arc::new(RwLock::new(HashMap::new()));
 


### PR DESCRIPTION
Closes #3631 

## What is done

- [x]  Fix `Rusk::new` method call by creating a `node::archive::Archive` instance in the temporary directory and passing it as the last argument to the method (feature-gated `archive`). This required to make the function where the `Rusk` is created, asynchronous.
- [x] Update all other functions and tests where appropriate functions are used
- [x] Fix `clippy` errors and warnings
- [x] Fix `accept_benchmark` function in `rusk/benches/block_ingestion.rs` (it can't be `async`)

## How to test

```bash
cargo test --release --features "testwallet chain archive" -- --nocapture --color=always --show-output --include-ignored
```

**Result:** all tests compile