### PR TITLE
w3sper.js: Release v1.3.0

### DIFF
--- a/w3sper.js/CHANGELOG.md
+++ b/w3sper.js/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Removed
+
+### Fixed
+
+## [1.3.0] - 2025-09-30
+
+### Added
+
 - Add `deposit` field to the transaction builder to deposit funds into contracts, allowing explicit values to be set instead of default `0n` [#3868]
 - Add data-driver runtime (`src/data-driver/loader.js`, `registry.js`, `mod.js`) for JSON <-> RKYV serialization and WASM driver loading [#3876]
 - Add minimal `Contract` API with `call`, and `tx` methods for driver-backed reads and writes [#3876]

--- a/w3sper.js/deno.json
+++ b/w3sper.js/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@dusk/w3sper",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "exports": "./src/mod.js",
   "imports": {
     "@dusk/exu": "jsr:@dusk/exu@0.1.2",


### PR DESCRIPTION
## [1.3.0] - 2025-09-30

### Added

- Add `deposit` field to the transaction builder to deposit funds into contracts, allowing explicit values to be set instead of default `0n` [#3868]
- Add data-driver runtime (`src/data-driver/loader.js`, `registry.js`, `mod.js`) for JSON <-> RKYV serialization and WASM driver loading [#3876]
- Add minimal `Contract` API with `call`, and `tx` methods for driver-backed reads and writes [#3876]
- Add first-class decoded contract events with `contract.events.<event>.once()/on()` using RUES and automatic driver-based event decoding [#3877]