### PR TITLE
rusk: add `mempool_nonce` field to `/on/account/status` response

### DIFF
--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for `TransactionData::Blob`
+- Add `mempool_nonce` field to `/on/account/status` response
 
 ## [1.3.0] - 2025-04-17
 


### PR DESCRIPTION
This PR allows any client to do multiple sequential transactions without manually inspecting the mempool

>  // Determine the next available nonce not already used in the mempool.
        // This ensures that any in-flight transactions using sequential nonces
        // are accounted for.
        // If the account has no transactions in the mempool, the mempool_nonce
        // will be `None`, indicating that the next nonce is the same as the
        // account's current nonce.