### PR TITLE
archive: Add missing indexes to archive node for query performance

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add extra SQLite indexes for archive node performance [#3874]
 - Add cursor based pagination to `fetch_finalized_events_from_contract` [#3871]
 - Add index on finalized_events (source, id) to do fast pagination [#3871]
 - Add separate read/write SQLite connection pools [#3863]
@@ -66,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First `dusk-node` release
 
 <!-- Issues -->
+[#3874]: https://github.com/dusk-network/rusk/issues/3874
 [#3871]: https://github.com/dusk-network/rusk/issues/3871
 [#3866]: https://github.com/dusk-network/rusk/issues/3866
 [#3865]: https://github.com/dusk-network/rusk/issues/3865

--- a/node/migrations/20250926044900_add_event_block_hash_and_unfinalized_indexes.sql
+++ b/node/migrations/20250926044900_add_event_block_hash_and_unfinalized_indexes.sql
@@ -1,0 +1,12 @@
+CREATE INDEX IF NOT EXISTS finalized_events_block_hash_idx
+  ON finalized_events (block_hash);
+
+CREATE INDEX IF NOT EXISTS unfinalized_events_block_hash_idx
+  ON unfinalized_events (block_hash);
+
+CREATE INDEX IF NOT EXISTS unfinalized_events_block_height_idx
+  ON unfinalized_events (block_height);
+
+CREATE INDEX IF NOT EXISTS finalized_blocks_phx1_height_idx
+  ON finalized_blocks (block_height)
+  WHERE phoenix_present = 1;


### PR DESCRIPTION
Resolves #3874

Rationale for the chosen indexes:
- `finalized_events_block_hash_idx`: Speeds up block lookups by `block_hash`, which is a bottleneck now
- `unfinalized_events_block_hash_idx`: Speeds up finalize/rollback operations that select or delete events by `block_hash`
- `unfinalized_events_block_height_idx`: Makes `MAX(block_height)` queries and `NOT EXISTS ... WHERE block_height=?` checks more efficient for unfinalized events
- `finalized_blocks_phx1_height_idx`: Allows for quick retrieval of the next block where a Phoenix TX is available, after a given height. (`nextPhoenix` GraphQL query)