### PR TITLE
ci: Set reduced Rusk block time

### DIFF
--- a/.github/workflows/rusk_ci.yml
+++ b/.github/workflows/rusk_ci.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
-      - run: make wasm
+      - run: make setup-compiler
       - run: make clippy
 
   test_nightly:

--- a/rusk/Makefile
+++ b/rusk/Makefile
@@ -3,7 +3,7 @@ INITFILE?=../rusk-recovery/config/localnet.toml
 help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-test: build-bench ## Run Rusk tests
+test: ## Run Rusk tests
 	@cargo test \
 		--release \
 		--features testwallet \

--- a/scripts/run-rusk-wallet-tests.sh
+++ b/scripts/run-rusk-wallet-tests.sh
@@ -15,10 +15,11 @@ RAND_POSTFIX=$(mktemp XXXXXX -u)
 STATE="/tmp/rusk-wallet-test-$RAND_POSTFIX.state"
 NODE_LOG="/tmp/rusk-wallet-test-node-$RAND_POSTFIX.log"
 
-cargo r --release -p dusk-rusk -- recovery state --init ../examples/genesis.toml -o "$STATE"
+# Build Rusk once
+cargo build --release -p dusk-rusk --features archive
 
-# Build rusk
-cargo build --release -p dusk-rusk --features archive,prover
+# Use the built binary to init state (no cargo run rebuild)
+../target/release/rusk recovery state --init ../examples/genesis.toml -o "$STATE"
 
 # Start nodes
 DUSK_CONSENSUS_KEYS_PASS=password ../target/release/rusk \


### PR DESCRIPTION
This PR introduces improvements to the Rusk CI workflow and related scripts, focusing on performance tuning for testing. The most notable changes involve updating the CI workflow to use a new setup step, setting an environment variable for minimum block time, and optimizing the wallet test script to avoid unnecessary rebuilds.

Before: 
`Clippy check release`: ~15 minutes
`Nightly tests`: ~23 minutes

After:
`Clippy check release`: ~11 minutes
`Nightly tests`: ~17 minutes