### PR TITLE
rusk: fix double contract query

### DIFF
--- a/rusk/src/lib/node/vm/query.rs
+++ b/rusk/src/lib/node/vm/query.rs
@@ -108,13 +108,6 @@ impl Rusk {
                 .data;
         }
 
-        session.call::<_, ()>(
-            contract_id,
-            call_name,
-            call_arg,
-            self.get_block_gas_limit(),
-        )?;
-
         Ok(())
     }
 


### PR DESCRIPTION
This bug was introduced in #909

In a next_pr `query_seq` will be removed, since it makes no sense anymore due to the availability of `feeder_query` method