### PR TITLE
w3sper.js: Release v1.4.0

### DIFF
--- a/w3sper.js/CHANGELOG.md
+++ b/w3sper.js/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Removed
+
+### Fixed
+
+## [1.4.0] - 2025-10-28
+
+### Added
+
 - Expose `Contract.encode(fnName, args)` publicly, allowing developers to manually convert JSON inputs to RKYV-encoded bytes for custom or intermediate use cases [#3901]
 - Extend `Contract.call()` to support feeder (streamed) contract queries, adds `{ feeder: true }` option and automatic fallback retry when the node responds with `VM Error: Missing feed` [#3902]
 
@@ -75,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Rues not dispatching a "disconnect" event when the socket closes on its own [#3568]
 - Fix AbortController's abort on Rues events not triggering unsubscription from server [#3582]
 
-## [1.0.0] - 2025-01-15
+## [0.1.0] - 2025-01-15
 
 - First `w3sper.js` release
 
@@ -96,7 +106,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- VERSIONS -->
 
-[Unreleased]: https://github.com/dusk-network/rusk/compare/w3sper-v.0.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/rusk/compare/w3sper-v.0.4.0...HEAD
+[1.4.0]: https://github.com/dusk-network/rusk/tree/w3sper-v.1.4.0
+[1.3.0]: https://github.com/dusk-network/rusk/tree/w3sper-v.1.3.0
 [1.2.0]: https://github.com/dusk-network/rusk/tree/w3sper-v.1.2.0
 [1.1.0]: https://github.com/dusk-network/rusk/tree/w3sper-v.1.1.0
-[1.0.0]: https://github.com/dusk-network/rusk/tree/w3sper-v.0.1.0
+[0.1.0]: https://github.com/dusk-network/rusk/tree/w3sper-v.0.1.0

--- a/w3sper.js/deno.json
+++ b/w3sper.js/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@dusk/w3sper",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "exports": "./src/mod.js",
   "imports": {
     "@dusk/exu": "jsr:@dusk/exu@0.1.2",


### PR DESCRIPTION
## [1.4.0] - 2025-10-28

### Added

- Expose `Contract.encode(fnName, args)` publicly, allowing developers to manually convert JSON inputs to RKYV-encoded bytes for custom or intermediate use cases [#3901]
- Extend `Contract.call()` to support feeder (streamed) contract queries, adds `{ feeder: true }` option and automatic fallback retry when the node responds with `VM Error: Missing feed` [#3902]

### Changed

### Removed

### Fixed