### PR TITLE
workspace: remove ci cache

### DIFF
--- a/.github/workflows/rusk_ci.yml
+++ b/.github/workflows/rusk_ci.yml
@@ -64,7 +64,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
-      - uses: Swatinem/rust-cache@v2
       - run: make wasm
       - run: make clippy
 
@@ -76,5 +75,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
-      - uses: Swatinem/rust-cache@v2
       - run: make test


### PR DESCRIPTION
Remove the cache step
Initially it was used to reuse test artifacts during the clippy checks

However, those two steps now run in parallel, so no sense at all in having the cache.
This saves 5min in uploading 2GB (twice)

## Before

<img width="740" alt="image" src="https://github.com/user-attachments/assets/3e411005-2977-4be4-bda6-22a2cbd69360" />

<img width="1113" alt="image" src="https://github.com/user-attachments/assets/5be0fd56-2507-468b-b7ba-77ade9ef7d1f" />

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/8a4ad243-eac0-4f96-be89-6b3bb8fd98d1" />

## After

<img width="823" alt="image" src="https://github.com/user-attachments/assets/3d061975-5de2-470f-a015-0d997a1885df" />

<img width="776" alt="image" src="https://github.com/user-attachments/assets/c7f90f3c-9e15-4a94-a835-8a69178f7750" />

