### PR TITLE
rusk-wallet: do not exit when an error is returned from the interactive menu

### DIFF
--- a/rusk-wallet/src/bin/interactive.rs
+++ b/rusk-wallet/src/bin/interactive.rs
@@ -160,7 +160,10 @@ pub(crate) async fn run_loop(
                 }
                 Err(e) => match e.downcast_ref::<InquireError>() {
                     Some(InquireError::OperationCanceled) => (),
-                    _ => return Err(e),
+                    Some(InquireError::OperationInterrupted) => {
+                        return Err(e);
+                    }
+                    _ => println!("{e}\n"),
                 },
             };
         }


### PR DESCRIPTION
Followup of https://github.com/dusk-network/rusk/pull/3696.
https://github.com/dusk-network/rusk/pull/3696 stops exiting when a command errors, but it doesn't stop when the command menu errors.
This PR prevents exiting when the command menu errors.