### PR TITLE
rusk-wallet: don't exit when command errors in interactive mode

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix transaction history deserialization [#3598]
 - Fix contract init parsing [#3602]
 - Fix contract call non-interactive parsing [#3602]
+- Fix exit when command errors in interactive mode [#3597], [#3192]
 
 ## [0.1.0] - 2025-01-20
 
@@ -65,6 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 <!-- Issues -->
+[#3597]: https://github.com/dusk-network/rusk/issues/3597
+[#3192]: https://github.com/dusk-network/rusk/issues/3192
 [#3650]: https://github.com/dusk-network/rusk/issues/3650
 [#3623]: https://github.com/dusk-network/rusk/issues/3623
 [#3602]: https://github.com/dusk-network/rusk/issues/3602

--- a/rusk-wallet/src/bin/interactive.rs
+++ b/rusk-wallet/src/bin/interactive.rs
@@ -90,7 +90,13 @@ pub(crate) async fn run_loop(
                     if confirm(&cmd, wallet)? {
                         // run command
                         prompt::hide_cursor()?;
-                        let res = cmd.run(wallet, settings).await?;
+                        let res = match cmd.run(wallet, settings).await {
+                            Ok(res) => res,
+                            Err(err) => {
+                                println!("{err}\n");
+                                continue;
+                            }
+                        };
                         prompt::show_cursor()?;
 
                         // output results


### PR DESCRIPTION
- Fixes https://github.com/dusk-network/rusk/issues/3192
- Partially fixes https://github.com/dusk-network/rusk/issues/3597.