### PR TITLE
Leave keccak256 host function, remove secp256k1 host function

### DIFF
--- a/contracts/host_fn/src/lib.rs
+++ b/contracts/host_fn/src/lib.rs
@@ -83,15 +83,6 @@ impl HostFnTest {
         abi::keccak256(bytes)
     }
 
-    pub fn verify_secp256k1(
-        &self,
-        msg: Vec<u8>,
-        pk: Vec<u8>,
-        sig: Vec<u8>,
-    ) -> bool {
-        abi::verify_secp256k1(msg, pk, sig)
-    }
-
     pub fn chain_id(&self) -> u8 {
         abi::chain_id()
     }
@@ -153,13 +144,6 @@ unsafe fn verify_bls_multisig(arg_len: u32) -> u32 {
 #[no_mangle]
 unsafe fn keccak256(arg_len: u32) -> u32 {
     abi::wrap_call(arg_len, |bytes| STATE.keccak256(bytes))
-}
-
-#[no_mangle]
-unsafe fn verify_secp256k1(arg_len: u32) -> u32 {
-    abi::wrap_call(arg_len, |(msg, pk, sig)| {
-        STATE.verify_secp256k1(msg, pk, sig)
-    })
 }
 
 #[no_mangle]

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -46,8 +46,6 @@ impl Query {
     pub const VERIFY_BLS_MULTISIG: &'static str = "verify_bls_multisig";
     /// Host-function name to compute the keccak256 hash.
     pub const KECCAK256: &'static str = "keccak256";
-    /// Host-function name to verify secp256k1 signature.
-    pub const VERIFY_SECP256K1: &'static str = "verify_secp256k1";
 }
 
 #[cfg(feature = "abi")]
@@ -148,13 +146,6 @@ pub(crate) mod host_queries {
     #[must_use]
     pub fn keccak256(bytes: Vec<u8>) -> [u8; 32] {
         host_query(Query::KECCAK256, bytes)
-    }
-
-    /// Verify if a secp256k1 signature is valid for a given public key and
-    /// message
-    #[must_use]
-    pub fn verify_secp256k1(msg: Vec<u8>, pk: Vec<u8>, sig: Vec<u8>) -> bool {
-        host_query(Query::VERIFY_SECP256K1, (msg, pk, sig))
     }
 
     /// Get the chain ID.

--- a/vm/CHANGELOG.md
+++ b/vm/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for `TransactionData::Blob`
-- Add `keccak256` and `verify_secp256k1` host query functions [#3774]
+- Add `keccak256` host query function [#3774]
 
 ## [1.3.0] - 2025-04-17
 

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -18,7 +18,6 @@ blake3 = { workspace = true }
 dusk-poseidon = { workspace = true }
 rkyv = { workspace = true, features = ["size_32"] }
 sha3 = { workspace = true }
-k256 = { workspace = true, features = ["ecdsa"] }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["getrandom"] }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -30,7 +30,7 @@ use piecrust::{SessionData, VM as PiecrustVM};
 use self::host_queries::{
     host_hash, host_keccak256, host_poseidon_hash, host_verify_bls,
     host_verify_bls_multisig, host_verify_groth16_bn254, host_verify_plonk,
-    host_verify_schnorr, host_verify_secp256k1,
+    host_verify_schnorr,
 };
 
 pub(crate) mod cache;
@@ -260,9 +260,5 @@ impl VM {
             host_verify_bls_multisig,
         );
         self.0.register_host_query(Query::KECCAK256, host_keccak256);
-        self.0.register_host_query(
-            Query::VERIFY_SECP256K1,
-            host_verify_secp256k1,
-        );
     }
 }

--- a/vm/tests/vm.rs
+++ b/vm/tests/vm.rs
@@ -32,10 +32,7 @@ use dusk_core::signatures::schnorr::{
 use dusk_core::BlsScalar;
 use dusk_vm::{ContractData, Session, VM};
 use ff::Field;
-use k256::ecdsa::signature::Signer;
-use k256::ecdsa::{Signature, SigningKey};
 use rand::rngs::OsRng;
-use sha3::{Digest, Keccak256};
 
 const POINT_LIMIT: u64 = 0x4000000;
 const CHAIN_ID: u8 = 0xFA;
@@ -275,52 +272,6 @@ fn keccak256() {
         "48299ecd7ccb5655d3be5747703c44137173e1c5ef2ec9e175bffe9e2c5e3eda",
         hex::encode(output),
     );
-}
-
-#[test]
-fn verify_secp256k1() {
-    let vm = VM::ephemeral().expect("Instantiating VM should succeed");
-    let (mut session, contract_id) = instantiate(&vm, 0);
-
-    let signing_key = SigningKey::random(&mut OsRng);
-    let verifying_key = signing_key.verifying_key();
-    let message = b"test message".to_vec();
-    let message_hash = Keccak256::digest(&message).to_vec();
-    let signature: Signature = signing_key.sign(&message_hash);
-    let mut arg = (
-        message_hash,
-        verifying_key.to_sec1_bytes().to_vec(),
-        signature.to_bytes().to_vec(),
-    );
-
-    let verification_result = session
-        .call::<_, bool>(contract_id, "verify_secp256k1", &arg, POINT_LIMIT)
-        .expect("Querying should succeed")
-        .data;
-
-    assert!(verification_result);
-
-    let bad_message = b"bad test message".to_vec();
-    let bad_message_hash = Keccak256::digest(bad_message).to_vec();
-    arg.0 = bad_message_hash;
-
-    let verification_result = session
-        .call::<_, bool>(contract_id, "verify_secp256k1", &arg, POINT_LIMIT)
-        .expect("Querying should succeed")
-        .data;
-
-    assert!(!verification_result);
-
-    let mut bad_hash = Keccak256::digest(&message).to_vec();
-    bad_hash[0] ^= 0xff;
-    arg.0 = bad_hash;
-
-    let verification_result = session
-        .call::<_, bool>(contract_id, "verify_secp256k1", &arg, POINT_LIMIT)
-        .expect("Querying should succeed")
-        .data;
-
-    assert!(!verification_result);
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
Leave keccak256 host function, remove secp256k1 host function

As k256 crate needed for secp256k1 is edition 2024, and we do not need secp256k1 as host function yet,
and we do need keccak256 to be available ASAP, this PR removes secp256k1 host function and k256 crate
rependency