### PR TITLE
Refactor State Transition (Part 2)

### DIFF
--- a/consensus/src/errors.rs
+++ b/consensus/src/errors.rs
@@ -69,10 +69,10 @@ impl From<BlsSigError> for ConsensusError {
 
 #[derive(Debug, Error)]
 pub enum OperationError {
-    #[error("VST failed: {0}")]
-    FailedVST(StateTransitionError),
-    #[error("EST failed: {0}")]
-    FailedEST(StateTransitionError),
+    #[error("State transition creation failed: {0}")]
+    FailedTransitionCreation(StateTransitionError),
+    #[error("State transition verification failed: {0}")]
+    FailedTransitionVerification(StateTransitionError),
     #[error("Invalid header: {0}")]
     InvalidHeader(HeaderError),
     #[error("Unable to update metrics: {0}")]
@@ -149,7 +149,9 @@ impl OperationError {
     pub fn must_vote(&self) -> bool {
         match self {
             Self::InvalidHeader(e) => e.must_vote(),
-            Self::FailedVST(StateTransitionError::TipChanged) => false,
+            Self::FailedTransitionVerification(
+                StateTransitionError::TipChanged,
+            ) => false,
             _ => true,
         }
     }

--- a/consensus/src/errors.rs
+++ b/consensus/src/errors.rs
@@ -111,19 +111,6 @@ pub enum HeaderError {
     #[error("Invalid Failed Iterations: {0}")]
     InvalidFailedIterations(FailedIterationError),
 
-    #[error(
-        "mismatch, event_bloom: {}, candidate_event_bloom: {}",
-        hex::encode(.0.as_ref()),
-        hex::encode(.1.as_ref())
-    )]
-    EventBloomMismatch(Box<[u8; 256]>, Box<[u8; 256]>),
-    #[error(
-        "mismatch, state_hash: {}, candidate_state_hash: {}",
-        hex::encode(.0),
-        hex::encode(.1)
-    )]
-    StateRootMismatch([u8; 32], [u8; 32]),
-
     #[error("Generic error in header verification: {0}")]
     Generic(&'static str),
 
@@ -143,8 +130,20 @@ pub enum StateTransitionError {
     SessionError(String),
     #[error("Execution failed: {0}")]
     ExecutionError(String),
-    #[error("Verification failed: {0}")]
-    VerificationError(String),
+    #[error(
+      "State root mismatch. transition result: {}, block header: {}",
+      hex::encode(.0),
+      hex::encode(.1)
+    )]
+    StateRootMismatch([u8; 32], [u8; 32]),
+    #[error(
+      "Event bloom mismatch. transition result: {}, block header: {}",
+      hex::encode(.0.as_ref()),
+      hex::encode(.1.as_ref())
+    )]
+    EventBloomMismatch(Box<[u8; 256]>, Box<[u8; 256]>),
+    #[error("Failed to persist state: {0}")]
+    PersistenceError(String),
 }
 
 impl OperationError {
@@ -175,8 +174,6 @@ impl HeaderError {
             HeaderError::InvalidSeed(_) => true,
             HeaderError::InvalidAttestation(_) => true,
             HeaderError::InvalidFailedIterations(_) => true,
-            HeaderError::EventBloomMismatch(_, _) => true,
-            HeaderError::StateRootMismatch(_, _) => true,
 
             HeaderError::Generic(..) => false,
         }

--- a/consensus/src/errors.rs
+++ b/consensus/src/errors.rs
@@ -139,6 +139,8 @@ pub enum StateTransitionError {
     InvalidSlash(io::Error),
     #[error("Invalid generator: {0:?}")]
     InvalidGenerator(dusk_bytes::Error),
+    #[error("Session instantiation failed: {0}")]
+    SessionError(String),
     #[error("Execution failed: {0}")]
     ExecutionError(String),
     #[error("Verification failed: {0}")]

--- a/consensus/src/operations.rs
+++ b/consensus/src/operations.rs
@@ -72,7 +72,7 @@ pub trait Operations: Send + Sync {
         prev_state: StateRoot,
         blk: &Block,
         cert_voters: &[Voter],
-    ) -> Result<StateTransitionResult, OperationError>;
+    ) -> Result<(), OperationError>;
 
     async fn generate_state_transition(
         &self,

--- a/consensus/src/operations.rs
+++ b/consensus/src/operations.rs
@@ -61,7 +61,7 @@ pub trait Operations: Send + Sync {
         &self,
         candidate_header: &Header,
         expected_generator: &PublicKeyBytes,
-    ) -> Result<(u8, Vec<Voter>, Vec<Voter>), HeaderError>;
+    ) -> Result<Vec<Voter>, HeaderError>;
 
     async fn validate_faults(
         &self,

--- a/consensus/src/operations.rs
+++ b/consensus/src/operations.rs
@@ -8,9 +8,7 @@ use std::fmt;
 use std::time::Duration;
 
 use node_data::bls::{PublicKey, PublicKeyBytes};
-use node_data::ledger::{
-    Block, Fault, Header, Slash, SpentTransaction, Transaction,
-};
+use node_data::ledger::{Block, Fault, Header, Slash, SpentTransaction};
 use node_data::StepName;
 
 use crate::errors::*;
@@ -76,17 +74,10 @@ pub trait Operations: Send + Sync {
         cert_voters: &[Voter],
     ) -> Result<StateTransitionResult, OperationError>;
 
-    async fn new_state_transition(
+    async fn generate_state_transition(
         &self,
         transition_data: StateTransitionData,
-    ) -> Result<
-        (
-            Vec<SpentTransaction>,
-            StateTransitionResult,
-            Vec<Transaction>,
-        ),
-        OperationError,
-    >;
+    ) -> Result<(Vec<SpentTransaction>, StateTransitionResult), OperationError>;
 
     async fn add_step_elapsed_time(
         &self,

--- a/consensus/src/proposal/block_generator.rs
+++ b/consensus/src/proposal/block_generator.rs
@@ -117,8 +117,10 @@ impl<T: Operations> Generator<T> {
         };
 
         // Compute a valid state transition for the block
-        let (executed_txs, transition_result, _) =
-            self.executor.new_state_transition(transition_data).await?;
+        let (executed_txs, transition_result) = self
+            .executor
+            .generate_state_transition(transition_data)
+            .await?;
 
         blk_header.state_hash = transition_result.state_root;
         blk_header.event_bloom = transition_result.event_bloom;

--- a/consensus/src/proposal/step.rs
+++ b/consensus/src/proposal/step.rs
@@ -113,7 +113,7 @@ impl<T: Operations + 'static, D: Database> ProposalStep<T, D> {
                 }
 
                 Err(err) => match err {
-                    OperationError::FailedEST(
+                    OperationError::FailedTransitionCreation(
                         StateTransitionError::TipChanged,
                     ) => {
                         warn!(

--- a/consensus/src/validation/step.rs
+++ b/consensus/src/validation/step.rs
@@ -89,7 +89,7 @@ impl<T: Operations + 'static, D: Database> ValidationStep<T, D> {
         let header = candidate.header();
         let candidate_hash = header.hash;
 
-        let vote = match Self::verify_candidate(
+        let vote = match Self::validate_candidate(
             candidate,
             ru.state_root(),
             executor,
@@ -119,7 +119,7 @@ impl<T: Operations + 'static, D: Database> ValidationStep<T, D> {
         Self::cast_vote(vote, ru, iteration, outbound, inbound).await;
     }
 
-    async fn verify_candidate(
+    async fn validate_candidate(
         candidate: &Block,
         prev_state: StateRoot,
         executor: Arc<T>,
@@ -127,17 +127,17 @@ impl<T: Operations + 'static, D: Database> ValidationStep<T, D> {
     ) -> Result<(), OperationError> {
         let header = candidate.header();
 
-        // Verify faults
+        // Validate faults
         executor
             .validate_faults(header.height, candidate.faults())
             .await?;
 
-        // Verify candidate header
+        // Validate candidate header
         let cert_voters = executor
             .validate_block_header(header, &expected_generator)
             .await?;
 
-        // Verify state transition
+        // Validate state transition
         executor
             .validate_state_transition(prev_state, candidate, &cert_voters)
             .await?;

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -718,12 +718,12 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
     ///
     /// * blk: the block to accept as successor of the tip
     /// * restart_consensus: `true` if the consensus loop has to be restarted
-    ///   after accepting a block, false otherwise.
+    ///   after accepting a block.
     ///
     /// # Returns
     ///
     /// * `true` if the accepted block triggered rolling finality on a previous
-    ///   block; `false` otherwise.
+    ///   block.
     pub(crate) async fn accept_block(
         &mut self,
         blk: &Block,
@@ -740,6 +740,8 @@ impl<DB: database::DB, VM: vm::VMExecution, N: Network> Acceptor<N, DB, VM> {
 
         let header_verification_start = std::time::Instant::now();
         // Verify Block Header
+        // `cert_voters` and `att_voters` are the voters of the previous-block
+        // Certificate and the `blk` Attestation, respectively
         let (pni, cert_voters, att_voters) = verify_block_header(
             self.db.clone(),
             &prev_header,
@@ -1535,7 +1537,11 @@ async fn broadcast<N: Network>(network: &Arc<RwLock<N>>, msg: &Message) {
 
 /// Verifies a block header against its previous block
 ///
-/// Returns the number of Previous Non-Attested Iterations (PNI).
+/// # Returns
+///
+/// * The number of Previous Non-Attested Iterations (PNI)
+/// * The list of voters in the previous-block Certificate
+/// * The list of voters in the current-block Attestation
 pub(crate) async fn verify_block_header<DB: database::DB>(
     db: Arc<RwLock<DB>>,
     prev_header: &ledger::Header,

--- a/node/src/chain/acceptor.rs
+++ b/node/src/chain/acceptor.rs
@@ -1531,8 +1531,7 @@ async fn broadcast<N: Network>(network: &Arc<RwLock<N>>, msg: &Message) {
     });
 }
 
-/// Performs full verification of block header against prev_block header where
-/// prev_block is usually the blockchain tip
+/// Verifies a block header against its previous block
 ///
 /// Returns the number of Previous Non-Attested Iterations (PNI).
 pub(crate) async fn verify_block_header<DB: database::DB>(
@@ -1565,6 +1564,6 @@ pub(crate) async fn verify_block_header<DB: database::DB>(
     // Verify header validity
     let validator = Validator::new(db, prev_header, provisioners);
     validator
-        .execute_checks(header, &expected_generator, check_att)
+        .verify_block_header_fields(header, &expected_generator, check_att)
         .await
 }

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -324,7 +324,7 @@ impl<DB: database::DB, VM: vm::VMExecution> Operations for Executor<DB, VM> {
         let vm = self.vm.read().await;
 
         vm.verify_state_transition(prev_state, blk, cert_voters)
-            .map_err(OperationError::FailedVST)
+            .map_err(OperationError::FailedTransitionVerification)
     }
 
     async fn new_state_transition(
@@ -348,7 +348,7 @@ impl<DB: database::DB, VM: vm::VMExecution> Operations for Executor<DB, VM> {
                     vm.create_state_transition(&transition_data, mempool_txs)?;
                 Ok(ret)
             })
-            .map_err(OperationError::FailedEST)?;
+            .map_err(OperationError::FailedTransitionCreation)?;
         let _ = db.update(|m| {
             for t in &discarded_txs {
                 if let Ok(_removed) = m.delete_mempool_tx(t.id(), true) {

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -18,9 +18,7 @@ use dusk_consensus::queue::MsgRegistry;
 use dusk_consensus::user::provisioners::ContextProvisioners;
 use metrics::gauge;
 use node_data::bls::PublicKeyBytes;
-use node_data::ledger::{
-    to_str, Block, Fault, Hash, Header, SpentTransaction, Transaction,
-};
+use node_data::ledger::{to_str, Block, Fault, Hash, Header, SpentTransaction};
 use node_data::message::{payload, AsyncQueue, ConsensusHeader};
 use node_data::{ledger, Serializable, StepName};
 use tokio::sync::{oneshot, Mutex, RwLock};
@@ -333,17 +331,11 @@ impl<DB: database::DB, VM: vm::VMExecution> Operations for Executor<DB, VM> {
             .map_err(OperationError::FailedTransitionVerification)
     }
 
-    async fn new_state_transition(
+    async fn generate_state_transition(
         &self,
         transition_data: StateTransitionData,
-    ) -> Result<
-        (
-            Vec<SpentTransaction>,
-            StateTransitionResult,
-            Vec<Transaction>,
-        ),
-        OperationError,
-    > {
+    ) -> Result<(Vec<SpentTransaction>, StateTransitionResult), OperationError>
+    {
         let vm = self.vm.read().await;
 
         let db = self.db.read().await;
@@ -366,7 +358,7 @@ impl<DB: database::DB, VM: vm::VMExecution> Operations for Executor<DB, VM> {
             Ok(())
         });
 
-        Ok((executed_txs, transition_result, discarded_txs))
+        Ok((executed_txs, transition_result))
     }
 
     async fn add_step_elapsed_time(

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -290,16 +290,22 @@ impl<DB: database::DB, VM: vm::VMExecution> Operations for Executor<DB, VM> {
         &self,
         candidate_header: &Header,
         expected_generator: &PublicKeyBytes,
-    ) -> Result<(u8, Vec<Voter>, Vec<Voter>), HeaderError> {
+    ) -> Result<Vec<Voter>, HeaderError> {
         let validator = Validator::new(
             self.db.clone(),
             &self.tip_header,
             &self.provisioners,
         );
 
-        validator
-            .execute_checks(candidate_header, expected_generator, false)
-            .await
+        let (_, cert_voters, _) = validator
+            .verify_block_header_fields(
+                candidate_header,
+                expected_generator,
+                false,
+            )
+            .await?;
+
+        Ok(cert_voters)
     }
 
     async fn validate_faults(

--- a/node/src/chain/consensus.rs
+++ b/node/src/chain/consensus.rs
@@ -324,11 +324,13 @@ impl<DB: database::DB, VM: vm::VMExecution> Operations for Executor<DB, VM> {
         prev_state: [u8; 32],
         blk: &Block,
         cert_voters: &[Voter],
-    ) -> Result<StateTransitionResult, OperationError> {
+    ) -> Result<(), OperationError> {
         let vm = self.vm.read().await;
 
         vm.verify_state_transition(prev_state, blk, cert_voters)
-            .map_err(OperationError::FailedTransitionVerification)
+            .map_err(OperationError::FailedTransitionVerification)?;
+
+        Ok(())
     }
 
     async fn generate_state_transition(

--- a/node/src/vm.rs
+++ b/node/src/vm.rs
@@ -39,16 +39,15 @@ pub trait VMExecution: Send + Sync + 'static {
         cert_voters: &[Voter],
     ) -> Result<(), StateTransitionError>;
 
-    fn do_accept_state_transition(
+    fn accept_state_transition(
         &self,
         prev_state: [u8; 32],
         blk: &Block,
         cert_voters: &[Voter],
-    ) -> anyhow::Result<(
-        Vec<SpentTransaction>,
-        StateTransitionResult,
-        Vec<ContractTxEvent>,
-    )>;
+    ) -> Result<
+        (Vec<SpentTransaction>, Vec<ContractTxEvent>),
+        StateTransitionError,
+    >;
 
     fn finalize_state(
         &self,

--- a/node/src/vm.rs
+++ b/node/src/vm.rs
@@ -37,7 +37,7 @@ pub trait VMExecution: Send + Sync + 'static {
         prev_state: [u8; 32],
         blk: &Block,
         cert_voters: &[Voter],
-    ) -> Result<StateTransitionResult, StateTransitionError>;
+    ) -> Result<(), StateTransitionError>;
 
     fn do_accept_state_transition(
         &self,

--- a/rusk/benches/block_ingestion.rs
+++ b/rusk/benches/block_ingestion.rs
@@ -19,7 +19,7 @@ use criterion::{
 };
 use dusk_core::transfer::Transaction as ProtocolTransaction;
 use node_data::bls::PublicKey;
-use node_data::ledger::Transaction;
+use node_data::ledger::{Block, Header, Transaction};
 use rand::prelude::StdRng;
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
@@ -132,18 +132,22 @@ fn bench_accept(
                 b.iter(|| {
                     let txs = txs[..*n_txs].to_vec();
 
-                    rusk.accept_state_transition(
-                        prev_state,
-                        BLOCK_HEIGHT,
-                        BLOCK_GAS_LIMIT,
-                        BLOCK_HASH,
-                        generator,
-                        txs,
-                        None,
-                        vec![],
-                        &[],
-                    )
-                    .expect("Accepting transactions should succeed");
+                    // Build block
+                    let mut header = Header::default();
+                    header.generator_bls_pubkey =
+                        *PublicKey::new(*DUSK_CONSENSUS_KEY).bytes();
+                    header.height = BLOCK_HEIGHT;
+                    header.hash = BLOCK_HASH;
+                    header.gas_limit = BLOCK_GAS_LIMIT;
+                    let blk = Block::new(header, txs, vec![])
+                        .expect("Creating a block should succeed");
+
+                    let (_, _, _, session) = rusk
+                        .execute_state_transition(prev_state, &blk, &[])
+                        .expect("Executing state transition should succeed");
+
+                    rusk.commit_session(session)
+                        .expect("Committing the session should succeed");
 
                     rusk.revert_to_base_root()
                         .expect("Reverting should succeed");

--- a/rusk/src/lib/error.rs
+++ b/rusk/src/lib/error.rs
@@ -47,9 +47,6 @@ pub enum Error {
     Vm(VMError),
     /// IO Errors
     Io(io::Error),
-    /// Failed to produce proper state
-    #[cfg(feature = "chain")]
-    InconsistentState(Box<dusk_consensus::operations::StateTransitionResult>),
     /// Other
     Other(Box<dyn std::error::Error>),
     /// Commit not found amongst existing commits
@@ -58,8 +55,6 @@ pub enum Error {
     InvalidCreditsCount(u64, usize),
     /// Memo too large
     MemoTooLarge(usize),
-    /// Chain tip different from the expected one
-    TipChanged,
 }
 
 impl std::error::Error for Error {}
@@ -171,10 +166,6 @@ impl fmt::Display for Error {
             Error::InvalidCircuitArguments(inputs_len, outputs_len) => {
                 write!(f,"Expected: 0 < (inputs: {inputs_len}) < 5, 0 ≤ (outputs: {outputs_len}) < 3")
             }
-            #[cfg(feature = "chain")]
-            Error::InconsistentState(vo) => {
-                write!(f, "Inconsistent state verification data {vo}",)
-            }
             Error::CommitNotFound(commit_id) => {
                 write!(f, "Commit not found, id = {}", hex::encode(commit_id),)
             }
@@ -183,9 +174,6 @@ impl fmt::Display for Error {
             }
             Error::MemoTooLarge(size) => {
                 write!(f, "The memo size {size} is too large")
-            }
-            Error::TipChanged => {
-                write!(f, "Chain tip different from the expected one")
             }
         }
     }

--- a/rusk/src/lib/node/rusk.rs
+++ b/rusk/src/lib/node/rusk.rs
@@ -118,7 +118,7 @@ impl Rusk {
             event = "Creating state transition",
             height = block_height,
             prev_state = to_str(&prev_state),
-            gas_limit = gas_limit,
+            gas_limit,
             ?slashes
         );
 

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -43,19 +43,11 @@ impl VMExecution for Rusk {
         ),
         StateTransitionError,
     > {
-        let (executed_txs, discarded_txs, transition_result) = self
-            .build_state_transition(transition_data, mempool_txs)
-            .map_err(|err| {
-                if let RuskError::TipChanged = err {
-                    StateTransitionError::TipChanged
-                } else {
-                    StateTransitionError::ExecutionError(format!("{err}"))
-                }
-            })?;
-
-        Ok((executed_txs, discarded_txs, transition_result))
+        self.create_state_transition(transition_data, mempool_txs)
     }
 
+    /// Executes a block's state transition and checks its result against the
+    /// block's header
     fn verify_state_transition(
         &self,
         prev_state: [u8; 32],


### PR DESCRIPTION
RENAMES
- Functions
  - `new_state_transition` -> `generate_state_transition`
  - `verify_candidate` -> `validate_candidate`
  - `check_header_vst` -> `check_transition_result`
  - `execute_checks` -> `verify_block_header_fields`
  - `verify_basic_fields` -> `verify_block_header_basic_fields`
  - `do_accept_state_transition` -> `accept_state_transition`
  - `build_state_transition` -> `create_state_transition`

- Errors
  - `FailedEST` -> `FailedTransitionCreation`
  - `FailedEST` -> `FailedTransitionVerification`
  
MOVES
  - `check_transition_result` to `vm.rs`
  - `EventBloomMismatch` and `StateRootMismatch` from `HeaderError` to `StateTransitionError`
  - `verify_block_generator` call from `execute_checks`  to `verify_block_header_basic_fields`
   
ADDS
- `StateTransitionError::SessionError`
- `StateTransitionError::PersistenceError`
- `Rusk::commit_session`

REMOVES:
- `verify_transactions` and `accept_state_transition` (merged into `execute_state_transition`)
- `InconsistentState` and `TipChanged` errors from (Rusk) Error

REFACTORS
- `validate_block_header`: remove unused `pni` and `att_voters` from returned tuple
- `generate_state_transition`: remove `discarded_txs` from returned tuple
- `verify_state_transition`: remove unused `StateTransitionResult` from returned tuple
- `accept_state_transition`: remove unused `StateTransitionResult` from returned tuple
- `create_state_transition`: return `StateTransitionError` instead of generic Error
- `new_block_session`: return `StateTransitionError` instead of generic Error
- `execute_state_transition`: 
  - take the full block instead of several arguments

  ---
  Tests:
  - [x] Local node
  - [x] Local cluster
  - [x] Local cluster with missing provisioners
  - [x] Testnet
    - [x] Block generated (create state transition)
    - [x] Cast vote (execute state transition)
