### PR TITLE
workspace: add script to test binary against mainnet history

### DIFF
--- a/rusk/mainnet.config.toml
+++ b/rusk/mainnet.config.toml
@@ -1,0 +1,74 @@
+# log_level = 'info'
+# log_type = 'coloured'
+# log_filter = 'dusk_consensus=debug'
+
+[http]
+#listen = true
+#listen_address = '127.0.0.1:8080'
+#cert = <path_of_pem>
+#key = <path_of_key>
+
+# The default max cost for feeder calls is the maximum representable. Put in a
+# a string wrapped number up to u64::MAX
+#feeder_call_gas = "18446744073709551615" 
+
+#ws_sub_channel_cap = 16,
+#ws_event_channel_cap = 1024,
+
+# Custom headers to put into every HTTP response. By default none are added.
+#headers = [["name1", "value1"], ["name2", "value2"]]
+
+[chain]
+genesis_timestamp = '2025-01-07T12:00:00Z'
+#db_path = '/home/user/.dusk/rusk'
+#consensus_keys_path = '/home/user/.dusk/rusk/consensus.keys'
+min_gas_limit = 150000
+
+# Note: changing the vm settings is equivalent to forking the chain.
+[vm]
+generation_timeout = '3s'
+# Note: changing the following settings is equivalent to forking the chain.
+gas_per_deploy_byte = 100
+min_deployment_gas_price = 2_000
+min_deploy_points = 5_000_000
+block_gas_limit = 3_000_000_000
+
+[vm.features]
+ABI_PUBLIC_SENDER = 355_000
+# key = activation_height
+# key = activation_height
+# key = activation_height
+
+[databroker]
+max_inv_entries = 100
+max_ongoing_requests = 1000
+
+[kadcast]
+kadcast_id = 0x1
+public_address = '127.0.0.1:9000'
+# listen_address = '127.0.0.1:9000'
+bootstrapping_nodes = []
+auto_propagate = true
+channel_size = 1000
+recursive_discovery = true
+
+[kadcast.bucket]
+node_ttl = '30s'
+node_evict_after = '5s'
+bucket_ttl = '1h'
+
+[kadcast.network]
+udp_recv_buffer_size = 5000000
+# udp_send_backoff_timeout = '50us'
+udp_send_retry_interval = '5ms'
+udp_send_retry_count = 3
+blocklist_refresh_interval = '10s'
+
+[kadcast.fec.encoder]
+min_repair_packets_per_block = 5
+mtu = 1300
+fec_redundancy = 0.15
+
+[kadcast.fec.decoder]
+cache_ttl = '1m'
+cache_prune_every = '5m'

--- a/test_mainnet.sh
+++ b/test_mainnet.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+STATE_LIST_URL="https://nodes.dusk.network/state/list"
+
+# Function to display all published states
+list_states() {
+  echo "Fetching available states..."
+  if ! curl -f -L -s "$STATE_LIST_URL"; then
+    echo "Error: Failed to fetch the list of states."
+    exit 1
+  fi
+}
+
+# Function to check if a specific state exists
+state_exists() {
+  local state=$1
+  while : ; do
+    if curl -f -L -s "$STATE_LIST_URL" | grep -q "^$state$"; then
+      return 0 # State exists
+    else
+      echo "State does not exist. Please enter a state from the list below:"
+      list_states
+      read -p "Enter a valid state number: " state
+      # Update the state_number variable in the global scope
+      state_number=$state
+    fi
+  done
+}
+
+# Function to get the latest state
+get_latest_state() {
+  curl -f -L -s "$STATE_LIST_URL" | tail -n 1
+}
+
+# Check if an argument is provided, otherwise use the fallback value (348211)
+if [ "$1" = "--list" ]; then
+  # List all possible states
+  list_states
+  exit 0
+elif [ -n "$1" ]; then
+  # User provided a specific state, check if it exists
+  state_number=$1
+  state_exists "$1"
+else
+  # No argument provided, use the latest state
+  state_number=$(get_latest_state)
+fi
+
+
+# Download the file
+STATE_URL="https://nodes.dusk.network/state/$state_number"
+echo "Downloading state $state_number from $STATE_URL..."
+
+if ! curl -f -# -o  /tmp/state.tar.gz -L "$STATE_URL"; then
+  echo "Error: Download failed. Exiting."
+  #exit 1
+fi
+
+# Create a temporary directory and assign it to a variable
+TEMP_DIR=$(mktemp -d)
+echo "Temporary directory created at $TEMP_DIR"
+tar -xvf /tmp/state.tar.gz -C $TEMP_DIR
+
+rm -f /tmp/mainnet-genesis.state || true
+cargo r --release -p dusk-rusk -- recovery state --init rusk-recovery/config/mainnet.toml -o /tmp/mainnet-genesis.state
+
+RUSK_EXT_CHAIN=$TEMP_DIR DUSK_CONSENSUS_KEYS_PASS=password cargo r --release -p dusk-rusk -- -s /tmp/mainnet-genesis.state --config rusk/mainnet.config.toml


### PR DESCRIPTION
simply run

`sh test_mainnet.sh` to test current binary against mainnet
or 
`sh test_mainnet.sh --list` to get the lists of the available states and the use `sh test_mainnet.sh <block_number>`

You'll notice some `cannot notify events` but that's ok