### PR TITLE
rusk: implement RuskHttp builder and shutdown

### DIFF
--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -89,8 +89,9 @@ const RUSK_VERSION_HEADER: &str = "Rusk-Version";
 const RUSK_VERSION_STRICT_HEADER: &str = "Rusk-Version-Strict";
 
 pub struct HttpServer {
-    handle: task::JoinHandle<()>,
-    _shutdown: broadcast::Sender<Infallible>,
+    handle: Option<task::JoinHandle<()>>,
+    #[cfg_attr(feature = "chain", allow(dead_code))]
+    shutdown: Option<broadcast::Sender<Infallible>>,
 }
 
 pub struct HttpServerConfig {
@@ -102,8 +103,17 @@ pub struct HttpServerConfig {
 }
 
 impl HttpServer {
-    pub async fn wait(self) -> Result<(), JoinError> {
-        self.handle.await
+    pub async fn wait(&mut self) -> Result<(), JoinError> {
+        match self.handle.take() {
+            Some(handle) => handle.await,
+            None => Ok(()),
+        }
+    }
+
+    #[cfg(not(feature = "chain"))]
+    pub(crate) async fn shutdown(&mut self) -> Result<(), JoinError> {
+        self.shutdown.take(); // this closes the channel to signal shutdown
+        self.wait().await
     }
 
     pub async fn bind<A, H, P1, P2>(
@@ -141,8 +151,8 @@ impl HttpServer {
         ));
 
         let server = Self {
-            handle,
-            _shutdown: shutdown_sender,
+            handle: Some(handle),
+            shutdown: Some(shutdown_sender),
         };
         Ok((server, local_addr))
     }
@@ -256,16 +266,9 @@ async fn listening_loop<H>(
         ws_event_channel_cap,
     };
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
-        .thread_name("http")
-        .enable_all()
-        .build()
-        .expect("http runtime to be created");
     loop {
         tokio::select! {
             _ = shutdown.recv() => {
-                runtime.shutdown_background();
                 break;
             }
             r = listener.accept() => {
@@ -279,8 +282,9 @@ async fn listening_loop<H>(
                 let stream = TokioIo::new(stream);
                 let service = service.clone();
 
-                runtime.spawn(async move {
-                    let conn = http.serve_connection_with_upgrades(stream, service);
+                task::spawn(async move {
+                    let conn =
+                        http.serve_connection_with_upgrades(stream, service);
                     conn.await
                 });
             }


### PR DESCRIPTION
Closes #2453

Fixes the panic messages in tests when running: 
`cargo test --release --lib http::tests -- --nocapture`
