### PR TITLE
rust: set default features to false for k256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ hyper = "1.4.1"
 hyper-tungstenite = "0.13"
 hyper-util = "0.1.9"
 inquire = "0.7.5"
-k256 = "0.13"
+k256 = { version = "0.13", default-features = false }
 konst = "0.3.9"
 lazy_static = "1.5"
 lru = "0.12.4"


### PR DESCRIPTION
rust: set default features to false for k256

fixes build issue with edition 2024 dependency
