### PR TITLE
Bug-3633 | Fix http::tests::http_query test

### DIFF
--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -742,6 +742,10 @@ mod tests {
 
     #[tokio::test]
     async fn https_query() {
+        let provider =
+            tokio_rustls::rustls::crypto::aws_lc_rs::default_provider();
+        let _ = provider.install_default();
+
         let cert_path = "tests/assets/cert.pem";
         let key_path = "tests/assets/key.pem";
 


### PR DESCRIPTION
Closes #3633 

## What is done

- [x] ~~Add the dependency `rustls` with feature `ring`~~ Use `rustls` re-exported from already installed `tokio_rustls` crate
- [x] Fix `http::tests::http_query` test by running `tokio_rustls::rustls::crypto::ring::default_provider().install_default()`

## How to test

```bash
cargo test --release --features "testwallet chain" -- --nocapture --color=always --show-output --include-ignored
```

**Result:** The `http::tests::http_query` test doesn't panicking and passes