### PR TITLE
node: followup – add active accounts table in archive

### DIFF
--- a/node/src/archive/sqlite.rs
+++ b/node/src/archive/sqlite.rs
@@ -434,7 +434,9 @@ impl Archive {
 
     /// Insert the active accounts into the active accounts table, skipping
     /// already existing ones
-    async fn update_active_accounts(
+    ///
+    /// TODO: This function should not be public.
+    pub async fn update_active_accounts(
         &self,
         active_accounts: HashSet<String>,
     ) -> Result<u64> {

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -15,10 +15,9 @@ use dusk_bytes::DeserializableSlice;
 use dusk_consensus::operations::{CallParams, VerificationOutput, Voter};
 use dusk_consensus::user::provisioners::Provisioners;
 use dusk_consensus::user::stake::Stake;
-use dusk_core::{
-    signatures::bls::PublicKey as BlsPublicKey, stake::StakeData,
-    transfer::Transaction as ProtocolTransaction,
-};
+use dusk_core::signatures::bls::PublicKey as BlsPublicKey;
+use dusk_core::stake::StakeData;
+use dusk_core::transfer::Transaction as ProtocolTransaction;
 use node::vm::{PreverificationResult, VMExecution};
 use node_data::bls::PublicKey;
 use node_data::ledger::{Block, Slash, SpentTransaction, Transaction};


### PR DESCRIPTION
Follow up of #3643, adding the migration