### PR TITLE
rusk-wallet: fix transaction history fail after unstaking

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix transaction history error when the wallet has no stake [#3734]
 - Fix transaction history fail after shield/unshield conversions [#3600]
-- Fix transaction history fail after staking [#3712]
+- Fix transaction history fail after stake/unstake [#3712]
 
 ## [0.2.0] - 2025-05-07
 

--- a/rusk-wallet/src/bin/command/tests.rs
+++ b/rusk-wallet/src/bin/command/tests.rs
@@ -29,7 +29,7 @@ async fn test_empty_history() {
 }
 
 #[tokio::test]
-async fn test_non_empty_history() {
+async fn test_history_transfer_convert() {
     configure_logger();
     wait_for_nodes_to_start().await.unwrap();
 
@@ -47,16 +47,11 @@ async fn test_non_empty_history() {
     )
     .await
     .unwrap();
-    // Need to wait for each transaction to be included in a block before moving
-    // to the next to ensure that the history ends up in the same order as the
-    // transactions made.
-    gql.wait_for(&rcv_moonlight).await.unwrap();
 
     let rcv_phoenix =
         rcv_phoenix_from_faucet(phoenix_addr.clone(), dusk(2500.0), gas_price)
             .await
             .unwrap();
-    gql.wait_for(&rcv_phoenix).await.unwrap();
 
     let mut txs_info = wait_for_tx_blocks_to_finalize(
         &gql,
@@ -74,6 +69,9 @@ async fn test_non_empty_history() {
     )
     .await
     .unwrap();
+    // Need to wait for each transaction to be included in a block before moving
+    // to the next to ensure that the history ends up in the same order as the
+    // transactions made.
     gql.wait_for(&moonlight_trans_to_other_wallet)
         .await
         .unwrap();
@@ -109,17 +107,6 @@ async fn test_non_empty_history() {
     .unwrap();
     gql.wait_for(&phoenix_to_moonlight).await.unwrap();
 
-    let stake_moonlight =
-        stake_moonlight(&mut wallet, &settings, dusk(1000.0).into(), gas_price)
-            .await
-            .unwrap();
-    gql.wait_for(&stake_moonlight).await.unwrap();
-
-    let stake_phoenix =
-        stake_phoenix(&mut wallet, &settings, dusk(1000.0).into(), gas_price)
-            .await
-            .unwrap();
-
     txs_info.extend(
         wait_for_tx_blocks_to_finalize(
             &gql,
@@ -128,8 +115,6 @@ async fn test_non_empty_history() {
                 &phoenix_trans_to_other_wallet,
                 &phoenix_to_moonlight,
                 &moonlight_to_phoenix,
-                &stake_moonlight,
-                &stake_phoenix,
             ],
         )
         .await
@@ -198,11 +183,105 @@ async fn test_non_empty_history() {
                 amount: 5_000.0,
                 fee: 0,
             },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_history_stake_unstake() {
+    configure_logger();
+    wait_for_nodes_to_start().await.unwrap();
+
+    let (mut wallet, settings) = create_wallet().await.unwrap();
+    let gql = GraphQL::new(settings.state.clone(), status::headless).unwrap();
+    let moonlight_addr = wallet.default_address();
+    let phoenix_addr = wallet.shielded_account(0).unwrap();
+    let gas_price = 1;
+
+    let rcv_moonlight = rcv_moonlight_from_faucet(
+        moonlight_addr.clone(),
+        dusk(1500.0),
+        gas_price,
+    )
+    .await
+    .unwrap();
+
+    let rcv_phoenix =
+        rcv_phoenix_from_faucet(phoenix_addr.clone(), dusk(1500.0), gas_price)
+            .await
+            .unwrap();
+
+    let stake_moonlight =
+        stake_moonlight(&mut wallet, &settings, dusk(1000.0).into(), gas_price)
+            .await
+            .unwrap();
+    gql.wait_for(&stake_moonlight).await.unwrap();
+
+    let unstake_moonlight =
+        unstake_moonlight(&mut wallet, &settings, gas_price)
+            .await
+            .unwrap();
+    gql.wait_for(&unstake_moonlight).await.unwrap();
+
+    let stake_phoenix =
+        stake_phoenix(&mut wallet, &settings, dusk(1000.0).into(), gas_price)
+            .await
+            .unwrap();
+    gql.wait_for(&stake_phoenix).await.unwrap();
+
+    let unstake_phoenix = unstake_phoenix(&mut wallet, &settings, gas_price)
+        .await
+        .unwrap();
+
+    let txs_info = wait_for_tx_blocks_to_finalize(
+        &gql,
+        vec![
+            &rcv_moonlight,
+            &rcv_phoenix,
+            &stake_moonlight,
+            &unstake_moonlight,
+            &stake_phoenix,
+            &unstake_phoenix,
+        ],
+    )
+    .await
+    .unwrap();
+
+    let cmd = Command::History { profile_idx: None };
+    let history = cmd.run(&mut wallet, &settings).await.unwrap();
+    assert!(matches!(history, RunResult::History(_)));
+    let RunResult::History(tx_history) = history else {
+        unreachable!();
+    };
+    let tx_history: Vec<StrippedTxHistoryItem> =
+        tx_history.into_iter().map(|item| item.into()).collect();
+
+    assert_eq!(
+        tx_history,
+        vec![
+            // Receive money from faucet to moonlight address
+            StrippedTxHistoryItem {
+                direction: TransactionDirection::In,
+                amount: dusk(1500.0) as f64,
+                fee: txs_info[&rcv_moonlight].gas_spent * gas_price,
+            },
+            // Receive money from faucet to phoenix address
+            StrippedTxHistoryItem {
+                direction: TransactionDirection::In,
+                amount: dusk(1500.0) as f64,
+                fee: txs_info[&rcv_phoenix].gas_spent * gas_price,
+            },
             // Stake 1000 dusk with moonlight
             StrippedTxHistoryItem {
                 direction: TransactionDirection::Out,
                 amount: -(dusk(1000.0) as f64),
                 fee: txs_info[&stake_moonlight].gas_spent * gas_price,
+            },
+            // Unstake with moonlight
+            StrippedTxHistoryItem {
+                direction: TransactionDirection::Out,
+                amount: dusk(1000.0) as f64,
+                fee: txs_info[&unstake_moonlight].gas_spent * gas_price,
             },
             // Stake 1000 dusk with phoenix
             StrippedTxHistoryItem {
@@ -210,6 +289,12 @@ async fn test_non_empty_history() {
                 amount: -(dusk(1000.0) as f64),
                 fee: txs_info[&stake_phoenix].gas_spent * gas_price,
             },
+            // Unstake with phoenix
+            StrippedTxHistoryItem {
+                direction: TransactionDirection::Out,
+                amount: dusk(1000.0) as f64,
+                fee: txs_info[&unstake_phoenix].gas_spent * gas_price,
+            },
         ]
-    );
+    )
 }

--- a/rusk-wallet/src/gql.rs
+++ b/rusk-wallet/src/gql.rs
@@ -12,6 +12,7 @@ use dusk_core::stake::StakeEvent;
 use dusk_core::transfer::phoenix::StealthAddress;
 use dusk_core::transfer::{
     ConvertEvent, DepositEvent, MoonlightTransactionEvent, Transaction,
+    WithdrawEvent,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -113,6 +114,8 @@ pub enum BlockData {
     StakeEvent(StakeEvent),
     /// For the deposit event.
     DepositEvent(DepositEvent),
+    /// For the withdraw event.
+    WithdrawEvent(WithdrawEvent),
 }
 
 #[derive(Deserialize, Debug)]

--- a/rusk-wallet/src/gql/tests/assets/full_moonlight_history.json
+++ b/rusk-wallet/src/gql/tests/assets/full_moonlight_history.json
@@ -175,6 +175,49 @@
                     }
                 ],
                 "origin": "ce6e57d9bba2bc25b5ce53c1f37410dbd7a9d26aa3637717a5cf853aea2c0e0d"
+            },
+            {
+                "block_height": 3774,
+                "events": [
+                    {
+                        "data": {
+                            "receiver": {
+                                "Moonlight": "yDUZERZYxSV8Ptwssck3V8KdeGTCzqX4cggNHqex9p8C9Xo6nKve5aqqHWptxCmNrR6GaNTrRUGLqzvHUuH7ucc4Jn6ff81qDiTayV7fY96N5JzMCkhBUDS1moeSVYyG8GN"
+                            },
+                            "sender": "0200000000000000000000000000000000000000000000000000000000000000",
+                            "value": "1000000000000"
+                        },
+                        "target": "0100000000000000000000000000000000000000000000000000000000000000",
+                        "topic": "withdraw"
+                    },
+                    {
+                        "data": {
+                            "keys": {
+                                "account": "yDUZERZYxSV8Ptwssck3V8KdeGTCzqX4cggNHqex9p8C9Xo6nKve5aqqHWptxCmNrR6GaNTrRUGLqzvHUuH7ucc4Jn6ff81qDiTayV7fY96N5JzMCkhBUDS1moeSVYyG8GN",
+                                "owner": {
+                                    "Account": "yDUZERZYxSV8Ptwssck3V8KdeGTCzqX4cggNHqex9p8C9Xo6nKve5aqqHWptxCmNrR6GaNTrRUGLqzvHUuH7ucc4Jn6ff81qDiTayV7fY96N5JzMCkhBUDS1moeSVYyG8GN"
+                                }
+                            },
+                            "locked": "0",
+                            "value": "1000000000000"
+                        },
+                        "target": "0200000000000000000000000000000000000000000000000000000000000000",
+                        "topic": "unstake"
+                    },
+                    {
+                        "data": {
+                            "gas_spent": "26118685",
+                            "memo": "",
+                            "receiver": null,
+                            "refund_info": null,
+                            "sender": "yDUZERZYxSV8Ptwssck3V8KdeGTCzqX4cggNHqex9p8C9Xo6nKve5aqqHWptxCmNrR6GaNTrRUGLqzvHUuH7ucc4Jn6ff81qDiTayV7fY96N5JzMCkhBUDS1moeSVYyG8GN",
+                            "value": "0"
+                        },
+                        "target": "0100000000000000000000000000000000000000000000000000000000000000",
+                        "topic": "moonlight"
+                    }
+                ],
+                "origin": "3c4471d5bb32e0cc24c0f901c9951ddab2f3a6150c2cc6490f86534c56afb433"
             }
         ]
     }


### PR DESCRIPTION
For https://github.com/dusk-network/rusk/issues/3712.
PR https://github.com/dusk-network/rusk/pull/3745 fixes the failure after staking.
This PR handles the unstaking.
