### PR TITLE
explorer: replace badly written `makeNodeUrl` test

### DIFF
--- a/explorer/src/lib/url/__tests__/makeNodeUrl.spec.js
+++ b/explorer/src/lib/url/__tests__/makeNodeUrl.spec.js
@@ -1,169 +1,83 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { makeNodeUrl } from "..";
+
+const protocol = "https://";
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
 
 describe("makeNodeUrl", () => {
   const localhostString = window.location.hostname;
 
   it("should return a local URL when VITE_NODE_URL is not set", () => {
-    delete import.meta.env.VITE_NODE_URL;
-    expect(makeNodeUrl().hostname).toBe(localhostString);
-  });
+    vi.stubEnv("VITE_NODE_URL", "");
 
-  it("should return a local URL when VITE_NODE_URL is an empty string", () => {
-    import.meta.env.VITE_NODE_URL = "";
     expect(makeNodeUrl().hostname).toBe(localhostString);
   });
 
   it("should return a local URL with no base path when VITE_NODE_URL is not set and VITE_RUSK_PATH is not set", () => {
-    delete import.meta.env.VITE_NODE_URL;
-    delete import.meta.env.VITE_RUSK_PATH;
-    expect(makeNodeUrl().hostname).toBe(localhostString);
-    expect(makeNodeUrl().pathname).toBe("/");
-  });
+    vi.stubEnv("VITE_NODE_URL", "");
+    vi.stubEnv("VITE_RUSK_PATH", "");
 
-  it("should return a local URL with no base path when VITE_NODE_URL is set to an empty string and VITE_RUSK_PATH is not set", () => {
-    import.meta.env.VITE_NODE_URL = "";
-    delete import.meta.env.VITE_RUSK_PATH;
-    expect(makeNodeUrl().hostname).toBe(localhostString);
-    expect(makeNodeUrl().pathname).toBe("/");
-  });
-
-  it("should return a local URL with no base path when VITE_NODE_URL is not set and VITE_RUSK_PATH is set to an empty string", () => {
-    delete import.meta.env.VITE_NODE_URL;
-    import.meta.env.VITE_RUSK_PATH = "";
-    expect(makeNodeUrl().hostname).toBe(localhostString);
-    expect(makeNodeUrl().pathname).toBe("/");
-  });
-
-  it("should return a local URL with no base path when VITE_NODE_URL is set to an empty string and VITE_RUSK_PATH is set to an empty string", () => {
-    import.meta.env.VITE_NODE_URL = "";
-    import.meta.env.VITE_RUSK_PATH = "";
     expect(makeNodeUrl().hostname).toBe(localhostString);
     expect(makeNodeUrl().pathname).toBe("/");
   });
 
   it("should return a local URL with a base path when `VITE_NODE_URL` is not set and `VITE_RUSK_PATH` is set to a valid string", () => {
-    delete import.meta.env.VITE_NODE_URL;
-    import.meta.env.VITE_RUSK_PATH = "/testing";
+    vi.stubEnv("VITE_NODE_URL", "");
+    vi.stubEnv("VITE_RUSK_PATH", "/testing");
+
     expect(makeNodeUrl().hostname).toBe(localhostString);
     expect(makeNodeUrl().pathname).toBe("/testing");
   });
 
-  it("should return a local URL with a base path when `VITE_NODE_URL` is set to an empty string and `VITE_RUSK_PATH` is set to a valid string", () => {
-    import.meta.env.VITE_NODE_URL = "";
-    import.meta.env.VITE_RUSK_PATH = "/testing";
-    expect(makeNodeUrl().hostname).toBe(localhostString);
-    expect(makeNodeUrl().pathname).toBe("/testing");
-  });
+  it("should return the devnet URL when the hostname starts with 'apps.staging.devnet'", () => {
+    const hostname = "apps.staging.devnet.dusk.network";
 
-  it("should return the devnet URL when the hostname starts with 'apps.staging.devnet' on the staging URL", () => {
-    global.window = Object.create(window);
-
-    const url = new URL("https://apps.staging.devnet.dusk.network");
-
-    Object.defineProperty(window, "location", {
-      value: {
-        hostname: url.hostname,
-        href: url.href,
-        protocol: url.protocol,
-      },
-    });
+    vi.stubGlobal("location", { hostname, protocol });
 
     expect(makeNodeUrl().hostname).toBe("devnet.nodes.dusk.network");
   });
 
   it("should return the devnet URL when the hostname starts with 'apps.devnet'", () => {
-    global.window = Object.create(window);
+    const hostname = "apps.devnet.dusk.network";
 
-    const url = new URL("https://apps.devnet.dusk.network");
-
-    Object.defineProperty(window, "location", {
-      value: {
-        hostname: url.hostname,
-        href: url.href,
-        protocol: url.protocol,
-      },
-    });
+    vi.stubGlobal("location", { hostname, protocol });
 
     expect(makeNodeUrl().hostname).toBe("devnet.nodes.dusk.network");
   });
 
-  it("should return the testnet URL when the hostname starts with 'apps.staging.testnet' on the staging URL", () => {
-    global.window = Object.create(window);
+  it("should return the testnet URL when the hostname starts with 'apps.staging.testnet'", () => {
+    const hostname = "apps.staging.testnet.dusk.network";
 
-    const url = new URL("https://apps.staging.testnet.dusk.network");
-
-    Object.defineProperty(window, "location", {
-      value: {
-        hostname: url.hostname,
-        href: url.href,
-        protocol: url.protocol,
-      },
-    });
+    vi.stubGlobal("location", { hostname, protocol });
 
     expect(makeNodeUrl().hostname).toBe("testnet.nodes.dusk.network");
   });
 
   it("should return the testnet URL when the hostname starts with 'apps.testnet'", () => {
-    global.window = Object.create(window);
+    const hostname = "apps.testnet.dusk.network";
 
-    const url = new URL("https://apps.testnet.dusk.network");
-
-    Object.defineProperty(window, "location", {
-      value: {
-        hostname: url.hostname,
-        href: url.href,
-        protocol: url.protocol,
-      },
-    });
+    vi.stubGlobal("location", { hostname, protocol });
 
     expect(makeNodeUrl().hostname).toBe("testnet.nodes.dusk.network");
   });
 
-  it("should return the mainnet URL when the hostname starts with 'apps.staging' on the staging URL", () => {
-    global.window = Object.create(window);
+  it("should return the mainnet URL when the hostname starts with 'apps.staging'", () => {
+    const hostname = "apps.staging.dusk.network";
 
-    const url = new URL("https://apps.staging.dusk.network");
-
-    Object.defineProperty(window, "location", {
-      value: {
-        hostname: url.hostname,
-        href: url.href,
-        protocol: url.protocol,
-      },
-    });
+    vi.stubGlobal("location", { hostname, protocol });
 
     expect(makeNodeUrl().hostname).toBe("nodes.dusk.network");
   });
 
   it("should return the mainnet URL when the hostname starts with 'apps'", () => {
-    global.window = Object.create(window);
+    const hostname = "apps.dusk.network";
 
-    const url = new URL("https://apps.dusk.network");
-
-    Object.defineProperty(window, "location", {
-      value: {
-        hostname: url.hostname,
-        href: url.href,
-        protocol: url.protocol,
-      },
-    });
-
-    expect(makeNodeUrl().hostname).toBe("nodes.dusk.network");
-  });
-
-  it("should return the mainnet URL when the hostname starts with 'apps.staging'", () => {
-    global.window = Object.create(window);
-
-    const url = new URL("https://apps.staging.dusk.network");
-
-    Object.defineProperty(window, "location", {
-      value: {
-        hostname: url.hostname,
-        href: url.href,
-        protocol: url.protocol,
-      },
-    });
+    vi.stubGlobal("location", { hostname, protocol });
 
     expect(makeNodeUrl().hostname).toBe("nodes.dusk.network");
   });


### PR DESCRIPTION
Resolves dusk-network/explorer#65