### PR TITLE
 wallet-core: change eip2333 public functions 

### DIFF
--- a/wallet-core/CHANGELOG.md
+++ b/wallet-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed eip2333 public functions `derive_master_sk`, `derive_child_sk`, `derive_bls_sk` [#3681]
+
 ## [1.3.0] - 2025-04-17
 
 ### Added
@@ -34,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `dusk-wallet-core` release
 
 <!-- Issues -->
+[#3681]: https://github.com/dusk-network/rusk/issues/3681
 [#3476]: https://github.com/dusk-network/rusk/issues/3476
 [#3438]: https://github.com/dusk-network/rusk/issues/3438
 [#3405]: https://github.com/dusk-network/rusk/issues/3405


### PR DESCRIPTION
- Make `derive_master_sk` public & return BlsSecretKey
- Let `derive_child_sk` return BlsSecretKey instead of BlsScalar
- Change `derive_bls_sk` to take a BlsSecretKey as arg instead of a Seed
- Adjust tests

Resolves #3681 