### PR TITLE
rusk: add gas_per_blob configuration

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -27,7 +27,7 @@ mod validation;
 
 pub use ratification::step::build_ratification_payload;
 pub use validation::step::build_validation_payload;
-pub use validation::step::validate_blobs;
+pub use validation::step::validate_blob_sidecars;
 
 mod iteration_ctx;
 pub mod merkle;

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for `TransactionData::Blob`
+- Add `error::TxPreconditionError`
+- Add `transfer::deploy_check`
+- Add `transfer::blob_check`
 
 ## [1.3.0] - 2025-04-17
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,7 +25,7 @@ pub mod stake;
 pub mod transfer;
 
 mod error;
-pub use error::Error;
+pub use error::{Error, TxPreconditionError};
 
 mod dusk;
 pub use dusk::{dusk, from_dusk, Dusk, LUX};

--- a/node/src/vm.rs
+++ b/node/src/vm.rs
@@ -92,6 +92,9 @@ pub trait VMExecution: Send + Sync + 'static {
     fn min_deployment_gas_price(&self) -> u64;
     fn min_gas_limit(&self) -> u64;
     fn min_deploy_points(&self) -> u64;
+
+    fn gas_per_blob(&self) -> u64;
+    fn blob_activation_height(&self) -> u64;
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/rusk/src/lib/node/vm.rs
+++ b/rusk/src/lib/node/vm.rs
@@ -287,6 +287,14 @@ impl VMExecution for Rusk {
     fn min_deploy_points(&self) -> u64 {
         self.vm_config.min_deploy_points
     }
+
+    fn gas_per_blob(&self) -> u64 {
+        self.vm_config.gas_per_blob
+    }
+
+    fn blob_activation_height(&self) -> u64 {
+        self.vm_config.feature(FEATURE_BLOB).unwrap_or(u64::MAX)
+    }
 }
 
 fn has_unique_elements<T>(iter: T) -> bool

--- a/vm/src/execute/config.rs
+++ b/vm/src/execute/config.rs
@@ -10,6 +10,8 @@ pub struct Config {
     /// The amount of gas points charged for each byte in a contract-deployment
     /// bytecode.
     pub gas_per_deploy_byte: u64,
+    /// The amount of gas points charged for each blob in a transaction.
+    pub gas_per_blob: u64,
     /// The minimum gas points charged for a contract deployment.
     pub min_deploy_points: u64,
     /// The minimum gas price set for a contract deployment
@@ -18,6 +20,9 @@ pub struct Config {
     ///
     /// This field may be deprecated after the feature rollout.
     pub with_public_sender: bool,
+
+    /// Enable the blob processing by the VM
+    pub with_blob: bool,
 }
 
 impl Default for Config {
@@ -30,8 +35,10 @@ impl Config {
     /// Create a config with all values to default
     pub const DEFAULT: Config = Config {
         gas_per_deploy_byte: 0,
+        gas_per_blob: 0,
         min_deploy_points: 0,
         min_deploy_gas_price: 0,
         with_public_sender: false,
+        with_blob: false,
     };
 }


### PR DESCRIPTION
This PR introduces a minimum gas limit to pay for blobs

Default to 0, it leaves the way open to future tuning


Additionally, this PR refactor how Blob and Deploy txs are verified, introducing a TxPreconditionCheck error variant that's handled in a single code spot (instead of having duplicated code)