### PR TITLE
docker: Lock Rust version in Docker image

### DIFF
--- a/Dockerfile.ephemeral
+++ b/Dockerfile.ephemeral
@@ -1,5 +1,5 @@
 # --- Build stage ---
-FROM rust:latest AS build-stage
+FROM rust:1.82 AS build-stage
 
 WORKDIR /opt/rusk
 ENV RUSK_PROFILE_PATH /.dusk/rusk
@@ -41,7 +41,7 @@ RUN if [ -n "$CARGO_FEATURES" ]; then \
     fi
 
 # --- Run stage ---
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 
 WORKDIR /opt/rusk
 


### PR DESCRIPTION
This PR locks the Dockerfile for Rusk to the Rust version used by our repo.

Resolves #3856