### PR TITLE
rusk: release `1.3.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-rusk"
-version = "1.2.1-alpha.1"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,6 +1621,26 @@ dependencies = [
 [[package]]
 name = "dusk-consensus"
 version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdea944555f6eeca4c36545a2ccc56d055db159ace763404e78e35e56e507bb0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "dusk-bytes",
+ "dusk-core 1.3.0",
+ "dusk-merkle",
+ "dusk-node-data 1.3.0",
+ "hex",
+ "num-bigint",
+ "sha3",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dusk-consensus"
+version = "1.3.1-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1748,7 +1768,7 @@ dependencies = [
  "bs58",
  "criterion",
  "dusk-bytes",
- "dusk-consensus",
+ "dusk-consensus 1.3.0",
  "dusk-core 1.3.0",
  "dusk-node-data 1.3.0",
  "dusk-wallet-core",
@@ -1878,7 +1898,7 @@ dependencies = [
  "criterion",
  "dirs",
  "dusk-bytes",
- "dusk-consensus",
+ "dusk-consensus 1.3.0",
  "dusk-core 1.3.0",
  "dusk-data-driver",
  "dusk-node",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4565,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "rusk-recovery"
-version = "1.0.4-alpha.1"
+version = "1.3.0"
 dependencies = [
  "bs58",
  "cargo_toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,40 @@ dependencies = [
 [[package]]
 name = "dusk-node"
 version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786afe06f5132cd299b6b5e4178966b5d49bb3f7e0111d719e78addefe22085a"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "async-trait",
+ "bs58",
+ "dusk-bytes",
+ "dusk-consensus 1.3.0",
+ "dusk-core 1.3.0",
+ "dusk-node-data 1.3.0",
+ "hex",
+ "humantime-serde",
+ "kadcast",
+ "memory-stats",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "native-tls",
+ "rkyv",
+ "rocksdb",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smallvec",
+ "sqlx",
+ "thiserror",
+ "time-util",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dusk-node"
+version = "1.3.1-alpha.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1901,7 +1935,7 @@ dependencies = [
  "dusk-consensus 1.3.0",
  "dusk-core 1.3.0",
  "dusk-data-driver",
- "dusk-node",
+ "dusk-node 1.3.0",
  "dusk-node-data 1.3.0",
  "dusk-stake-contract-dd",
  "dusk-transfer-contract-dd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-stake-contract-dd"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 dependencies = [
  "dlmalloc",
  "dusk-core 1.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 name = "alice"
 version = "0.3.0"
 dependencies = [
- "dusk-core",
+ "dusk-core 1.3.0",
 ]
 
 [[package]]
@@ -767,7 +767,7 @@ version = "0.3.0"
 dependencies = [
  "bytecheck",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.3.0",
  "rkyv",
 ]
 
@@ -887,7 +887,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "charlie"
 version = "0.3.0"
 dependencies = [
- "dusk-core",
+ "dusk-core 1.3.0",
  "rkyv",
 ]
 
@@ -1626,7 +1626,7 @@ dependencies = [
  "async-trait",
  "criterion",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.3.0",
  "dusk-merkle",
  "dusk-node-data",
  "hex",
@@ -1641,6 +1641,35 @@ dependencies = [
 [[package]]
 name = "dusk-core"
 version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31cbf35a8632ecc33cdeb54b7866e2d615fb5b24fea7f4b43f2e1e62668afcbd"
+dependencies = [
+ "ark-bn254",
+ "ark-groth16",
+ "ark-relations",
+ "ark-serialize",
+ "bls12_381-bls 0.5.0",
+ "bytecheck",
+ "dusk-bls12_381 0.14.2",
+ "dusk-bytes",
+ "dusk-jubjub",
+ "dusk-plonk",
+ "dusk-poseidon",
+ "ff",
+ "jubjub-schnorr",
+ "phoenix-circuits",
+ "phoenix-core",
+ "piecrust-uplink",
+ "poseidon-merkle",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "dusk-core"
+version = "1.3.1-alpha.1"
 dependencies = [
  "ark-bn254",
  "ark-groth16",
@@ -1720,7 +1749,7 @@ dependencies = [
  "criterion",
  "dusk-bytes",
  "dusk-consensus",
- "dusk-core",
+ "dusk-core 1.3.0",
  "dusk-node-data",
  "dusk-wallet-core",
  "fake",
@@ -1758,7 +1787,7 @@ dependencies = [
  "bs58",
  "chrono",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.3.0",
  "fake",
  "hex",
  "rand 0.8.5",
@@ -1823,7 +1852,7 @@ dependencies = [
  "dirs",
  "dusk-bytes",
  "dusk-consensus",
- "dusk-core",
+ "dusk-core 1.3.0",
  "dusk-data-driver",
  "dusk-node",
  "dusk-node-data",
@@ -1880,7 +1909,7 @@ name = "dusk-stake-contract-dd"
 version = "0.0.1-alpha.1"
 dependencies = [
  "dlmalloc",
- "dusk-core",
+ "dusk-core 1.3.0",
  "dusk-data-driver",
  "wasm-bindgen",
 ]
@@ -1890,7 +1919,7 @@ name = "dusk-transfer-contract-dd"
 version = "0.0.1-alpha.1"
 dependencies = [
  "dlmalloc",
- "dusk-core",
+ "dusk-core 1.3.0",
  "dusk-data-driver",
  "wasm-bindgen",
 ]
@@ -1902,7 +1931,7 @@ dependencies = [
  "blake2b_simd",
  "blake3",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.3.0",
  "dusk-poseidon",
  "ff",
  "lru",
@@ -1920,7 +1949,7 @@ dependencies = [
  "bytecheck",
  "dlmalloc",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.3.0",
  "ff",
  "hex",
  "hkdf",
@@ -2610,7 +2639,7 @@ name = "host_fn"
 version = "0.2.0"
 dependencies = [
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.3.0",
 ]
 
 [[package]]
@@ -4408,7 +4437,7 @@ name = "rusk-prover"
 version = "1.1.1-alpha.1"
 dependencies = [
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.3.0",
  "dusk-plonk",
  "hex",
  "once_cell",
@@ -4424,7 +4453,7 @@ dependencies = [
  "bs58",
  "cargo_toml",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.3.0",
  "dusk-plonk",
  "dusk-vm",
  "ff",
@@ -4460,7 +4489,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.3.0",
  "dusk-node-data",
  "dusk-wallet-core",
  "flume 0.10.14",
@@ -5118,7 +5147,7 @@ version = "0.8.0"
 dependencies = [
  "criterion",
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.3.0",
  "dusk-vm",
  "dusk-wallet-core",
  "ff",
@@ -5601,7 +5630,7 @@ name = "transfer-contract"
 version = "0.10.1"
 dependencies = [
  "dusk-bytes",
- "dusk-core",
+ "dusk-core 1.3.0",
  "dusk-vm",
  "ff",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-core"
-version = "1.2.2-alpha.1"
+version = "1.3.0"
 dependencies = [
  "ark-bn254",
  "ark-groth16",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-node"
-version = "1.2.1-alpha.1"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-data-driver"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 dependencies = [
  "bytecheck",
  "rkyv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-node-data"
-version = "1.2.1-alpha.1"
+version = "1.3.0"
 dependencies = [
  "aes 0.7.5",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-consensus"
-version = "1.2.1-alpha.1"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,7 +1950,7 @@ dependencies = [
  "dusk-node 1.3.0",
  "dusk-node-data 1.3.0",
  "dusk-stake-contract-dd",
- "dusk-transfer-contract-dd",
+ "dusk-transfer-contract-dd 0.1.0",
  "dusk-vm 1.3.0",
  "dusk-wallet-core 1.3.0",
  "ff",
@@ -2010,6 +2010,18 @@ dependencies = [
 [[package]]
 name = "dusk-transfer-contract-dd"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306dcec4456faf19853836bd81e29eb4276d6037a0b34106c9d88de40620dfe1"
+dependencies = [
+ "dlmalloc",
+ "dusk-core 1.3.0",
+ "dusk-data-driver 0.1.0",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "dusk-transfer-contract-dd"
+version = "0.1.1-alpha.1"
 dependencies = [
  "dlmalloc",
  "dusk-core 1.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 name = "alice"
 version = "0.3.0"
 dependencies = [
- "dusk-core 1.3.0",
+ "dusk-core",
 ]
 
 [[package]]
@@ -767,7 +767,7 @@ version = "0.3.0"
 dependencies = [
  "bytecheck",
  "dusk-bytes",
- "dusk-core 1.3.0",
+ "dusk-core",
  "rkyv",
 ]
 
@@ -887,7 +887,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "charlie"
 version = "0.3.0"
 dependencies = [
- "dusk-core 1.3.0",
+ "dusk-core",
  "rkyv",
 ]
 
@@ -1620,35 +1620,15 @@ dependencies = [
 
 [[package]]
 name = "dusk-consensus"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdea944555f6eeca4c36545a2ccc56d055db159ace763404e78e35e56e507bb0"
-dependencies = [
- "anyhow",
- "async-trait",
- "dusk-bytes",
- "dusk-core 1.3.0",
- "dusk-merkle",
- "dusk-node-data 1.3.0",
- "hex",
- "num-bigint",
- "sha3",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "dusk-consensus"
 version = "1.3.1-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
  "criterion",
  "dusk-bytes",
- "dusk-core 1.3.0",
+ "dusk-core",
  "dusk-merkle",
- "dusk-node-data 1.3.0",
+ "dusk-node-data",
  "hex",
  "num-bigint",
  "rand 0.8.5",
@@ -1656,35 +1636,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "dusk-core"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31cbf35a8632ecc33cdeb54b7866e2d615fb5b24fea7f4b43f2e1e62668afcbd"
-dependencies = [
- "ark-bn254",
- "ark-groth16",
- "ark-relations",
- "ark-serialize",
- "bls12_381-bls 0.5.0",
- "bytecheck",
- "dusk-bls12_381 0.14.2",
- "dusk-bytes",
- "dusk-jubjub",
- "dusk-plonk",
- "dusk-poseidon",
- "ff",
- "jubjub-schnorr",
- "phoenix-circuits",
- "phoenix-core",
- "piecrust-uplink",
- "poseidon-merkle",
- "rand 0.8.5",
- "rkyv",
- "serde",
- "serde_with",
 ]
 
 [[package]]
@@ -1713,18 +1664,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
-]
-
-[[package]]
-name = "dusk-data-driver"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c1f5c22c0ed47aea3fde481be1ad658460ef6d0d17d0cda398433f57164017"
-dependencies = [
- "bytecheck",
- "rkyv",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1772,40 +1711,6 @@ dependencies = [
 
 [[package]]
 name = "dusk-node"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786afe06f5132cd299b6b5e4178966b5d49bb3f7e0111d719e78addefe22085a"
-dependencies = [
- "anyhow",
- "async-channel",
- "async-trait",
- "bs58",
- "dusk-bytes",
- "dusk-consensus 1.3.0",
- "dusk-core 1.3.0",
- "dusk-node-data 1.3.0",
- "hex",
- "humantime-serde",
- "kadcast",
- "memory-stats",
- "metrics",
- "metrics-exporter-prometheus",
- "native-tls",
- "rkyv",
- "rocksdb",
- "serde",
- "serde_json",
- "serde_with",
- "smallvec",
- "sqlx",
- "thiserror",
- "time-util",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "dusk-node"
 version = "1.3.1-alpha.1"
 dependencies = [
  "anyhow",
@@ -1814,10 +1719,10 @@ dependencies = [
  "bs58",
  "criterion",
  "dusk-bytes",
- "dusk-consensus 1.3.0",
- "dusk-core 1.3.0",
- "dusk-node-data 1.3.0",
- "dusk-wallet-core 1.3.0",
+ "dusk-consensus",
+ "dusk-core",
+ "dusk-node-data",
+ "dusk-wallet-core",
  "fake",
  "hex",
  "humantime-serde",
@@ -1843,33 +1748,6 @@ dependencies = [
 
 [[package]]
 name = "dusk-node-data"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f35024b1064ce6a1a3060e985b0c84d4f22b491e76e8037d3b3dccabb06c72d"
-dependencies = [
- "aes 0.7.5",
- "anyhow",
- "async-channel",
- "base64 0.22.1",
- "block-modes",
- "bs58",
- "chrono",
- "dusk-bytes",
- "dusk-core 1.3.0",
- "fake",
- "hex",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_with",
- "sha2 0.10.8",
- "sha3",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "dusk-node-data"
 version = "1.3.1-alpha.1"
 dependencies = [
  "aes 0.7.5",
@@ -1880,7 +1758,7 @@ dependencies = [
  "bs58",
  "chrono",
  "dusk-bytes",
- "dusk-core 1.3.0",
+ "dusk-core",
  "fake",
  "hex",
  "rand 0.8.5",
@@ -1944,15 +1822,15 @@ dependencies = [
  "criterion",
  "dirs",
  "dusk-bytes",
- "dusk-consensus 1.3.0",
- "dusk-core 1.3.0",
- "dusk-data-driver 0.1.0",
- "dusk-node 1.3.0",
- "dusk-node-data 1.3.0",
- "dusk-stake-contract-dd 0.1.0",
- "dusk-transfer-contract-dd 0.1.0",
- "dusk-vm 1.3.0",
- "dusk-wallet-core 1.3.0",
+ "dusk-consensus",
+ "dusk-core",
+ "dusk-data-driver",
+ "dusk-node",
+ "dusk-node-data",
+ "dusk-stake-contract-dd",
+ "dusk-transfer-contract-dd",
+ "dusk-vm",
+ "dusk-wallet-core",
  "ff",
  "futures",
  "futures-util",
@@ -1968,9 +1846,9 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rkyv",
- "rusk-profile 1.0.1",
- "rusk-prover 1.3.0",
- "rusk-recovery 1.3.0",
+ "rusk-profile",
+ "rusk-prover",
+ "rusk-recovery",
  "rustc_tools_util",
  "rustls-pemfile",
  "semver",
@@ -1999,35 +1877,11 @@ dependencies = [
 
 [[package]]
 name = "dusk-stake-contract-dd"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8145dc94ad4c738d3d34e0d4f09060206550e0532e2cf81b2084ab34a10c12ea"
-dependencies = [
- "dlmalloc",
- "dusk-core 1.3.0",
- "dusk-data-driver 0.1.0",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "dusk-stake-contract-dd"
 version = "0.1.1-alpha.1"
 dependencies = [
  "dlmalloc",
- "dusk-core 1.3.0",
- "dusk-data-driver 0.1.0",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "dusk-transfer-contract-dd"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306dcec4456faf19853836bd81e29eb4276d6037a0b34106c9d88de40620dfe1"
-dependencies = [
- "dlmalloc",
- "dusk-core 1.3.0",
- "dusk-data-driver 0.1.0",
+ "dusk-core",
+ "dusk-data-driver",
  "wasm-bindgen",
 ]
 
@@ -2036,25 +1890,9 @@ name = "dusk-transfer-contract-dd"
 version = "0.1.1-alpha.1"
 dependencies = [
  "dlmalloc",
- "dusk-core 1.3.0",
- "dusk-data-driver 0.1.0",
+ "dusk-core",
+ "dusk-data-driver",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "dusk-vm"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8382d22f5367a81f6b03372d48237d01dd69facb0fab63740880e43f8c61f145"
-dependencies = [
- "blake2b_simd",
- "blake3",
- "dusk-bytes",
- "dusk-core 1.3.0",
- "dusk-poseidon",
- "lru",
- "piecrust",
- "rkyv",
 ]
 
 [[package]]
@@ -2064,7 +1902,7 @@ dependencies = [
  "blake2b_simd",
  "blake3",
  "dusk-bytes",
- "dusk-core 1.3.0",
+ "dusk-core",
  "dusk-poseidon",
  "ff",
  "lru",
@@ -2076,33 +1914,13 @@ dependencies = [
 
 [[package]]
 name = "dusk-wallet-core"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "018851beb0a54d6ed47d68e863b6da127422c9cfd93f5184227dfea83a4aaf40"
-dependencies = [
- "blake3",
- "bytecheck",
- "dlmalloc",
- "dusk-bytes",
- "dusk-core 1.3.0",
- "ff",
- "hkdf",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rkyv",
- "sha2 0.10.8",
- "zeroize",
-]
-
-[[package]]
-name = "dusk-wallet-core"
 version = "1.3.1-alpha.1"
 dependencies = [
  "blake3",
  "bytecheck",
  "dlmalloc",
  "dusk-bytes",
- "dusk-core 1.3.0",
+ "dusk-core",
  "ff",
  "hex",
  "hkdf",
@@ -2792,7 +2610,7 @@ name = "host_fn"
 version = "0.2.0"
 dependencies = [
  "dusk-bytes",
- "dusk-core 1.3.0",
+ "dusk-core",
 ]
 
 [[package]]
@@ -4555,23 +4373,6 @@ dependencies = [
 
 [[package]]
 name = "rusk-profile"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "096be7f24357ebde8859b56c423b694278d4d151ab055b14d445dfd749efed69"
-dependencies = [
- "blake3",
- "console",
- "dirs",
- "hex",
- "serde",
- "sha2 0.10.8",
- "toml",
- "tracing",
- "version_check",
-]
-
-[[package]]
-name = "rusk-profile"
 version = "1.0.2-alpha.1"
 dependencies = [
  "blake3",
@@ -4587,61 +4388,16 @@ dependencies = [
 
 [[package]]
 name = "rusk-prover"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ec33ea54518b45d9d26ec791ddc6430f96dcf75083e32170c3d87f7082f692"
-dependencies = [
- "dusk-bytes",
- "dusk-core 1.3.0",
- "dusk-plonk",
- "hex",
- "once_cell",
- "rand 0.8.5",
- "rusk-profile 1.0.1",
- "tracing",
-]
-
-[[package]]
-name = "rusk-prover"
 version = "1.3.1-alpha.1"
 dependencies = [
  "dusk-bytes",
- "dusk-core 1.3.0",
+ "dusk-core",
  "dusk-plonk",
  "hex",
  "once_cell",
  "rand 0.8.5",
- "rusk-profile 1.0.1",
+ "rusk-profile",
  "tracing",
-]
-
-[[package]]
-name = "rusk-recovery"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8a915b0121a43f40a83408f6069530822328b50a11c5474b9573f8c4d8c644"
-dependencies = [
- "bs58",
- "cargo_toml",
- "dusk-bytes",
- "dusk-core 1.3.0",
- "dusk-plonk",
- "dusk-vm 1.3.0",
- "ff",
- "flate2",
- "hex",
- "http_req",
- "rand 0.8.5",
- "reqwest",
- "rusk-profile 1.0.1",
- "serde",
- "serde_derive",
- "tar",
- "tokio",
- "toml",
- "tracing",
- "url",
- "zip",
 ]
 
 [[package]]
@@ -4651,16 +4407,16 @@ dependencies = [
  "bs58",
  "cargo_toml",
  "dusk-bytes",
- "dusk-core 1.3.0",
+ "dusk-core",
  "dusk-plonk",
- "dusk-vm 1.3.0",
+ "dusk-vm",
  "ff",
  "flate2",
  "hex",
  "http_req",
  "rand 0.8.5",
  "reqwest",
- "rusk-profile 1.0.1",
+ "rusk-profile",
  "serde",
  "serde_derive",
  "tar",
@@ -4687,9 +4443,9 @@ dependencies = [
  "crossterm",
  "dirs",
  "dusk-bytes",
- "dusk-core 1.3.0",
- "dusk-node-data 1.3.0",
- "dusk-wallet-core 1.3.0",
+ "dusk-core",
+ "dusk-node-data",
+ "dusk-wallet-core",
  "flume 0.10.14",
  "futures",
  "hex",
@@ -5345,13 +5101,13 @@ version = "0.8.0"
 dependencies = [
  "criterion",
  "dusk-bytes",
- "dusk-core 1.3.0",
- "dusk-vm 1.3.0",
- "dusk-wallet-core 1.3.0",
+ "dusk-core",
+ "dusk-vm",
+ "dusk-wallet-core",
  "ff",
  "rand 0.8.5",
  "rkyv",
- "rusk-prover 1.3.0",
+ "rusk-prover",
 ]
 
 [[package]]
@@ -5828,14 +5584,14 @@ name = "transfer-contract"
 version = "0.10.1"
 dependencies = [
  "dusk-bytes",
- "dusk-core 1.3.0",
- "dusk-vm 1.3.0",
+ "dusk-core",
+ "dusk-vm",
  "ff",
  "rand 0.8.5",
  "ringbuffer",
  "rkyv",
- "rusk-profile 1.0.1",
- "rusk-prover 1.3.0",
+ "rusk-profile",
+ "rusk-prover",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
  "dusk-node-data",
  "dusk-stake-contract-dd",
  "dusk-transfer-contract-dd",
- "dusk-vm",
+ "dusk-vm 1.3.0",
  "dusk-wallet-core",
  "ff",
  "futures",
@@ -1927,6 +1927,22 @@ dependencies = [
 [[package]]
 name = "dusk-vm"
 version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8382d22f5367a81f6b03372d48237d01dd69facb0fab63740880e43f8c61f145"
+dependencies = [
+ "blake2b_simd",
+ "blake3",
+ "dusk-bytes",
+ "dusk-core 1.3.0",
+ "dusk-poseidon",
+ "lru",
+ "piecrust",
+ "rkyv",
+]
+
+[[package]]
+name = "dusk-vm"
+version = "1.3.1-alpha.1"
 dependencies = [
  "blake2b_simd",
  "blake3",
@@ -4455,7 +4471,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-core 1.3.0",
  "dusk-plonk",
- "dusk-vm",
+ "dusk-vm 1.3.0",
  "ff",
  "flate2",
  "hex",
@@ -5148,7 +5164,7 @@ dependencies = [
  "criterion",
  "dusk-bytes",
  "dusk-core 1.3.0",
- "dusk-vm",
+ "dusk-vm 1.3.0",
  "dusk-wallet-core",
  "ff",
  "rand 0.8.5",
@@ -5631,7 +5647,7 @@ version = "0.10.1"
 dependencies = [
  "dusk-bytes",
  "dusk-core 1.3.0",
- "dusk-vm",
+ "dusk-vm 1.3.0",
  "ff",
  "rand 0.8.5",
  "ringbuffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-transfer-contract-dd"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 dependencies = [
  "dlmalloc",
  "dusk-core 1.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4551,7 +4551,7 @@ dependencies = [
 
 [[package]]
 name = "rusk-prover"
-version = "1.1.1-alpha.1"
+version = "1.3.0"
 dependencies = [
  "dusk-bytes",
  "dusk-core 1.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,7 +1958,7 @@ dependencies = [
  "rkyv",
  "rusk-profile 1.0.1",
  "rusk-prover",
- "rusk-recovery",
+ "rusk-recovery 1.3.0",
  "rustc_tools_util",
  "rustls-pemfile",
  "semver",
@@ -4566,6 +4566,35 @@ dependencies = [
 [[package]]
 name = "rusk-recovery"
 version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8a915b0121a43f40a83408f6069530822328b50a11c5474b9573f8c4d8c644"
+dependencies = [
+ "bs58",
+ "cargo_toml",
+ "dusk-bytes",
+ "dusk-core 1.3.0",
+ "dusk-plonk",
+ "dusk-vm 1.3.0",
+ "ff",
+ "flate2",
+ "hex",
+ "http_req",
+ "rand 0.8.5",
+ "reqwest",
+ "rusk-profile 1.0.1",
+ "serde",
+ "serde_derive",
+ "tar",
+ "tokio",
+ "toml",
+ "tracing",
+ "url",
+ "zip",
+]
+
+[[package]]
+name = "rusk-recovery"
+version = "1.3.1-alpha.1"
 dependencies = [
  "bs58",
  "cargo_toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-rusk"
-version = "1.3.0"
+version = "1.3.1-alpha.1"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-vm"
-version = "1.2.1-alpha.1"
+version = "1.3.0"
 dependencies = [
  "blake2b_simd",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,7 +1771,7 @@ dependencies = [
  "dusk-consensus 1.3.0",
  "dusk-core 1.3.0",
  "dusk-node-data 1.3.0",
- "dusk-wallet-core",
+ "dusk-wallet-core 1.3.0",
  "fake",
  "hex",
  "humantime-serde",
@@ -1906,7 +1906,7 @@ dependencies = [
  "dusk-stake-contract-dd",
  "dusk-transfer-contract-dd",
  "dusk-vm 1.3.0",
- "dusk-wallet-core",
+ "dusk-wallet-core 1.3.0",
  "ff",
  "futures",
  "futures-util",
@@ -2007,6 +2007,26 @@ dependencies = [
 [[package]]
 name = "dusk-wallet-core"
 version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "018851beb0a54d6ed47d68e863b6da127422c9cfd93f5184227dfea83a4aaf40"
+dependencies = [
+ "blake3",
+ "bytecheck",
+ "dlmalloc",
+ "dusk-bytes",
+ "dusk-core 1.3.0",
+ "ff",
+ "hkdf",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rkyv",
+ "sha2 0.10.8",
+ "zeroize",
+]
+
+[[package]]
+name = "dusk-wallet-core"
+version = "1.3.1-alpha.1"
 dependencies = [
  "blake3",
  "bytecheck",
@@ -4554,7 +4574,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-core 1.3.0",
  "dusk-node-data 1.3.0",
- "dusk-wallet-core",
+ "dusk-wallet-core 1.3.0",
  "flume 0.10.14",
  "futures",
  "hex",
@@ -5212,7 +5232,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-core 1.3.0",
  "dusk-vm 1.3.0",
- "dusk-wallet-core",
+ "dusk-wallet-core 1.3.0",
  "ff",
  "rand 0.8.5",
  "rkyv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3795,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "piecrust"
-version = "0.28.1-rc.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd3d1f26fd2bedd96bd5cc8aa72dd68fd0fa255c735fbc3ed082623647a38d9"
+checksum = "9cba214d425b78af81f4a6a7a63f3dbf73249965873c04794f01b57c06fe5c7b"
 dependencies = [
  "blake3",
  "bytecheck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-core 1.3.0",
  "dusk-merkle",
- "dusk-node-data",
+ "dusk-node-data 1.3.0",
  "hex",
  "num-bigint",
  "rand 0.8.5",
@@ -1750,7 +1750,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-consensus",
  "dusk-core 1.3.0",
- "dusk-node-data",
+ "dusk-node-data 1.3.0",
  "dusk-wallet-core",
  "fake",
  "hex",
@@ -1778,6 +1778,33 @@ dependencies = [
 [[package]]
 name = "dusk-node-data"
 version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f35024b1064ce6a1a3060e985b0c84d4f22b491e76e8037d3b3dccabb06c72d"
+dependencies = [
+ "aes 0.7.5",
+ "anyhow",
+ "async-channel",
+ "base64 0.22.1",
+ "block-modes",
+ "bs58",
+ "chrono",
+ "dusk-bytes",
+ "dusk-core 1.3.0",
+ "fake",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.8",
+ "sha3",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "dusk-node-data"
+version = "1.3.1-alpha.1"
 dependencies = [
  "aes 0.7.5",
  "anyhow",
@@ -1855,7 +1882,7 @@ dependencies = [
  "dusk-core 1.3.0",
  "dusk-data-driver",
  "dusk-node",
- "dusk-node-data",
+ "dusk-node-data 1.3.0",
  "dusk-stake-contract-dd",
  "dusk-transfer-contract-dd",
  "dusk-vm 1.3.0",
@@ -4506,7 +4533,7 @@ dependencies = [
  "dirs",
  "dusk-bytes",
  "dusk-core 1.3.0",
- "dusk-node-data",
+ "dusk-node-data 1.3.0",
  "dusk-wallet-core",
  "flume 0.10.14",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "dusk-wallet-core"
-version = "1.1.1-alpha.1"
+version = "1.3.0"
 dependencies = [
  "blake3",
  "bytecheck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,18 @@ dependencies = [
 [[package]]
 name = "dusk-data-driver"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c1f5c22c0ed47aea3fde481be1ad658460ef6d0d17d0cda398433f57164017"
+dependencies = [
+ "bytecheck",
+ "rkyv",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "dusk-data-driver"
+version = "0.1.1-alpha.1"
 dependencies = [
  "bytecheck",
  "rkyv",
@@ -1934,7 +1946,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-consensus 1.3.0",
  "dusk-core 1.3.0",
- "dusk-data-driver",
+ "dusk-data-driver 0.1.0",
  "dusk-node 1.3.0",
  "dusk-node-data 1.3.0",
  "dusk-stake-contract-dd",
@@ -1991,7 +2003,7 @@ version = "0.0.1-alpha.1"
 dependencies = [
  "dlmalloc",
  "dusk-core 1.3.0",
- "dusk-data-driver",
+ "dusk-data-driver 0.1.0",
  "wasm-bindgen",
 ]
 
@@ -2001,7 +2013,7 @@ version = "0.0.1-alpha.1"
 dependencies = [
  "dlmalloc",
  "dusk-core 1.3.0",
- "dusk-data-driver",
+ "dusk-data-driver 0.1.0",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,7 @@ dependencies = [
  "reqwest",
  "rkyv",
  "rusk-profile 1.0.1",
- "rusk-prover",
+ "rusk-prover 1.3.0",
  "rusk-recovery 1.3.0",
  "rustc_tools_util",
  "rustls-pemfile",
@@ -4552,6 +4552,22 @@ dependencies = [
 [[package]]
 name = "rusk-prover"
 version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ec33ea54518b45d9d26ec791ddc6430f96dcf75083e32170c3d87f7082f692"
+dependencies = [
+ "dusk-bytes",
+ "dusk-core 1.3.0",
+ "dusk-plonk",
+ "hex",
+ "once_cell",
+ "rand 0.8.5",
+ "rusk-profile 1.0.1",
+ "tracing",
+]
+
+[[package]]
+name = "rusk-prover"
+version = "1.3.1-alpha.1"
 dependencies = [
  "dusk-bytes",
  "dusk-core 1.3.0",
@@ -5299,7 +5315,7 @@ dependencies = [
  "ff",
  "rand 0.8.5",
  "rkyv",
- "rusk-prover",
+ "rusk-prover 1.3.0",
 ]
 
 [[package]]
@@ -5783,7 +5799,7 @@ dependencies = [
  "ringbuffer",
  "rkyv",
  "rusk-profile 1.0.1",
- "rusk-prover",
+ "rusk-prover 1.3.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,7 +1949,7 @@ dependencies = [
  "dusk-data-driver 0.1.0",
  "dusk-node 1.3.0",
  "dusk-node-data 1.3.0",
- "dusk-stake-contract-dd",
+ "dusk-stake-contract-dd 0.1.0",
  "dusk-transfer-contract-dd 0.1.0",
  "dusk-vm 1.3.0",
  "dusk-wallet-core 1.3.0",
@@ -2000,6 +2000,18 @@ dependencies = [
 [[package]]
 name = "dusk-stake-contract-dd"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8145dc94ad4c738d3d34e0d4f09060206550e0532e2cf81b2084ab34a10c12ea"
+dependencies = [
+ "dlmalloc",
+ "dusk-core 1.3.0",
+ "dusk-data-driver 0.1.0",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "dusk-stake-contract-dd"
+version = "0.1.1-alpha.1"
 dependencies = [
  "dlmalloc",
  "dusk-core 1.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ dusk-consensus = { version = "1.2.1-alpha.1", path = "./consensus/" }
 dusk-core = "1.3.0"
 # dusk-core = { version = "1.3.1-alpha.1", path = "./core/" }
 # dusk-vm = "1.2.0"
-dusk-vm = { version = "1.2.1-alpha.1", path = "./vm/" }
+dusk-vm = { version = "1.3.0", path = "./vm/" }
 # node = { version = "1.2.0", package = "dusk-node" }
 node = { version = "1.2.1-alpha.1", path = "./node/", package = "dusk-node" }
 # node-data = { version = "1.2.0", package = "dusk-node-data" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ resolver = "2"
 dusk-consensus = { version = "1.2.1-alpha.1", path = "./consensus/" }
 dusk-core = "1.3.0"
 # dusk-core = { version = "1.3.1-alpha.1", path = "./core/" }
-# dusk-vm = "1.2.0"
-dusk-vm = { version = "1.3.0", path = "./vm/" }
+dusk-vm = "1.3.0"
+# dusk-vm = { version = "1.3.1-alpha.1", path = "./vm/" }
 # node = { version = "1.2.0", package = "dusk-node" }
 node = { version = "1.2.1-alpha.1", path = "./node/", package = "dusk-node" }
 # node-data = { version = "1.2.0", package = "dusk-node-data" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ resolver = "2"
 # Workspace internal dependencies
 # dusk-consensus = "1.2.0"
 dusk-consensus = { version = "1.2.1-alpha.1", path = "./consensus/" }
-# dusk-core = "1.2.1"
-dusk-core = { version = "1.3.0", path = "./core/" }
+dusk-core = "1.3.0"
+# dusk-core = { version = "1.3.1-alpha.1", path = "./core/" }
 # dusk-vm = "1.2.0"
 dusk-vm = { version = "1.2.1-alpha.1", path = "./vm/" }
 # node = { version = "1.2.0", package = "dusk-node" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ resolver = "2"
 # dusk-consensus = "1.2.0"
 dusk-consensus = { version = "1.2.1-alpha.1", path = "./consensus/" }
 # dusk-core = "1.2.1"
-dusk-core = { version = "1.2.2-alpha.1", path = "./core/" }
+dusk-core = { version = "1.3.0", path = "./core/" }
 # dusk-vm = "1.2.0"
 dusk-vm = { version = "1.2.1-alpha.1", path = "./vm/" }
 # node = { version = "1.2.0", package = "dusk-node" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,11 +53,12 @@ rusk-recovery = "1.3.0"
 wallet-core = { version = "1.3.0", package = "dusk-wallet-core" }
 # wallet-core = { version = "1.3.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 
-dusk-data-driver = { version = "0.1.0" }
+dusk-data-driver = "0.1.0"
 # dusk-data-driver = { version = "0.1.1-alpha.1", path = "./data-drivers/data-driver" }
-dusk-transfer-contract-dd = { version = "0.1.0" }
+dusk-transfer-contract-dd = "0.1.0"
 # dusk-transfer-contract-dd = { version = "0.1.1-alpha.1", path = "./data-drivers/transfer-contract" }
-dusk-stake-contract-dd = { version = "0.1.0", path = "./data-drivers/stake-contract" }
+dusk-stake-contract-dd = "0.1.0"
+# dusk-stake-contract-dd = { version = "0.1.1-alpha.1", path = "./data-drivers/stake-contract" }
 
 # Dusk dependencies outside the workspace
 bls12_381-bls = { version = "0.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ resolver = "2"
 
 [workspace.dependencies]
 # Workspace internal dependencies
-# dusk-consensus = "1.2.0"
-dusk-consensus = { version = "1.3.0", path = "./consensus/" }
+dusk-consensus = "1.3.0"
+# dusk-consensus = { version = "1.3.1-alpha.1", path = "./consensus/" }
 dusk-core = "1.3.0"
 # dusk-core = { version = "1.3.1-alpha.1", path = "./core/" }
 dusk-vm = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,8 @@ wallet-core = { version = "1.3.0", package = "dusk-wallet-core" }
 
 dusk-data-driver = { version = "0.1.0" }
 # dusk-data-driver = { version = "0.1.1-alpha.1", path = "./data-drivers/data-driver" }
-dusk-transfer-contract-dd = { version = "0.1.0", path = "./data-drivers/transfer-contract" }
+dusk-transfer-contract-dd = { version = "0.1.0" }
+# dusk-transfer-contract-dd = { version = "0.1.1-alpha.1", path = "./data-drivers/transfer-contract" }
 dusk-stake-contract-dd = { version = "0.0.1-alpha.1", path = "./data-drivers/stake-contract" }
 
 # Dusk dependencies outside the workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ rusk-profile = "1.0.1"
 rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
 # rusk-recovery = "1.0.3"
 rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
-# wallet-core = { version = "1.1.0", package = "dusk-wallet-core" }
-wallet-core = { version = "1.3.0", path = "./wallet-core/", package = "dusk-wallet-core" }
+wallet-core = { version = "1.3.0", package = "dusk-wallet-core" }
+# wallet-core = { version = "1.3.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 
 dusk-data-driver = { version = "0.0.1-alpha.1", path = "./data-drivers/data-driver" }
 dusk-transfer-contract-dd = { version = "0.0.1-alpha.1", path = "./data-drivers/transfer-contract" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ wallet-core = { version = "1.3.0", package = "dusk-wallet-core" }
 
 dusk-data-driver = { version = "0.1.0" }
 # dusk-data-driver = { version = "0.1.1-alpha.1", path = "./data-drivers/data-driver" }
-dusk-transfer-contract-dd = { version = "0.0.1-alpha.1", path = "./data-drivers/transfer-contract" }
+dusk-transfer-contract-dd = { version = "0.1.0", path = "./data-drivers/transfer-contract" }
 dusk-stake-contract-dd = { version = "0.0.1-alpha.1", path = "./data-drivers/stake-contract" }
 
 # Dusk dependencies outside the workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,8 @@ rusk-recovery = "1.3.0"
 wallet-core = { version = "1.3.0", package = "dusk-wallet-core" }
 # wallet-core = { version = "1.3.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 
-dusk-data-driver = { version = "0.1.0", path = "./data-drivers/data-driver" }
+dusk-data-driver = { version = "0.1.0" }
+# dusk-data-driver = { version = "0.1.1-alpha.1", path = "./data-drivers/data-driver" }
 dusk-transfer-contract-dd = { version = "0.0.1-alpha.1", path = "./data-drivers/transfer-contract" }
 dusk-stake-contract-dd = { version = "0.0.1-alpha.1", path = "./data-drivers/stake-contract" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
 # rusk-recovery = "1.0.3"
 rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
 # wallet-core = { version = "1.1.0", package = "dusk-wallet-core" }
-wallet-core = { version = "1.1.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
+wallet-core = { version = "1.3.0", path = "./wallet-core/", package = "dusk-wallet-core" }
 
 dusk-data-driver = { version = "0.0.1-alpha.1", path = "./data-drivers/data-driver" }
 dusk-transfer-contract-dd = { version = "0.0.1-alpha.1", path = "./data-drivers/transfer-contract" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ dusk-vm = "1.3.0"
 # node = { version = "1.2.0", package = "dusk-node" }
 node = { version = "1.2.1-alpha.1", path = "./node/", package = "dusk-node" }
 # node-data = { version = "1.2.0", package = "dusk-node-data" }
-node-data = { version = "1.2.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
+node-data = { version = "1.3.0", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 # rusk-prover = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ rusk-recovery = "1.3.0"
 wallet-core = { version = "1.3.0", package = "dusk-wallet-core" }
 # wallet-core = { version = "1.3.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 
-dusk-data-driver = { version = "0.0.1-alpha.1", path = "./data-drivers/data-driver" }
+dusk-data-driver = { version = "0.1.0", path = "./data-drivers/data-driver" }
 dusk-transfer-contract-dd = { version = "0.0.1-alpha.1", path = "./data-drivers/transfer-contract" }
 dusk-stake-contract-dd = { version = "0.0.1-alpha.1", path = "./data-drivers/stake-contract" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 # rusk-prover = "1.1.0"
 rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
-# rusk-recovery = "1.0.3"
-rusk-recovery = { version = "1.3.0", path = "./rusk-recovery/" }
+rusk-recovery = "1.3.0"
+# rusk-recovery = { version = "1.3.1-alpha.1", path = "./rusk-recovery/" }
 wallet-core = { version = "1.3.0", package = "dusk-wallet-core" }
 # wallet-core = { version = "1.3.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ jubjub-schnorr = { version = "0.6", default-features = false }
 kadcast = "0.7"
 phoenix-circuits = { version = "0.6", default-features = false }
 phoenix-core = { version = "0.34.0", default-features = false }
-piecrust = "0.28.1-rc.0"
+piecrust = "0.28.1"
 piecrust-uplink = "0.18.0"
 poseidon-merkle = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ dusk-vm = "1.3.0"
 # dusk-vm = { version = "1.3.1-alpha.1", path = "./vm/" }
 # node = { version = "1.2.0", package = "dusk-node" }
 node = { version = "1.2.1-alpha.1", path = "./node/", package = "dusk-node" }
-# node-data = { version = "1.2.0", package = "dusk-node-data" }
-node-data = { version = "1.3.0", path = "./node-data/", package = "dusk-node-data" }
+node-data = { version = "1.3.0", package = "dusk-node-data" }
+# node-data = { version = "1.3.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 # rusk-prover = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ dusk-core = "1.3.0"
 # dusk-core = { version = "1.3.1-alpha.1", path = "./core/" }
 dusk-vm = "1.3.0"
 # dusk-vm = { version = "1.3.1-alpha.1", path = "./vm/" }
-# node = { version = "1.2.0", package = "dusk-node" }
-node = { version = "1.3.0", path = "./node/", package = "dusk-node" }
+node = { version = "1.3.0", package = "dusk-node" }
+# node = { version = "1.3.1-alpha.1", path = "./node/", package = "dusk-node" }
 node-data = { version = "1.3.0", package = "dusk-node-data" }
 # node-data = { version = "1.3.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ node-data = { version = "1.3.0", package = "dusk-node-data" }
 # node-data = { version = "1.3.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
-# rusk-prover = "1.1.0"
-rusk-prover = { version = "1.3.0", path = "./rusk-prover/" }
+rusk-prover = "1.3.0"
+# rusk-prover = { version = "1.3.1-alpha.1", path = "./rusk-prover/" }
 rusk-recovery = "1.3.0"
 # rusk-recovery = { version = "1.3.1-alpha.1", path = "./rusk-recovery/" }
 wallet-core = { version = "1.3.0", package = "dusk-wallet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ node-data = { version = "1.3.0", package = "dusk-node-data" }
 rusk-profile = "1.0.1"
 # rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
 # rusk-prover = "1.1.0"
-rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
+rusk-prover = { version = "1.3.0", path = "./rusk-prover/" }
 rusk-recovery = "1.3.0"
 # rusk-recovery = { version = "1.3.1-alpha.1", path = "./rusk-recovery/" }
 wallet-core = { version = "1.3.0", package = "dusk-wallet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,31 +34,31 @@ resolver = "2"
 
 [workspace.dependencies]
 # Workspace internal dependencies
-dusk-consensus = "1.3.0"
-# dusk-consensus = { version = "1.3.1-alpha.1", path = "./consensus/" }
-dusk-core = "1.3.0"
-# dusk-core = { version = "1.3.1-alpha.1", path = "./core/" }
-dusk-vm = "1.3.0"
-# dusk-vm = { version = "1.3.1-alpha.1", path = "./vm/" }
-node = { version = "1.3.0", package = "dusk-node" }
-# node = { version = "1.3.1-alpha.1", path = "./node/", package = "dusk-node" }
-node-data = { version = "1.3.0", package = "dusk-node-data" }
-# node-data = { version = "1.3.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
-rusk-profile = "1.0.1"
-# rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
-rusk-prover = "1.3.0"
-# rusk-prover = { version = "1.3.1-alpha.1", path = "./rusk-prover/" }
-rusk-recovery = "1.3.0"
-# rusk-recovery = { version = "1.3.1-alpha.1", path = "./rusk-recovery/" }
-wallet-core = { version = "1.3.0", package = "dusk-wallet-core" }
-# wallet-core = { version = "1.3.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
+# dusk-consensus = "1.3.0"
+dusk-consensus = { version = "1.3.1-alpha.1", path = "./consensus/" }
+# dusk-core = "1.3.0"
+dusk-core = { version = "1.3.1-alpha.1", path = "./core/" }
+# dusk-vm = "1.3.0"
+dusk-vm = { version = "1.3.1-alpha.1", path = "./vm/" }
+# node = { version = "1.3.0", package = "dusk-node" }
+node = { version = "1.3.1-alpha.1", path = "./node/", package = "dusk-node" }
+# node-data = { version = "1.3.0", package = "dusk-node-data" }
+node-data = { version = "1.3.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
+# rusk-profile = "1.0.1"
+rusk-profile = { version = "1.0.2-alpha.1", path = "./rusk-profile/" }
+# rusk-prover = "1.3.0"
+rusk-prover = { version = "1.3.1-alpha.1", path = "./rusk-prover/" }
+# rusk-recovery = "1.3.0"
+rusk-recovery = { version = "1.3.1-alpha.1", path = "./rusk-recovery/" }
+# wallet-core = { version = "1.3.0", package = "dusk-wallet-core" }
+wallet-core = { version = "1.3.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 
-dusk-data-driver = "0.1.0"
-# dusk-data-driver = { version = "0.1.1-alpha.1", path = "./data-drivers/data-driver" }
-dusk-transfer-contract-dd = "0.1.0"
-# dusk-transfer-contract-dd = { version = "0.1.1-alpha.1", path = "./data-drivers/transfer-contract" }
-dusk-stake-contract-dd = "0.1.0"
-# dusk-stake-contract-dd = { version = "0.1.1-alpha.1", path = "./data-drivers/stake-contract" }
+# dusk-data-driver = "0.1.0"
+dusk-data-driver = { version = "0.1.1-alpha.1", path = "./data-drivers/data-driver" }
+# dusk-transfer-contract-dd = "0.1.0"
+dusk-transfer-contract-dd = { version = "0.1.1-alpha.1", path = "./data-drivers/transfer-contract" }
+# dusk-stake-contract-dd = "0.1.0"
+dusk-stake-contract-dd = { version = "0.1.1-alpha.1", path = "./data-drivers/stake-contract" }
 
 # Dusk dependencies outside the workspace
 bls12_381-bls = { version = "0.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ resolver = "2"
 [workspace.dependencies]
 # Workspace internal dependencies
 # dusk-consensus = "1.2.0"
-dusk-consensus = { version = "1.2.1-alpha.1", path = "./consensus/" }
+dusk-consensus = { version = "1.3.0", path = "./consensus/" }
 dusk-core = "1.3.0"
 # dusk-core = { version = "1.3.1-alpha.1", path = "./core/" }
 dusk-vm = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ rusk-profile = "1.0.1"
 # rusk-prover = "1.1.0"
 rusk-prover = { version = "1.1.1-alpha.1", path = "./rusk-prover/" }
 # rusk-recovery = "1.0.3"
-rusk-recovery = { version = "1.0.4-alpha.1", path = "./rusk-recovery/" }
+rusk-recovery = { version = "1.3.0", path = "./rusk-recovery/" }
 wallet-core = { version = "1.3.0", package = "dusk-wallet-core" }
 # wallet-core = { version = "1.3.1-alpha.1", path = "./wallet-core/", package = "dusk-wallet-core" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ dusk-core = "1.3.0"
 dusk-vm = "1.3.0"
 # dusk-vm = { version = "1.3.1-alpha.1", path = "./vm/" }
 # node = { version = "1.2.0", package = "dusk-node" }
-node = { version = "1.2.1-alpha.1", path = "./node/", package = "dusk-node" }
+node = { version = "1.3.0", path = "./node/", package = "dusk-node" }
 node-data = { version = "1.3.0", package = "dusk-node-data" }
 # node-data = { version = "1.3.1-alpha.1", path = "./node-data/", package = "dusk-node-data" }
 rusk-profile = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ dusk-data-driver = { version = "0.1.0" }
 # dusk-data-driver = { version = "0.1.1-alpha.1", path = "./data-drivers/data-driver" }
 dusk-transfer-contract-dd = { version = "0.1.0" }
 # dusk-transfer-contract-dd = { version = "0.1.1-alpha.1", path = "./data-drivers/transfer-contract" }
-dusk-stake-contract-dd = { version = "0.0.1-alpha.1", path = "./data-drivers/stake-contract" }
+dusk-stake-contract-dd = { version = "0.1.0", path = "./data-drivers/stake-contract" }
 
 # Dusk dependencies outside the workspace
 bls12_381-bls = { version = "0.5", default-features = false }

--- a/consensus/CHANGELOG.md
+++ b/consensus/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-04-17
+
 ### Fixed
 
 - Fix invalid Quorum message with NoQuorum result [#3543]
@@ -32,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Issues -->
 [#3543]: https://github.com/dusk-network/rusk/issues/3543
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-consensus-1.2.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-consensus-1.3.0...HEAD
+[1.3.0]: https://github.com/dusk-network/rusk/compare/dusk-consensus-1.2.0...dusk-consensus-1.3.0
 [1.2.0]: https://github.com/dusk-network/rusk/compare/dusk-consensus-1.0.1...dusk-consensus-1.2.0
 [1.0.1]: https://github.com/dusk-network/rusk/compare/consensus-1.0.0...dusk-consensus-1.0.1
 [0.1.0]: https://github.com/dusk-network/rusk/tree/consensus-1.0.0

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-consensus"
-version = "1.3.0"
+version = "1.3.1-alpha.1"
 edition = "2021"
 repository = "https://github.com/dusk-network/rusk"
 description = "Implementation of Dusk Succinct Attestation consensus protocol"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-consensus"
-version = "1.2.1-alpha.1"
+version = "1.3.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/rusk"
 description = "Implementation of Dusk Succinct Attestation consensus protocol"

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-04-17
+
 ### Added
 
 - Add `ContractCall::with_args` [#3533]
@@ -57,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3341]: https://github.com/dusk-network/rusk/issues/3341
 [#2773]: https://github.com/dusk-network/rusk/issues/2773
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-core-1.2.1...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-core-1.3.0...HEAD
+[1.3.0]: https://github.com/dusk-network/rusk/compare/dusk-core-1.2.1...dusk-core-1.3.0
 [1.2.1]: https://github.com/dusk-network/rusk/compare/dusk-core-1.1.0...dusk-core-1.2.1
 [1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-core-1.0.0...dusk-core-1.1.0
 [1.0.0]: https://github.com/dusk-network/rusk/compare/dusk-core-0.1.0...dusk-core-1.0.0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-core"
-version = "1.2.2-alpha.1"
+version = "1.3.0"
 edition = "2021"
 
 description = "Types used for interacting with Dusk's transfer and stake contracts."

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-core"
-version = "1.3.0"
+version = "1.3.1-alpha.1"
 edition = "2021"
 
 description = "Types used for interacting with Dusk's transfer and stake contracts."

--- a/data-drivers/data-driver/CHANGELOG.md
+++ b/data-drivers/data-driver/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2025-04-17
+
 ### Added
 
 - Add `ConvertibleContract` trait for seamless conversion between JSON and RKYV formats.
 - Add `rkyv_to_json` and `json_to_rkyv` functions for bidirectional serialization.
 - Add support for encoding and decoding function inputs, outputs, and events in RKYV.
+
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-data-driver-0.1.0...HEAD
+[0.1.0]: https://github.com/dusk-network/rusk/tree/dusk-data-driver-0.1.0

--- a/data-drivers/data-driver/Cargo.toml
+++ b/data-drivers/data-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-data-driver"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 edition = "2021"
 
 description = "Data driver contract interface to support json serialization"

--- a/data-drivers/data-driver/Cargo.toml
+++ b/data-drivers/data-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-data-driver"
-version = "0.1.0"
+version = "0.1.1-alpha.1"
 edition = "2021"
 
 description = "Data driver contract interface to support json serialization"

--- a/data-drivers/data-driver/src/lib.rs
+++ b/data-drivers/data-driver/src/lib.rs
@@ -135,7 +135,7 @@ pub trait ConvertibleContract: Send {
     ///   `"0.10.1"`).
     #[must_use]
     fn get_version(&self) -> &'static str {
-        "1.0.0"
+        "0.1.0"
     }
 }
 

--- a/data-drivers/stake-contract/CHANGELOG.md
+++ b/data-drivers/stake-contract/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2025-04-17
+
 ### Added
 
 - Add implementation for `ConvertibleContract`
+
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-stake-contract-dd-0.1.0...HEAD
+[0.1.0]: https://github.com/dusk-network/rusk/tree/dusk-stake-contract-dd-0.1.0

--- a/data-drivers/stake-contract/Cargo.toml
+++ b/data-drivers/stake-contract/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "dusk-stake-contract-dd"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 edition = "2021"
+
+description = "Data driver for Dusk Stake Contract"
+license = "MPL-2.0"
+repository = "https://github.com/dusk-network/rusk"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/data-drivers/stake-contract/Cargo.toml
+++ b/data-drivers/stake-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-stake-contract-dd"
-version = "0.1.0"
+version = "0.1.1-alpha.1"
 edition = "2021"
 
 description = "Data driver for Dusk Stake Contract"

--- a/data-drivers/transfer-contract/CHANGELOG.md
+++ b/data-drivers/transfer-contract/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2025-04-17
+
 ### Added
 
 - Add implementation for `ConvertibleContract`
+
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-transfer-contract-dd-0.1.0...HEAD
+[0.1.0]: https://github.com/dusk-network/rusk/tree/dusk-transfer-contract-dd-0.1.0

--- a/data-drivers/transfer-contract/Cargo.toml
+++ b/data-drivers/transfer-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-transfer-contract-dd"
-version = "0.1.0"
+version = "0.1.1-alpha.1"
 edition = "2021"
 
 description = "Data driver for Dusk Transfer Contract"

--- a/data-drivers/transfer-contract/Cargo.toml
+++ b/data-drivers/transfer-contract/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "dusk-transfer-contract-dd"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 edition = "2021"
+
+description = "Data driver for Dusk Transfer Contract"
+license = "MPL-2.0"
+repository = "https://github.com/dusk-network/rusk"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/node-data/CHANGELOG.md
+++ b/node-data/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-04-17
+
 ### Changed
 
 - Make Transaction `size` method infallible
@@ -47,7 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3359]: https://github.com/dusk-network/rusk/issues/3359
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.2.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.3.0...HEAD
+[1.3.0]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.2.0...dusk-node-data-1.3.0
 [1.2.0]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.1.0...dusk-node-data-1.2.0
 [1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.0.1...dusk-node-data-1.1.0
 [1.0.1]: https://github.com/dusk-network/rusk/compare/dusk-node-data-1.0.0...dusk-node-data-1.0.1

--- a/node-data/Cargo.toml
+++ b/node-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-node-data"
-version = "1.3.0"
+version = "1.3.1-alpha.1"
 edition = "2021"
 
 description = "Types used for interacting with Dusk node."

--- a/node-data/Cargo.toml
+++ b/node-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-node-data"
-version = "1.2.1-alpha.1"
+version = "1.3.0"
 edition = "2021"
 
 description = "Types used for interacting with Dusk node."

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-04-17
+
 ### Added
 
 - Add transaction serialization check
@@ -57,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3407]: https://github.com/dusk-network/rusk/issues/3407
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-node-1.2.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-node-1.3.0...HEAD
+[1.3.0]: https://github.com/dusk-network/rusk/compare/dusk-node-1.2.0...dusk-node-1.3.0
 [1.2.0]: https://github.com/dusk-network/rusk/compare/dusk-node-1.1.0...dusk-node-1.2.0
 [1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-node-1.0.1...dusk-node-1.1.0
 [1.0.1]: https://github.com/dusk-network/rusk/compare/node-1.0.0...dusk-node-1.0.1

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-node"
-version = "1.2.1-alpha.1"
+version = "1.3.0"
 edition = "2021"
 autobins = false
 repository = "https://github.com/dusk-network/rusk"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-node"
-version = "1.3.0"
+version = "1.3.1-alpha.1"
 edition = "2021"
 autobins = false
 repository = "https://github.com/dusk-network/rusk"

--- a/rusk-prover/CHANGELOG.md
+++ b/rusk-prover/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-04-17
+
 ### Changed
 
 - Upgrade `dusk-core` to `1.3.0`
@@ -40,7 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Issues -->
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-prover-1.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-prover-1.3.0...HEAD
+[1.3.0]: https://github.com/dusk-network/rusk/compare/rusk-prover-1.1.0...rusk-prover-1.3.0
 [1.1.0]: https://github.com/dusk-network/rusk/compare/rusk-prover-1.0.1...rusk-prover-1.1.0
 [1.0.1]: https://github.com/dusk-network/rusk/compare/rusk-prover-1.0.0...rusk-prover-1.0.1
 [1.0.0]: https://github.com/dusk-network/rusk/tree/rusk-prover-1.0.0

--- a/rusk-prover/CHANGELOG.md
+++ b/rusk-prover/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `dusk-core` to `1.3.0`
+
 ## [1.1.0] - 2025-02-14
 
 ### Changed

--- a/rusk-prover/Cargo.toml
+++ b/rusk-prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-prover"
-version = "1.1.1-alpha.1"
+version = "1.3.0"
 edition = "2021"
 autobins = false
 

--- a/rusk-prover/Cargo.toml
+++ b/rusk-prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-prover"
-version = "1.3.0"
+version = "1.3.1-alpha.1"
 edition = "2021"
 autobins = false
 

--- a/rusk-recovery/CHANGELOG.md
+++ b/rusk-recovery/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-04-17
+
 ### Changed
 
 - Upgrade piecrust to `0.28.1`
@@ -33,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3407]: https://github.com/dusk-network/rusk/issues/3407
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-recovery-1.0.3...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/rusk-recovery-1.3.0...HEAD
+[1.3.0]: https://github.com/dusk-network/rusk/compare/rusk-recovery-1.0.3...rusk-recovery-1.3.0
 [1.0.3]: https://github.com/dusk-network/rusk/compare/rusk-recovery-1.0.2...rusk-recovery-1.0.3
 [1.0.2]: https://github.com/dusk-network/rusk/compare/rusk-recovery-1.0.1...rusk-recovery-1.0.2
 [1.0.1]: https://github.com/dusk-network/rusk/tree/rusk-recovery-1.0.1

--- a/rusk-recovery/CHANGELOG.md
+++ b/rusk-recovery/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade piecrust to `0.28.1`
+- Upgrade `dusk-vm` to `1.3.0`
+- Upgrade `dusk-core` to `1.3.0`
+
 ## [1.0.3] - 2025-02-14
 
 ### Changed

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-recovery"
-version = "1.3.0"
+version = "1.3.1-alpha.1"
 edition = "2021"
 autobins = false
 description = "Tool to restore Rusk to factory settings"

--- a/rusk-recovery/Cargo.toml
+++ b/rusk-recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-recovery"
-version = "1.0.4-alpha.1"
+version = "1.3.0"
 edition = "2021"
 autobins = false
 description = "Tool to restore Rusk to factory settings"

--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-04-17
+
 ### Added
 
 - Add `Content-Type: application/json` support for `/on/contracts` endpoint
@@ -406,7 +408,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#290]: https://github.com/dusk-network/rusk/issues/290
 
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.2.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.3.0...HEAD
+[1.3.0]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.2.0...dusk-rusk-1.3.0
 [1.2.0]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.1.1...dusk-rusk-1.2.0
 [1.1.1]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.1.0...dusk-rusk-1.1.1
 [1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-rusk-1.0.2...dusk-rusk-1.1.0

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-rusk"
-version = "1.3.0"
+version = "1.3.1-alpha.1"
 edition = "2021"
 autobins = false
 

--- a/rusk/Cargo.toml
+++ b/rusk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-rusk"
-version = "1.2.1-alpha.1"
+version = "1.3.0"
 edition = "2021"
 autobins = false
 

--- a/vm/CHANGELOG.md
+++ b/vm/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-04-17
+
 ### Changed
 
 - Change piecrust version requirement to `0.28.1`
@@ -47,7 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 [#3437]: https://github.com/dusk-network/rusk/issues/3437
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-vm-1.2.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-vm-1.3.0...HEAD
+[1.3.0]: https://github.com/dusk-network/rusk/compare/dusk-vm-1.2.0...dusk-vm-1.3.0
 [1.2.0]: https://github.com/dusk-network/rusk/compare/dusk-vm-1.1.0...dusk-vm-1.2.0
 [1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-vm-1.0.0...dusk-vm-1.1.0
 [1.0.0]: https://github.com/dusk-network/rusk/compare/dusk-vm-0.1.0...dusk-vm-1.0.0

--- a/vm/CHANGELOG.md
+++ b/vm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change piecrust version requirement to `0.28.1`
+
 ## [1.2.0] - 2025-03-20
 
 ### Changed

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-vm"
-version = "1.3.0"
+version = "1.3.1-alpha.1"
 edition = "2021"
 
 repository = "https://github.com/dusk-network/rusk"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-vm"
-version = "1.2.1-alpha.1"
+version = "1.3.0"
 edition = "2021"
 
 repository = "https://github.com/dusk-network/rusk"

--- a/wallet-core/CHANGELOG.md
+++ b/wallet-core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-04-17
+
 ### Added
 
 - Added support for EIP2333 BLS key derivation [#3476]
@@ -36,7 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3438]: https://github.com/dusk-network/rusk/issues/3438
 [#3405]: https://github.com/dusk-network/rusk/issues/3405
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-wallet-core-1.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/dusk-wallet-core-1.3.0...HEAD
+[1.3.0]: https://github.com/dusk-network/rusk/compare/dusk-wallet-core-1.1.0...dusk-wallet-core-1.3.0
 [1.1.0]: https://github.com/dusk-network/rusk/compare/dusk-wallet-core-1.0.1...dusk-wallet-core-1.1.0
 [1.0.1]: https://github.com/dusk-network/rusk/compare/wallet-core-1.0.0...dusk-wallet-core-1.0.1
 [1.0.0]: https://github.com/dusk-network/rusk/tree/wallet-core-1.0.0

--- a/wallet-core/CHANGELOG.md
+++ b/wallet-core/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for EIP2333 BLS key derivation [#3476]
 
+### Changed
+
+- Changed `dusk-core` version to `1.3.0`
+
 ## [1.1.0] - 2025-02-14
 
 ### Changed

--- a/wallet-core/Cargo.toml
+++ b/wallet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "1.1.1-alpha.1"
+version = "1.3.0"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"

--- a/wallet-core/Cargo.toml
+++ b/wallet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "1.3.0"
+version = "1.3.1-alpha.1"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"


### PR DESCRIPTION

### Added

- Add `Content-Type: application/json` support for `/on/contracts` endpoint
- Add transaction serialization check
- Add max transaction size check
- Add `/on/driver:<contract>/<method>:<target>` endpoint
- Add from_block & to_block params to `full_moonlight_history` in gql [#3613]

### Changed

- Upgrade piecrust to `0.28.1`