### PR TITLE
consensus: Refactor verify_att

### DIFF
--- a/consensus/src/aggregator.rs
+++ b/consensus/src/aggregator.rs
@@ -360,8 +360,9 @@ mod tests {
             let vote = vote.clone();
             // Last member's vote should reach the quorum
             if i == winning_index {
-                // (hash, sv) is only returned in case we reach the quorum
-                let (sv, quorum_reached) =
+                // (hash, step_votes) is only returned in case we reach the
+                // quorum
+                let (step_votes, quorum_reached) =
                     a.collect_vote(&c, msg).expect("failed to reach quorum");
 
                 assert!(quorum_reached, "quorum should be reached");
@@ -370,8 +371,8 @@ mod tests {
 
                 // Check expected StepVotes bitset
                 // bitset: 0b00000000000000000000000000000000000000000000000000000000011111
-                println!("bitset: {:#064b}", sv.bitset);
-                assert_eq!(sv.bitset, 31);
+                println!("bitset: {:#064b}", step_votes.bitset);
+                assert_eq!(step_votes.bitset, 31);
 
                 break;
             }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -133,7 +133,7 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
                 future_msgs.lock().await.remove_msgs_by_round(ru.round - 1);
             }
 
-            let sv_registry = Arc::new(Mutex::new(AttInfoRegistry::new()));
+            let att_registry = Arc::new(Mutex::new(AttInfoRegistry::new()));
 
             let proposal_handler = Arc::new(Mutex::new(
                 proposal::handler::ProposalHandler::new(db.clone()),
@@ -141,14 +141,14 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
 
             let validation_handler = Arc::new(Mutex::new(
                 validation::handler::ValidationHandler::new(
-                    sv_registry.clone(),
+                    att_registry.clone(),
                     db.clone(),
                 ),
             ));
 
             let ratification_handler = Arc::new(Mutex::new(
                 ratification::handler::RatificationHandler::new(
-                    sv_registry.clone(),
+                    att_registry.clone(),
                 ),
             ));
 
@@ -233,7 +233,7 @@ impl<T: Operations + 'static, D: Database + 'static> Consensus<T, D> {
                         iter,
                         step_name,
                         executor.clone(),
-                        sv_registry.clone(),
+                        att_registry.clone(),
                     );
 
                     // Execute a phase

--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -55,7 +55,7 @@ pub struct ExecutionCtx<'a, T, DB: Database> {
 
     pub client: Arc<T>,
 
-    pub sv_registry: SafeAttestationInfoRegistry,
+    pub att_registry: SafeAttestationInfoRegistry,
 }
 
 impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
@@ -71,7 +71,7 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
         iteration: u8,
         step: StepName,
         client: Arc<T>,
-        sv_registry: SafeAttestationInfoRegistry,
+        att_registry: SafeAttestationInfoRegistry,
     ) -> Self {
         Self {
             iter_ctx,
@@ -83,7 +83,7 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
             iteration,
             step,
             client,
-            sv_registry,
+            att_registry,
             step_start_time: None,
         }
     }
@@ -280,10 +280,10 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
                                     // past-iteration Attestations without
                                     // interrupting the step execution
 
-                                    let mut sv_registry =
-                                        self.sv_registry.lock().await;
+                                    let mut att_registry =
+                                        self.att_registry.lock().await;
 
-                                    match sv_registry.get_fail_att(qiter) {
+                                    match att_registry.get_fail_att(qiter) {
                                         None => {
                                             debug!(
                                               event = "Storing Fail Attestation",
@@ -296,7 +296,7 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
                                                 .iter_ctx
                                                 .get_generator(qiter);
 
-                                            sv_registry
+                                            att_registry
                                             .set_attestation(
                                               qiter,
                                               att,

--- a/consensus/src/proposal/step.rs
+++ b/consensus/src/proposal/step.rs
@@ -64,9 +64,9 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
             let iteration =
                 cmp::min(config::RELAX_ITERATION_THRESHOLD, ctx.iteration);
 
-            // Fetch failed attestations from sv_registry
+            // Fetch failed attestations from att_registry
             let failed_attestations =
-                ctx.sv_registry.lock().await.get_failed_atts(iteration);
+                ctx.att_registry.lock().await.get_failed_atts(iteration);
 
             match self
                 .bg

--- a/consensus/src/quorum/verifiers.rs
+++ b/consensus/src/quorum/verifiers.rs
@@ -25,126 +25,78 @@ use crate::user::committee::{Committee, CommitteeSet};
 use crate::user::sortition;
 
 pub async fn verify_step_votes(
-    header: &ConsensusHeader,
+    ch: &ConsensusHeader,
     vote: &Vote,
     sv: &StepVotes,
     committees_set: &RwLock<CommitteeSet<'_>>,
     seed: Seed,
     step: StepName,
 ) -> Result<Vec<Voter>, StepSigError> {
-    let round = header.round;
-    let iteration = header.iteration;
-
-    let mut exclusion_list = vec![];
-    let generator = committees_set
-        .read()
-        .await
-        .provisioners()
-        .get_generator(iteration, seed, round);
-
-    exclusion_list.push(generator);
-
-    if exclude_next_generator(iteration) {
-        let next_generator = committees_set
-            .read()
-            .await
-            .provisioners()
-            .get_generator(iteration + 1, seed, round);
-
-        exclusion_list.push(next_generator);
+    // When verifying a NoQuorum Attestation, the Validation StepVotes should be
+    // empty. To be on the safe side, we simply skip verification, instead of
+    // failing verification
+    if step == StepName::Validation && *vote == Vote::NoQuorum {
+        return Ok(vec![]);
     }
 
-    let cfg =
-        sortition::Config::new(seed, round, iteration, step, exclusion_list);
+    let committee = get_step_committee(ch, committees_set, seed, step).await;
 
-    if committees_set.read().await.get(&cfg).is_none() {
-        let _ = committees_set.write().await.get_or_create(&cfg);
-    }
-
-    let set = committees_set.read().await;
-    let committee = set.get(&cfg).expect("committee to be created");
-
+    // Verify the aggregated signature is valid and reach the quorum threshold
     let voters =
-        verify_votes(header, step, vote, sv, committee)
-        .map_err(|e|
-            {
-                error!( "invalid {:?}, vote = {:?}, round = {}, iter = {}, seed = {}, sv = {:?}, err = {}",
-                    step,
-                    vote,
-                    header.round,
-                    header.iteration,
-                    to_str(seed.inner()),
-                    sv,
-                    e
-                );
-                e
-            }
-        )?;
+        verify_quorum_votes(ch, step, vote, sv, &committee).map_err(|e| {
+            error!(
+                event = "Invalid StepVotes",
+                reason = %e,
+                ?vote,
+                round = ch.round,
+                iter = ch.iteration,
+                ?step,
+                seed = to_str(seed.inner()),
+                ?sv
+            );
+
+            e
+        })?;
 
     Ok(voters)
 }
 
-pub struct QuorumResult {
-    pub total: usize,
-    pub target_quorum: usize,
-}
-
-impl QuorumResult {
-    pub fn quorum_reached(&self) -> bool {
-        self.total >= self.target_quorum
-    }
-}
-
-pub fn verify_votes(
+pub fn verify_quorum_votes(
     header: &ConsensusHeader,
     step: StepName,
     vote: &Vote,
-    step_votes: &StepVotes,
+    sv: &StepVotes,
     committee: &Committee,
 ) -> Result<Vec<Voter>, StepSigError> {
-    let bitset = step_votes.bitset;
-    let signature = step_votes.aggregate_signature().inner();
+    let bitset = sv.bitset;
+    let signature = sv.aggregate_signature().inner();
     let sub_committee = committee.intersect(bitset);
 
-    let total = committee.total_occurrences(&sub_committee);
-    let target_quorum = match vote {
+    let total_credits = committee.total_occurrences(&sub_committee);
+    let quorum_threshold = match vote {
         Vote::Valid(_) => committee.super_majority_quorum(),
         _ => committee.majority_quorum(),
     };
 
-    let quorum_result = QuorumResult {
-        total,
-        target_quorum,
-    };
-
-    let skip_quorum = step == StepName::Validation && vote == &Vote::NoQuorum;
-
-    if !skip_quorum && !quorum_result.quorum_reached() {
-        tracing::error!(
-            desc = "vote_set_too_small",
+    // Check credits reach the quorum
+    if total_credits < quorum_threshold {
+        error!(
+            event = "Invalid quorum",
+            reason = "Credits below the quorum threhsold",
+            total_credits,
+            quorum_threshold,
             committee = format!("{committee}"),
             sub_committee = format!("{:#?}", sub_committee),
             bitset,
-            target_quorum,
-            total,
             ?vote
         );
         return Err(StepSigError::VoteSetTooSmall);
     }
 
-    // If bitset=0 this means that we are checking for failed iteration
-    // attestations. If a winning attestation is checked with bitset=0 it will
-    // fail to pass the quorum and results in VoteSetTooSmall.
-    // FIXME: Anyway this should be handled properly, maybe with a different
-    // function
-    if bitset > 0 {
-        // aggregate public keys
-        let apk = sub_committee.aggregate_pks()?;
+    // Verify aggregated signature
+    let apk = sub_committee.aggregate_pks()?;
+    verify_step_signature(header, step, vote, apk, signature)?;
 
-        // verify signatures
-        verify_step_signature(header, step, vote, apk, signature)?;
-    }
-    // Verification done
     Ok(sub_committee.to_voters())
 }
 

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -23,7 +23,7 @@ use crate::config::is_emergency_iter;
 use crate::errors::ConsensusError;
 use crate::iteration_ctx::RoundCommittees;
 use crate::msg_handler::{MsgHandler, StepOutcome};
-use crate::quorum::verifiers::verify_votes;
+use crate::quorum::verifiers::verify_quorum_votes;
 use crate::step_votes_reg::SafeAttestationInfoRegistry;
 use crate::user::committee::Committee;
 
@@ -344,7 +344,7 @@ impl RatificationHandler {
                 error!("could not get validation committee");
                 ConsensusError::CommitteeNotGenerated
             })?;
-        verify_votes(
+        verify_quorum_votes(
             header,
             StepName::Validation,
             result.vote(),

--- a/consensus/src/ratification/handler.rs
+++ b/consensus/src/ratification/handler.rs
@@ -28,7 +28,7 @@ use crate::step_votes_reg::SafeAttestationInfoRegistry;
 use crate::user::committee::Committee;
 
 pub struct RatificationHandler {
-    pub(crate) sv_registry: SafeAttestationInfoRegistry,
+    pub(crate) att_registry: SafeAttestationInfoRegistry,
 
     pub(crate) aggregator: Aggregator<Ratification>,
     validation_result: ValidationResult,
@@ -131,7 +131,7 @@ impl MsgHandler for RatificationHandler {
 
         if vote == Vote::NoQuorum {
             // If the vote is NoQuorum, ensure StepVotes is empty
-            if !p.validation_result.sv().is_empty() {
+            if !p.validation_result.step_votes().is_empty() {
                 warn!(
                     event = "Vote discarded",
                     step = "Ratification",
@@ -194,7 +194,7 @@ impl MsgHandler for RatificationHandler {
         }
 
         // Collect vote
-        let (ratification_sv, quorum_reached) = self
+        let (step_votes, quorum_reached) = self
             .aggregator
             .collect_vote(committee, &p)
             .map_err(|error| {
@@ -212,14 +212,16 @@ impl MsgHandler for RatificationHandler {
 
         // Record updated Ratification StepVotes in global registry
         // If we reached a quorum on both steps, return the Quorum message
-        if let Some(attestation) = self.sv_registry.lock().await.set_step_votes(
-            iteration,
-            &vote,
-            ratification_sv,
-            StepName::Ratification,
-            quorum_reached,
-            &generator.expect("There must be a valid generator"),
-        ) {
+        if let Some(attestation) =
+            self.att_registry.lock().await.set_step_votes(
+                iteration,
+                &vote,
+                step_votes,
+                StepName::Ratification,
+                quorum_reached,
+                &generator.expect("There must be a valid generator"),
+            )
+        {
             let ch = ConsensusHeader {
                 prev_block_hash: ru.hash(),
                 round: ru.round,
@@ -245,13 +247,13 @@ impl MsgHandler for RatificationHandler {
         let collect_vote = self.aggregator.collect_vote(committee, &p);
 
         match collect_vote {
-            Ok((sv, quorum_reached)) => {
+            Ok((step_votes, quorum_reached)) => {
                 // Record any signature in global registry
                 if let Some(attestation) =
-                    self.sv_registry.lock().await.set_step_votes(
+                    self.att_registry.lock().await.set_step_votes(
                         p.header().iteration,
                         &p.vote,
-                        sv,
+                        step_votes,
                         StepName::Ratification,
                         quorum_reached,
                         &generator.expect("There must be a valid generator"),
@@ -289,9 +291,9 @@ impl MsgHandler for RatificationHandler {
 }
 
 impl RatificationHandler {
-    pub(crate) fn new(sv_registry: SafeAttestationInfoRegistry) -> Self {
+    pub(crate) fn new(att_registry: SafeAttestationInfoRegistry) -> Self {
         Self {
-            sv_registry,
+            att_registry,
             aggregator: Default::default(),
             validation_result: Default::default(),
             curr_iteration: 0,
@@ -348,7 +350,7 @@ impl RatificationHandler {
             header,
             StepName::Validation,
             result.vote(),
-            result.sv(),
+            result.step_votes(),
             validation_committee,
         )?;
         Ok(())

--- a/consensus/src/ratification/step.rs
+++ b/consensus/src/ratification/step.rs
@@ -46,7 +46,7 @@ impl RatificationStep {
               step = "Ratification",
               info = ?msg.header,
               vote = ?vote,
-              validation_bitset = result.sv().bitset
+              validation_bitset = result.step_votes().bitset
             );
 
             // Publish
@@ -111,9 +111,9 @@ impl RatificationStep {
             name = self.name(),
             round = round,
             iter = iteration,
-            vote = ?handler.validation_result().vote(),
-            fsv_bitset = handler.validation_result().sv().bitset,
-            quorum_type = ?handler.validation_result().quorum()
+            validation_quorum = ?handler.validation_result().quorum(),
+            validation_vote = ?handler.validation_result().vote(),
+            validation_bitset = handler.validation_result().step_votes().bitset
         )
     }
 

--- a/node-data/src/encoding.rs
+++ b/node-data/src/encoding.rs
@@ -396,7 +396,7 @@ impl Serializable for Ratification {
 
 impl Serializable for ValidationResult {
     fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        self.sv.write(w)?;
+        self.step_votes.write(w)?;
         self.vote.write(w)?;
         self.quorum.write(w)?;
 
@@ -407,11 +407,11 @@ impl Serializable for ValidationResult {
     where
         Self: Sized,
     {
-        let sv = StepVotes::read(r)?;
+        let step_votes: StepVotes = StepVotes::read(r)?;
         let vote = Vote::read(r)?;
         let quorum = QuorumType::read(r)?;
 
-        Ok(ValidationResult::new(sv, vote, quorum))
+        Ok(ValidationResult::new(step_votes, vote, quorum))
     }
 }
 

--- a/node-data/src/message.rs
+++ b/node-data/src/message.rs
@@ -725,20 +725,28 @@ pub mod payload {
     pub struct ValidationResult {
         pub(crate) quorum: QuorumType,
         pub(crate) vote: Vote,
-        pub(crate) sv: StepVotes,
+        pub(crate) step_votes: StepVotes,
     }
 
     impl ValidationResult {
-        pub fn new(sv: StepVotes, vote: Vote, quorum: QuorumType) -> Self {
-            Self { sv, vote, quorum }
+        pub fn new(
+            step_votes: StepVotes,
+            vote: Vote,
+            quorum: QuorumType,
+        ) -> Self {
+            Self {
+                step_votes,
+                vote,
+                quorum,
+            }
         }
 
         pub fn quorum(&self) -> QuorumType {
             self.quorum
         }
 
-        pub fn sv(&self) -> &StepVotes {
-            &self.sv
+        pub fn step_votes(&self) -> &StepVotes {
+            &self.step_votes
         }
 
         pub fn vote(&self) -> &Vote {

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -965,8 +965,8 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
             histogram!("dusk_future_msg_count").record(f.msg_count() as f64);
         }
 
-        let fsv_bitset = tip.inner().header().att.validation.bitset;
-        let ssv_bitset = tip.inner().header().att.ratification.bitset;
+        let validation_bitset = tip.inner().header().att.validation.bitset;
+        let ratification_bitset = tip.inner().header().att.ratification.bitset;
 
         let duration = start.elapsed();
         info!(
@@ -976,10 +976,10 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
             hash = to_str(&tip.inner().header().hash),
             txs = tip.inner().txs().len(),
             state_hash = to_str(&tip.inner().header().state_hash),
-            fsv_bitset,
-            ssv_bitset,
-            block_time,
             generator = tip.inner().header().generator_bls_pubkey.to_bs58(),
+            validation_bitset,
+            ratification_bitset,
+            block_time,
             dur_ms = duration.as_millis(),
             ?label
         );

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -474,16 +474,15 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
                             .current()
                             .clone();
 
-                        let res = verify_att(
+                        match verify_att(
                             &qmsg.att,
                             qmsg.header,
                             cur_seed,
                             &cur_provisioners,
                             None,
                         )
-                        .await;
-
-                        match res {
+                        .await
+                        {
                             Ok(_) => {
                                 // Reroute to Consensus
                                 //


### PR DESCRIPTION
- Removes unused QuorumResult from `verify_step_votes` and `verify_votes`
- Transform `verify_votes` into `verify_quorum_votes` to make it explicit it checks votes reach the quorum threshold
- Move check to skip Validation votes verification (in case of NoQuorum vote) to `verify_step_votes`

---
Tests:
 - [x] Local node
 - [x] Local cluster
 - [x] Testnet