### PR TITLE
explorer: Release v1.3.2

### DIFF
--- a/explorer/CHANGELOG.md
+++ b/explorer/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to
 
 ### Fixed
 
+## [1.3.2] - 2025-04-29
+
+### Fixed
+
 - Fix truncated provisioners addresses when copied while on mobile view [#3675]
 - Fix line height and letter spacing not being applied to the account balance's container [#3676]
 
@@ -233,6 +237,7 @@ and this project adheres to
 <!-- VERSIONS -->
 
 [Unreleased]: https://github.com/dusk-network/rusk/tree/master/explorer
+[1.3.2]: https://github.com/dusk-network/rusk/tree/explorer-v1.3.2
 [1.3.1]: https://github.com/dusk-network/rusk/tree/explorer-v1.3.1
 [1.3.0]: https://github.com/dusk-network/rusk/tree/explorer-v1.3.0
 [1.2.0]: https://github.com/dusk-network/rusk/tree/explorer-v1.2.0

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "explorer",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "explorer",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@floating-ui/dom": "1.6.13",

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -33,7 +33,7 @@
     "typecheck:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch --fail-on-warnings"
   },
   "type": "module",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "dependencies": {
     "@floating-ui/dom": "1.6.13",
     "@mdi/js": "7.4.47",


### PR DESCRIPTION
Resolves #3680

## 1.3.2 - 2025-04-29

### Fixed

- Fix truncated provisioners addresses when copied while on mobile view [#3675]
- Fix line height and letter spacing not being applied to the account balance's container [#3676]