### PR TITLE
rusk-wallet: use only transfer contract emitted events in tx history

### DIFF
--- a/rusk-wallet/src/gql.rs
+++ b/rusk-wallet/src/gql.rs
@@ -8,6 +8,7 @@
 //! The <node-url>/on/gaphql/query if queried with empty bytes returns the
 //! graphql schema
 
+use dusk_core::abi::ContractId;
 use dusk_core::stake::StakeEvent;
 use dusk_core::transfer::phoenix::StealthAddress;
 use dusk_core::transfer::{
@@ -121,6 +122,7 @@ pub enum BlockData {
 #[derive(Deserialize, Debug)]
 pub struct BlockEvents {
     pub data: BlockData,
+    pub target: ContractId,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Follow up on https://github.com/dusk-network/rusk/issues/3712.

Use only events emitted by the transfer contract to make the transaction history.