### PR TITLE
explorer: Fix Transaction and Block entries have different row heights (Home page)

### DIFF
--- a/explorer/CHANGELOG.md
+++ b/explorer/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to
 
 ### Fixed
 
-- Fix Badge doesn't have content width [#3692]
+- Fix transaction type badges get wrapped [#3692]
+- Fix Transaction and Block entries have different row heights (Home page) [#3694]
 
 ## [1.3.2] - 2025-04-29
 
@@ -235,7 +236,8 @@ and this project adheres to
 [#3667]: https://github.com/dusk-network/rusk/issues/3667
 [#3675]: https://github.com/dusk-network/rusk/issues/3675
 [#3676]: https://github.com/dusk-network/rusk/issues/3676
-[#3676]: https://github.com/dusk-network/rusk/issues/3692
+[#3692]: https://github.com/dusk-network/rusk/issues/3692
+[#3694]: https://github.com/dusk-network/rusk/issues/3694
 
 <!-- VERSIONS -->
 

--- a/explorer/src/lib/components/latest-blocks-card/LatestBlocksCard.svelte
+++ b/explorer/src/lib/components/latest-blocks-card/LatestBlocksCard.svelte
@@ -41,6 +41,12 @@
       <BlocksList data={block} />
     {/each}
   {:else}
-    <BlocksTable data={blocks} />
+    <BlocksTable data={blocks} className="latest-blocks-card__table" />
   {/if}
 </DataCard>
+
+<style>
+  :global(.latest-blocks-card__table .table__body .table__row) {
+    height: 3.4375rem;
+  }
+</style>

--- a/explorer/src/lib/components/latest-transactions-card/LatestTransactionsCard.svelte
+++ b/explorer/src/lib/components/latest-transactions-card/LatestTransactionsCard.svelte
@@ -60,8 +60,15 @@
   {:else}
     <TransactionsTable
       data={txns}
+      className="latest-transactions-card__table"
       {displayTooltips}
       mode={isOnHomeScreen ? "compact" : "full"}
     />
   {/if}
 </DataCard>
+
+<style>
+  :global(.latest-transactions-card__table .table__body .table__row) {
+    height: 3.4375rem;
+  }
+</style>

--- a/explorer/src/routes/__tests__/__snapshots__/page.spec.js.snap
+++ b/explorer/src/routes/__tests__/__snapshots__/page.spec.js.snap
@@ -1844,7 +1844,7 @@ exports[`home page > should render the home page, start polling for the latest c
         class="data-card__content"
       >
         <div
-          class="table-container blocks-table"
+          class="table-container blocks-table latest-blocks-card__table"
         >
           <table
             class="table"
@@ -2828,7 +2828,7 @@ exports[`home page > should render the home page, start polling for the latest c
         class="data-card__content"
       >
         <div
-          class="table-container transactions-table"
+          class="table-container transactions-table latest-transactions-card__table"
         >
           <table
             class="table"

--- a/explorer/src/routes/blocks/block/__tests__/__snapshots__/page.spec.js.snap
+++ b/explorer/src/routes/blocks/block/__tests__/__snapshots__/page.spec.js.snap
@@ -597,7 +597,7 @@ exports[`Block Details > should render the Block Details page and query the nece
         class="data-card__content"
       >
         <div
-          class="table-container transactions-table"
+          class="table-container transactions-table latest-transactions-card__table"
         >
           <table
             class="table"


### PR DESCRIPTION
Resolves #3694

<img width="1773" alt="Screenshot 2025-05-01 at 19 16 58" src="https://github.com/user-attachments/assets/dfe65bb1-9ec3-4721-9932-4aa3a4de0603" />
