### PR TITLE
consensus: Update docs URL

### DIFF
--- a/consensus/README.md
+++ b/consensus/README.md
@@ -1,3 +1,3 @@
 Implementation of Dusk [Succinct Attestation] consensus protocol 
 
-[Succinct Attestation]: (https://github.com/dusk-network/docs-public/blob/main/src/content/docs/learn/deep-dive/succinct-attestation.md)
+[Succinct Attestation]: (https://github.com/dusk-network/docs/blob/main/src/content/docs/learn/deep-dive/succinct-attestation.md)


### PR DESCRIPTION
Due to renaming of `docs-public` to `docs`, the URL needs to change pointing to SA.