### PR TITLE
rusk-wallet: ensure zeroize is called for secret keys on an early function return

### DIFF
--- a/rusk-wallet/CHANGELOG.md
+++ b/rusk-wallet/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix transaction history error when the wallet has no stake [#3734]
 - Fix transaction history fail after shield/unshield conversions [#3600]
 - Fix transaction history fail after stake/unstake [#3712]
+- Fix zeroize calls for secret keys to ensure they are executed on early returns from functions [#3687]
 
 ## [0.2.0] - 2025-05-07
 
@@ -98,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3704]: https://github.com/dusk-network/rusk/issues/3704
 [#3702]: https://github.com/dusk-network/rusk/issues/3702
 [#3700]: https://github.com/dusk-network/rusk/issues/3700
+[#3687]: https://github.com/dusk-network/rusk/issues/3687
 [#3650]: https://github.com/dusk-network/rusk/issues/3650
 [#3623]: https://github.com/dusk-network/rusk/issues/3623
 [#3602]: https://github.com/dusk-network/rusk/issues/3602

--- a/rusk-wallet/src/clients.rs
+++ b/rusk-wallet/src/clients.rs
@@ -233,6 +233,8 @@ impl State {
             })
             .collect();
 
+        sk.zeroize();
+
         // pick up to MAX_INPUT_NOTES input-notes that cover the tx-cost
         let tx_input_notes = pick_notes(&vk, cached_notes.into(), tx_cost);
         if tx_input_notes.is_empty() {
@@ -247,8 +249,6 @@ impl State {
 
             tx_input.push((note_leaf.note.clone(), opening, *nullifier));
         }
-
-        sk.zeroize();
 
         Ok(tx_input)
     }

--- a/rusk-wallet/src/lib.rs
+++ b/rusk-wallet/src/lib.rs
@@ -14,6 +14,9 @@
 
 #![deny(missing_docs)]
 #![deny(clippy::pedantic)]
+// This feature has been stabilized since 1.76.0.
+// It can just be removed when the toolchain is updated.
+#![feature(result_option_inspect)]
 
 mod cache;
 mod clients;

--- a/rusk-wallet/src/wallet/transaction.rs
+++ b/rusk-wallet/src/wallet/transaction.rs
@@ -58,7 +58,6 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let mut rng = StdRng::from_entropy();
         let amt = *amt;
 
-        let mut sender_sk = self.derive_phoenix_sk(sender_idx);
         let refund_pk = self.shielded_key(sender_idx)?;
 
         let tx_cost = amt + gas.limit * gas.price;
@@ -71,6 +70,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         let root = state.fetch_root().await?;
         let chain_id = state.fetch_chain_id().await?;
+
+        let mut sender_sk = self.derive_phoenix_sk(sender_idx);
 
         let tx = phoenix(
             &mut rng,
@@ -87,11 +88,11 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             chain_id,
             memo,
             &Prover,
-        )?;
+        );
 
         sender_sk.zeroize();
 
-        let tx = state.prove(tx).await?;
+        let tx = state.prove(tx?).await?;
         state.propagate(tx).await
     }
 
@@ -118,13 +119,14 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             return Err(Error::NotEnoughGas);
         }
 
-        let mut sender_sk = self.derive_bls_sk(sender_idx);
         let sender_pk = self.public_key(sender_idx)?;
         let amt = *amt;
 
         let state = self.state()?;
         let nonce = state.fetch_account(sender_pk).await?.nonce + 1;
         let chain_id = state.fetch_chain_id().await?;
+
+        let mut sender_sk = self.derive_bls_sk(sender_idx);
 
         let tx = moonlight(
             &sender_sk,
@@ -136,11 +138,11 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             nonce,
             chain_id,
             memo,
-        )?;
+        );
 
         sender_sk.zeroize();
 
-        state.propagate(tx).await
+        state.propagate(tx?).await
     }
 
     /// Executes a generic contract call, paying gas with a shielded account.
@@ -164,7 +166,6 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let deposit = *deposit;
 
         let mut rng = StdRng::from_entropy();
-        let mut sender_sk = self.derive_phoenix_sk(sender_idx);
         // in a contract execution or deployment, the sender and receiver are
         // the same
         let receiver_pk = self.shielded_key(sender_idx)?;
@@ -179,6 +180,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         let root = state.fetch_root().await?;
         let chain_id = state.fetch_chain_id().await?;
+
+        let mut sender_sk = self.derive_phoenix_sk(sender_idx);
 
         let tx = phoenix(
             &mut rng,
@@ -195,11 +198,11 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             chain_id,
             Some(data),
             &Prover,
-        )?;
+        );
 
         sender_sk.zeroize();
 
-        let tx = state.prove(tx).await?;
+        let tx = state.prove(tx?).await?;
         state.propagate(tx).await
     }
 
@@ -225,7 +228,6 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let state = self.state()?;
         let deposit = *deposit;
 
-        let mut sender_sk = self.derive_bls_sk(sender_idx);
         let sender = self.public_key(sender_idx)?;
 
         let account = state.fetch_account(sender).await?;
@@ -235,6 +237,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let nonce = account.nonce + 1;
 
         let chain_id = state.fetch_chain_id().await?;
+
+        let mut sender_sk = self.derive_bls_sk(sender_idx);
 
         let tx = moonlight(
             &sender_sk,
@@ -246,11 +250,11 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             nonce,
             chain_id,
             exec,
-        )?;
+        );
 
         sender_sk.zeroize();
 
-        state.propagate(tx).await
+        state.propagate(tx?).await
     }
 
     /// Stakes Dusk using shielded notes.
@@ -279,8 +283,6 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         let mut rng = StdRng::from_entropy();
         let amt = *amt;
-        let mut sender_sk = self.derive_phoenix_sk(profile_idx);
-        let mut stake_sk = self.derive_bls_sk(profile_idx);
 
         let stake_pk = self.public_key(profile_idx)?;
         let stake_owner_idx = match self.find_stake_owner_idx(stake_pk).await {
@@ -297,7 +299,6 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
                 return Err(e);
             }
         };
-        let mut stake_owner_sk = self.derive_bls_sk(stake_owner_idx);
 
         let tx_cost = amt + gas.limit * gas.price;
         let inputs = state
@@ -309,6 +310,10 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         let root = state.fetch_root().await?;
         let chain_id = state.fetch_chain_id().await?;
+
+        let mut sender_sk = self.derive_phoenix_sk(profile_idx);
+        let mut stake_sk = self.derive_bls_sk(profile_idx);
+        let mut stake_owner_sk = self.derive_bls_sk(stake_owner_idx);
 
         let stake = phoenix_stake(
             &mut rng,
@@ -322,13 +327,13 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             chain_id,
             amt,
             &Prover,
-        )?;
+        );
 
         sender_sk.zeroize();
         stake_sk.zeroize();
         stake_owner_sk.zeroize();
 
-        let stake = state.prove(stake).await?;
+        let stake = state.prove(stake?).await?;
         state.propagate(stake).await
     }
 
@@ -356,7 +361,6 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         let state = self.state()?;
         let amt = *amt;
-        let mut stake_sk = self.derive_bls_sk(profile_idx);
         let stake_pk = self.public_key(profile_idx)?;
         let chain_id = state.fetch_chain_id().await?;
         let moonlight_current_nonce =
@@ -376,6 +380,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
                 return Err(e);
             }
         };
+
+        let mut stake_sk = self.derive_bls_sk(profile_idx);
         let mut stake_owner_sk = self.derive_bls_sk(stake_owner_idx);
 
         let stake = moonlight_stake(
@@ -387,12 +393,12 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             gas.price,
             moonlight_current_nonce,
             chain_id,
-        )?;
+        );
 
         stake_sk.zeroize();
         stake_owner_sk.zeroize();
 
-        state.propagate(stake).await
+        state.propagate(stake?).await
     }
 
     /// Unstakes Dusk into shielded notes.
@@ -410,29 +416,35 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         let state = self.state()?;
 
-        let mut sender_sk = self.derive_phoenix_sk(profile_idx);
-        let mut stake_sk = self.derive_bls_sk(profile_idx);
-        let stake_pk = BlsPublicKey::from(&stake_sk);
-
-        let stake_owner_idx = self.find_stake_owner_idx(&stake_pk).await?;
-        let mut stake_owner_sk = self.derive_bls_sk(stake_owner_idx);
-
-        let unstake_value = state
-            .fetch_stake(&stake_pk)
-            .await?
-            .and_then(|s| s.amount)
-            .map(|s| s.total_funds())
-            .unwrap_or_default();
-
-        if unstake_value == 0 {
-            return Err(Error::NotStaked);
-        }
-
         let tx_cost = gas.limit * gas.price;
         let inputs = state.tx_input_notes(profile_idx, tx_cost).await?;
 
         let root = state.fetch_root().await?;
         let chain_id = state.fetch_chain_id().await?;
+
+        let mut stake_sk = self.derive_bls_sk(profile_idx);
+        let stake_pk = BlsPublicKey::from(&stake_sk);
+
+        let stake_owner_idx = self
+            .find_stake_owner_idx(&stake_pk)
+            .await
+            .inspect_err(|_| stake_sk.zeroize())?;
+
+        let unstake_value = state
+            .fetch_stake(&stake_pk)
+            .await
+            .inspect_err(|_| stake_sk.zeroize())?
+            .and_then(|s| s.amount)
+            .map(|s| s.total_funds())
+            .unwrap_or_default();
+
+        if unstake_value == 0 {
+            stake_sk.zeroize();
+            return Err(Error::NotStaked);
+        }
+
+        let mut sender_sk = self.derive_phoenix_sk(profile_idx);
+        let mut stake_owner_sk = self.derive_bls_sk(stake_owner_idx);
 
         let unstake = phoenix_unstake(
             &mut rng,
@@ -446,13 +458,13 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             gas.price,
             chain_id,
             &Prover,
-        )?;
+        );
 
         sender_sk.zeroize();
         stake_sk.zeroize();
         stake_owner_sk.zeroize();
 
-        let unstake = state.prove(unstake).await?;
+        let unstake = state.prove(unstake?).await?;
         state.propagate(unstake).await
     }
 
@@ -469,7 +481,6 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
     ) -> Result<Transaction, Error> {
         let mut rng = StdRng::from_entropy();
         let state = self.state()?;
-        let mut stake_sk = self.derive_bls_sk(profile_idx);
 
         let stake_pk = self.public_key(profile_idx)?;
 
@@ -488,7 +499,9 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         }
 
         let stake_owner_idx = self.find_stake_owner_idx(stake_pk).await?;
+
         let mut stake_owner_sk = self.derive_bls_sk(stake_owner_idx);
+        let mut stake_sk = self.derive_bls_sk(profile_idx);
 
         let unstake = moonlight_unstake(
             &mut rng,
@@ -500,12 +513,12 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             gas.price,
             account_nonce,
             chain_id,
-        )?;
+        );
 
         stake_sk.zeroize();
         stake_owner_sk.zeroize();
 
-        state.propagate(unstake).await
+        state.propagate(unstake?).await
     }
 
     /// Withdraws accumulated staking to a shielded account.
@@ -522,16 +535,11 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let state = self.state()?;
         let mut rng = StdRng::from_entropy();
 
-        let mut sender_sk = self.derive_phoenix_sk(sender_idx);
-        let mut stake_sk = self.derive_bls_sk(sender_idx);
-
         let tx_cost = gas.limit * gas.price;
         let inputs = state.tx_input_notes(sender_idx, tx_cost).await?;
 
         let root = state.fetch_root().await?;
         let chain_id = state.fetch_chain_id().await?;
-
-        let stake_pk = BlsPublicKey::from(&stake_sk);
 
         let available_reward = self.get_stake_reward(sender_idx).await?;
 
@@ -548,8 +556,16 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             None => *available_reward,
         };
 
-        let stake_owner_idx = self.find_stake_owner_idx(&stake_pk).await?;
+        let mut stake_sk = self.derive_bls_sk(sender_idx);
+        let stake_pk = BlsPublicKey::from(&stake_sk);
+
+        let stake_owner_idx = self
+            .find_stake_owner_idx(&stake_pk)
+            .await
+            .inspect_err(|_| stake_sk.zeroize())?;
+
         let mut stake_owner_sk = self.derive_bls_sk(stake_owner_idx);
+        let mut sender_sk = self.derive_phoenix_sk(sender_idx);
 
         let withdraw = phoenix_stake_reward(
             &mut rng,
@@ -563,13 +579,13 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             gas.price,
             chain_id,
             &Prover,
-        )?;
+        );
 
         sender_sk.zeroize();
         stake_sk.zeroize();
         stake_owner_sk.zeroize();
 
-        let withdraw = state.prove(withdraw).await?;
+        let withdraw = state.prove(withdraw?).await?;
         state.propagate(withdraw).await
     }
 
@@ -605,10 +621,10 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             None => *available_reward,
         };
 
-        let mut sender_sk = self.derive_bls_sk(sender_idx);
-
         let stake_pk = self.public_key(sender_idx)?;
         let stake_owner_idx = self.find_stake_owner_idx(stake_pk).await?;
+
+        let mut sender_sk = self.derive_bls_sk(sender_idx);
         let mut stake_owner_sk = self.derive_bls_sk(stake_owner_idx);
 
         let withdraw = moonlight_stake_reward(
@@ -621,12 +637,12 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             gas.price,
             nonce,
             chain_id,
-        )?;
+        );
 
         sender_sk.zeroize();
         stake_owner_sk.zeroize();
 
-        state.propagate(withdraw).await
+        state.propagate(withdraw?).await
     }
 
     /// Converts Dusk from a shielded account to a public account.
@@ -662,12 +678,12 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             gas.price,
             chain_id,
             &Prover,
-        )?;
+        );
 
         phoenix_sk.zeroize();
         moonlight_sk.zeroize();
 
-        let convert = state.prove(convert).await?;
+        let convert = state.prove(convert?).await?;
         state.propagate(convert).await
     }
 
@@ -702,12 +718,12 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             gas.price,
             nonce,
             chain_id,
-        )?;
+        );
 
         phoenix_sk.zeroize();
         moonlight_sk.zeroize();
 
-        state.propagate(convert).await
+        state.propagate(convert?).await
     }
 
     /// Deploys a contract using shielded notes to pay gas.
@@ -732,8 +748,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         let tx_cost = gas.limit * gas.price;
         let inputs = state.tx_input_notes(sender_idx, tx_cost).await?;
 
-        let mut sender_sk = self.derive_phoenix_sk(sender_idx);
         let owner_pk = self.public_key(sender_idx)?;
+        let mut sender_sk = self.derive_phoenix_sk(sender_idx);
 
         let deploy = phoenix_deployment(
             &mut rng,
@@ -748,11 +764,11 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             gas.price,
             chain_id,
             &Prover,
-        )?;
+        );
 
         sender_sk.zeroize();
 
-        let deploy = state.prove(deploy).await?;
+        let deploy = state.prove(deploy?).await?;
         state.propagate(deploy).await
     }
 
@@ -787,11 +803,11 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             moonlight_nonce,
             deploy_nonce,
             chain_id,
-        )?;
+        );
 
         sender_sk.zeroize();
 
-        state.propagate(deploy).await
+        state.propagate(deploy?).await
     }
 
     /// Finds the index of the stake owner account.


### PR DESCRIPTION
For https://github.com/dusk-network/rusk/issues/3687.

It's still possible for a secret key to never be zeroed if something panics between the creation and `zeroize` call.