### PR TITLE
rusk: Fix dockerfiles to >= glibc 2.39

### DIFF
--- a/Dockerfile.ephemeral
+++ b/Dockerfile.ephemeral
@@ -1,10 +1,18 @@
 # --- Build stage ---
-FROM rust:1.82 AS build-stage
+FROM ubuntu:24.04 AS build-stage
+
+RUN apt-get update && apt-get install -y unzip curl build-essential openssl libssl-dev pkg-config && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 WORKDIR /opt/rusk
 ENV RUSK_PROFILE_PATH /.dusk/rusk
+ENV PATH="$PATH:/root/.cargo/bin"
 
 RUN apt-get update && apt-get install -y clang && rm -rf /var/lib/apt/lists/*
+
+# Using this to modify rusk config file before running a node
+RUN cargo install toml-cli --version 0.2.3
 
 COPY . .
 


### PR DESCRIPTION
The DuskC compiler for ARM64/MacOS is built against a base OS that had glibc version 2.39, which isn't the case for the other compiled artifacts.

The rust:1.82 version in our Dockerfile, however, uses glibc version 2.36, which means it fails for Mac users. This PR should resolve this by setting Ubuntu 24.04 explicitly, which comes with glibc version 2.39.