### PR TITLE
w3sper: Validate required exports on data-driver load

### DIFF
--- a/w3sper.js/CHANGELOG.md
+++ b/w3sper.js/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Validate required WASM exports on data-driver load, rejecting invalid modules early with an actionable error message [#3990]
+
 ### Changed
 
 ### Removed
@@ -103,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3877]: https://github.com/dusk-network/rusk/issues/3877
 [#3901]: https://github.com/dusk-network/rusk/issues/3901
 [#3902]: https://github.com/dusk-network/rusk/issues/3902
+[#3990]: https://github.com/dusk-network/rusk/issues/3990
 
 <!-- VERSIONS -->
 

--- a/w3sper.js/src/data-driver/loader.js
+++ b/w3sper.js/src/data-driver/loader.js
@@ -44,6 +44,20 @@
  * ```
  */
 
+const REQUIRED_EXPORTS = [
+  "memory",
+  "alloc",
+  "dealloc",
+  "get_last_error",
+  "encode_input_fn",
+  "decode_input_fn",
+  "decode_output_fn",
+  "decode_event",
+  "get_schema",
+  "get_version",
+  "init",
+];
+
 /**
  * Create a JS driver from a compiled WASM binary.
  * @param {Uint8Array|ArrayBuffer} bytes - The compiled data‑driver WASM.
@@ -60,6 +74,14 @@
 export async function loadWasmDataDriver(bytes) {
   const wasmModule = await WebAssembly.instantiate(bytes, { env: {} });
   const exports = wasmModule.instance.exports;
+
+  const missing = REQUIRED_EXPORTS.filter((name) => !(name in exports));
+  if (missing.length > 0) {
+    throw new Error(
+      `Invalid data-driver WASM: missing required exports: ${missing.join(", ")}`,
+    );
+  }
+
   const memory = exports.memory;
 
   const textEncoder = new TextEncoder();

--- a/w3sper.js/tests/contract_test.js
+++ b/w3sper.js/tests/contract_test.js
@@ -9,6 +9,7 @@ import {
   AddressSyncer,
   Bookkeeper,
   Contract,
+  dataDrivers,
   Network,
   ProfileGenerator,
 } from "../src/mod.js";
@@ -261,3 +262,17 @@ test(
     }
   },
 );
+
+test("loadWasmDataDriver: rejects WASM missing required exports", async () => {
+  // Minimal valid WASM module (magic + version, no exports)
+  const emptyWasm = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+  ]);
+
+  await assert.reject(
+    () => dataDrivers.load(emptyWasm),
+    Error,
+    "missing required exports",
+  );
+});


### PR DESCRIPTION
Reject invalid WASM modules early with an actionable error listing all missing exports, instead of failing with a cryptic TypeError at first use. User who build contracts with Dusk Forge should always end up with valid data-drivers.

Resolves #3990