### PR TITLE
consensus: add unit tests

### DIFF
--- a/consensus/src/execution_ctx.rs
+++ b/consensus/src/execution_ctx.rs
@@ -777,6 +777,682 @@ impl<'a, T: Operations + 'static, DB: Database> ExecutionCtx<'a, T, DB> {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use dusk_core::signatures::bls::{
+        PublicKey as BlsPublicKey, SecretKey as BlsSecretKey,
+    };
+    use node_data::ledger::{Attestation, Block, Header, StepVotes};
+    use node_data::message::payload::{Candidate, ValidationQuorum};
+    use node_data::message::{ConsensusHeader, SignedStepMessage};
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+    use std::collections::HashMap;
+    use tokio::sync::Mutex;
+
+    use crate::commons::TimeoutSet;
+    use crate::config::{MIN_STEP_TIMEOUT, TIMEOUT_INCREASE};
+    use crate::iteration_ctx::IterationCtx;
+    use crate::merkle::merkle_root;
+    use crate::operations::{
+        StateTransitionData, StateTransitionResult, Voter,
+    };
+    use crate::proposal::handler::ProposalHandler;
+    use crate::ratification::handler::RatificationHandler;
+    use crate::step_votes_reg::AttInfoRegistry;
+    use crate::user::provisioners::DUSK;
+    use crate::validation::handler::ValidationHandler;
+
+    #[derive(Default)]
+    struct DummyDb {
+        stored_candidates: Arc<Mutex<usize>>,
+        validation_results: Arc<
+            Mutex<Vec<(node_data::message::ConsensusHeader, ValidationResult)>>,
+        >,
+    }
+
+    // Minimal DB stub that records candidate/validation side effects.
+    #[async_trait]
+    impl Database for DummyDb {
+        async fn store_candidate_block(&mut self, _b: Block) {
+            let mut count = self.stored_candidates.lock().await;
+            *count += 1;
+        }
+        async fn store_validation_result(
+            &mut self,
+            ch: &node_data::message::ConsensusHeader,
+            vr: &node_data::message::payload::ValidationResult,
+        ) {
+            let mut results = self.validation_results.lock().await;
+            results.push((*ch, vr.clone()));
+        }
+        async fn get_last_iter(&self) -> (node_data::ledger::Hash, u8) {
+            ([0u8; 32], 0)
+        }
+        async fn store_last_iter(
+            &mut self,
+            _data: (node_data::ledger::Hash, u8),
+        ) {
+        }
+    }
+
+    #[derive(Default)]
+    struct DummyOps;
+
+    // No-op Operations implementation to isolate message-flow behavior.
+    #[async_trait]
+    impl Operations for DummyOps {
+        async fn validate_block_header(
+            &self,
+            _candidate_header: &node_data::ledger::Header,
+            _expected_generator: &node_data::bls::PublicKeyBytes,
+        ) -> Result<Vec<Voter>, crate::errors::HeaderError> {
+            Ok(vec![])
+        }
+        async fn validate_faults(
+            &self,
+            _block_height: u64,
+            _faults: &[node_data::ledger::Fault],
+        ) -> Result<(), crate::errors::OperationError> {
+            Ok(())
+        }
+        async fn validate_state_transition(
+            &self,
+            _prev_state: [u8; 32],
+            _blk: &Block,
+            _cert_voters: &[Voter],
+        ) -> Result<(), crate::errors::OperationError> {
+            Ok(())
+        }
+        async fn generate_state_transition(
+            &self,
+            _transition_data: StateTransitionData,
+        ) -> Result<
+            (
+                Vec<node_data::ledger::SpentTransaction>,
+                StateTransitionResult,
+            ),
+            crate::errors::OperationError,
+        > {
+            Ok((
+                vec![],
+                StateTransitionResult {
+                    state_root: [0u8; 32],
+                    event_bloom: [0u8; 256],
+                },
+            ))
+        }
+        async fn add_step_elapsed_time(
+            &self,
+            _round: u64,
+            _step_name: StepName,
+            _elapsed: Duration,
+        ) -> Result<(), crate::errors::OperationError> {
+            Ok(())
+        }
+        async fn get_block_gas_limit(&self) -> u64 {
+            0
+        }
+    }
+
+    struct NoopHandler;
+
+    // Handler that accepts every message and never terminates a step.
+    #[async_trait]
+    impl MsgHandler for NoopHandler {
+        fn verify(
+            &self,
+            _msg: &Message,
+            _round_committees: &crate::iteration_ctx::RoundCommittees,
+        ) -> Result<(), ConsensusError> {
+            Ok(())
+        }
+
+        async fn collect(
+            &mut self,
+            _msg: Message,
+            _ru: &RoundUpdate,
+            _committee: &crate::user::committee::Committee,
+            _generator: Option<PublicKeyBytes>,
+            _round_committees: &crate::iteration_ctx::RoundCommittees,
+        ) -> Result<StepOutcome, ConsensusError> {
+            Ok(StepOutcome::Pending)
+        }
+
+        async fn collect_from_past(
+            &mut self,
+            _msg: Message,
+            _committee: &crate::user::committee::Committee,
+            _generator: Option<PublicKeyBytes>,
+        ) -> Result<StepOutcome, ConsensusError> {
+            Ok(StepOutcome::Pending)
+        }
+
+        fn handle_timeout(
+            &self,
+            _ru: &RoundUpdate,
+            _curr_iteration: u8,
+        ) -> Option<Message> {
+            None
+        }
+    }
+
+    // Build iteration context plus shared handler references for tests.
+    fn build_iter_ctx(
+        db: Arc<Mutex<DummyDb>>,
+    ) -> (
+        IterationCtx<DummyDb>,
+        SafeAttestationInfoRegistry,
+        Arc<Mutex<ValidationHandler<DummyDb>>>,
+    ) {
+        let att_registry = Arc::new(Mutex::new(AttInfoRegistry::new()));
+        let validation = Arc::new(Mutex::new(ValidationHandler::new(
+            att_registry.clone(),
+            db.clone(),
+        )));
+        let validation_ref = validation.clone();
+        let ratification = Arc::new(Mutex::new(RatificationHandler::new(
+            att_registry.clone(),
+        )));
+        let proposal = Arc::new(Mutex::new(ProposalHandler::new(db)));
+
+        let mut timeouts: TimeoutSet = HashMap::new();
+        timeouts.insert(StepName::Proposal, MIN_STEP_TIMEOUT);
+        timeouts
+            .insert(StepName::Validation, MIN_STEP_TIMEOUT + TIMEOUT_INCREASE);
+        timeouts.insert(
+            StepName::Ratification,
+            MIN_STEP_TIMEOUT + TIMEOUT_INCREASE + TIMEOUT_INCREASE,
+        );
+
+        (
+            IterationCtx::new(
+                1,
+                0,
+                validation,
+                ratification,
+                proposal,
+                timeouts,
+            ),
+            att_registry,
+            validation_ref,
+        )
+    }
+
+    // Build a signed candidate for the current round/iteration.
+    fn build_candidate_message(ru: &RoundUpdate) -> Message {
+        let mut header = Header::default();
+        header.height = ru.round;
+        header.iteration = 0;
+        header.prev_block_hash = ru.hash();
+        header.generator_bls_pubkey = *ru.pubkey_bls.bytes();
+        header.txroot = merkle_root::<[u8; 32]>(&[]);
+        header.faultroot = merkle_root::<[u8; 32]>(&[]);
+
+        let block = Block::new(header, vec![], vec![]).expect("valid block");
+        let mut candidate = Candidate { candidate: block };
+        candidate.sign(&ru.secret_key, ru.pubkey_bls.inner());
+        candidate.into()
+    }
+
+    // Build a quorum payload with caller-chosen ratification outcome.
+    fn build_quorum_message(
+        ru: &RoundUpdate,
+        iteration: u8,
+        result: RatificationResult,
+    ) -> Message {
+        let att = Attestation {
+            result,
+            validation: StepVotes::default(),
+            ratification: StepVotes::default(),
+        };
+        let header = ConsensusHeader {
+            prev_block_hash: ru.hash(),
+            round: ru.round,
+            iteration,
+        };
+        let quorum = node_data::message::payload::Quorum { header, att };
+        quorum.into()
+    }
+
+    #[tokio::test]
+    // Outside emergency mode, past-step candidate messages must be ignored.
+    async fn past_message_not_processed_outside_emergency() {
+        let stored_candidates = Arc::new(Mutex::new(0usize));
+        let db = Arc::new(Mutex::new(DummyDb {
+            stored_candidates: stored_candidates.clone(),
+            ..Default::default()
+        }));
+        let (mut iter_ctx, att_registry, validation_handler) =
+            build_iter_ctx(db);
+
+        let mut provisioners = Provisioners::empty();
+        let mut rng = StdRng::seed_from_u64(1);
+        let mut keys = Vec::new();
+        for _ in 0..3 {
+            let sk = BlsSecretKey::random(&mut rng);
+            let pk = node_data::bls::PublicKey::new(BlsPublicKey::from(&sk));
+            provisioners.add_provisioner_with_value(pk.clone(), 1000 * DUSK);
+            keys.push((pk, sk));
+        }
+
+        let mut tip = node_data::ledger::Header::default();
+        tip.height = 0;
+        tip.seed = node_data::ledger::Seed::from([7u8; 48]);
+        tip.hash = [3u8; 32];
+        let (pk1, sk1) = &keys[0];
+        let round_update = RoundUpdate::new(
+            pk1.clone(),
+            sk1.clone(),
+            &tip,
+            HashMap::new(),
+            vec![],
+        );
+
+        let inbound = AsyncQueue::bounded(16, "test-inbound");
+        let outbound = AsyncQueue::bounded(16, "test-outbound");
+        let future_msgs = Arc::new(Mutex::new(MsgRegistry::default()));
+        let client = Arc::new(DummyOps::default());
+
+        iter_ctx.generate_iteration_committees(
+            0,
+            &provisioners,
+            round_update.seed(),
+        );
+
+        let generator =
+            iter_ctx.get_generator(0).expect("generator for iter 0");
+        let (gen_pk, gen_sk) = keys
+            .iter()
+            .find(|(pk, _)| pk.bytes() == &generator)
+            .map(|(pk, sk)| (pk.clone(), sk.clone()))
+            .expect("generator key");
+        let generator_ru =
+            RoundUpdate::new(gen_pk, gen_sk, &tip, HashMap::new(), vec![]);
+
+        let mut ctx = ExecutionCtx::new(
+            &mut iter_ctx,
+            inbound,
+            outbound,
+            future_msgs,
+            &provisioners,
+            round_update,
+            0,
+            StepName::Validation,
+            client,
+            att_registry,
+        );
+
+        let msg = build_candidate_message(&generator_ru);
+        let _ = ctx.process_inbound_msg(validation_handler, msg).await;
+
+        let stored = *stored_candidates.lock().await;
+        assert_eq!(
+            stored, 0,
+            "past messages should not be processed outside emergency"
+        );
+    }
+
+    #[tokio::test]
+    // Future-step messages should be queued first, then drained when current.
+    async fn future_message_is_queued_then_drained() {
+        let db = Arc::new(Mutex::new(DummyDb::default()));
+        let (mut iter_ctx, att_registry, validation_handler) =
+            build_iter_ctx(db);
+
+        let mut provisioners = Provisioners::empty();
+        let mut rng = StdRng::seed_from_u64(5);
+        let mut keys = Vec::new();
+        for _ in 0..3 {
+            let sk = BlsSecretKey::random(&mut rng);
+            let pk = node_data::bls::PublicKey::new(BlsPublicKey::from(&sk));
+            provisioners.add_provisioner_with_value(pk.clone(), 1000 * DUSK);
+            keys.push((pk, sk));
+        }
+
+        let mut tip = node_data::ledger::Header::default();
+        tip.height = 0;
+        tip.seed = node_data::ledger::Seed::from([7u8; 48]);
+        tip.hash = [3u8; 32];
+        let (pk1, sk1) = &keys[0];
+        let round_update = RoundUpdate::new(
+            pk1.clone(),
+            sk1.clone(),
+            &tip,
+            HashMap::new(),
+            vec![],
+        );
+
+        iter_ctx.generate_iteration_committees(
+            0,
+            &provisioners,
+            round_update.seed(),
+        );
+        iter_ctx.generate_iteration_committees(
+            1,
+            &provisioners,
+            round_update.seed(),
+        );
+
+        let committee = iter_ctx
+            .committees
+            .get_committee(StepName::Validation.to_step(1))
+            .expect("committee for iter 1");
+        let member = committee.iter().next().expect("member");
+        let (member_pk, member_sk) = keys
+            .iter()
+            .find(|(pk, _)| pk.bytes() == member.bytes())
+            .map(|(pk, sk)| (pk.clone(), sk.clone()))
+            .expect("member key");
+        let signer_ru = RoundUpdate::new(
+            member_pk,
+            member_sk,
+            &tip,
+            HashMap::new(),
+            vec![],
+        );
+
+        let inbound = AsyncQueue::bounded(16, "test-inbound");
+        let outbound = AsyncQueue::bounded(16, "test-outbound");
+        let future_msgs = Arc::new(Mutex::new(MsgRegistry::default()));
+        let client = Arc::new(DummyOps::default());
+
+        let mut ctx = ExecutionCtx::new(
+            &mut iter_ctx,
+            inbound.clone(),
+            outbound.clone(),
+            future_msgs.clone(),
+            &provisioners,
+            round_update.clone(),
+            0,
+            StepName::Validation,
+            client.clone(),
+            att_registry.clone(),
+        );
+
+        let future_validation =
+            crate::validation::step::build_validation_payload(
+                Vote::NoCandidate,
+                &signer_ru,
+                1,
+            );
+        let msg: Message = future_validation.into();
+        let _ = ctx
+            .process_inbound_msg(validation_handler.clone(), msg)
+            .await;
+
+        let queued = {
+            let mut registry = future_msgs.lock().await;
+            let step = StepName::Validation.to_step(1);
+            let drained =
+                registry.drain_msg_by_round_step(round_update.round, step);
+            let len = drained.as_ref().map(|items| items.len()).unwrap_or(0);
+            if let Some(items) = drained {
+                for msg in items {
+                    registry.put_msg(msg).expect("reinsert future msg");
+                }
+            }
+            len
+        };
+        assert_eq!(queued, 1, "future message should be queued");
+
+        validation_handler.lock().await.reset(1);
+        let ctx_future = ExecutionCtx::new(
+            &mut iter_ctx,
+            inbound,
+            outbound.clone(),
+            future_msgs.clone(),
+            &provisioners,
+            round_update,
+            1,
+            StepName::Validation,
+            client,
+            att_registry,
+        );
+
+        let _ = ctx_future.handle_future_msgs(validation_handler).await;
+
+        let drained = future_msgs
+            .lock()
+            .await
+            .drain_msg_by_round_step(
+                tip.height + 1,
+                StepName::Validation.to_step(1),
+            )
+            .map(|items| items.is_empty())
+            .unwrap_or(true);
+        assert!(drained, "future message should be drained");
+
+        let forwarded = outbound.recv().await.expect("forwarded message");
+        assert!(matches!(forwarded.payload, Payload::Validation(_)));
+    }
+
+    #[tokio::test]
+    // Open-consensus mode should rebroadcast only Success quorum outcomes.
+    async fn open_consensus_mode_broadcasts_only_success_quorums() {
+        let db = Arc::new(Mutex::new(DummyDb::default()));
+        let att_registry = Arc::new(Mutex::new(AttInfoRegistry::new()));
+        let validation = Arc::new(Mutex::new(ValidationHandler::new(
+            att_registry.clone(),
+            db.clone(),
+        )));
+        let ratification = Arc::new(Mutex::new(RatificationHandler::new(
+            att_registry.clone(),
+        )));
+        let proposal = Arc::new(Mutex::new(ProposalHandler::new(db)));
+
+        let mut timeouts: TimeoutSet = HashMap::new();
+        timeouts.insert(StepName::Proposal, Duration::from_millis(20));
+        timeouts.insert(StepName::Validation, Duration::from_millis(20));
+        timeouts.insert(StepName::Ratification, Duration::from_millis(20));
+
+        let mut iter_ctx = IterationCtx::new(
+            1,
+            0,
+            validation,
+            ratification,
+            proposal,
+            timeouts,
+        );
+
+        let mut provisioners = Provisioners::empty();
+        let mut rng = StdRng::seed_from_u64(11);
+        let mut keys = Vec::new();
+        for _ in 0..3 {
+            let sk = BlsSecretKey::random(&mut rng);
+            let pk = node_data::bls::PublicKey::new(BlsPublicKey::from(&sk));
+            provisioners.add_provisioner_with_value(pk.clone(), 1000 * DUSK);
+            keys.push((pk, sk));
+        }
+
+        let mut tip = Header::default();
+        tip.height = 0;
+        tip.seed = node_data::ledger::Seed::from([7u8; 48]);
+        tip.hash = [3u8; 32];
+        let (pk1, sk1) = &keys[0];
+        let round_update = RoundUpdate::new(
+            pk1.clone(),
+            sk1.clone(),
+            &tip,
+            HashMap::new(),
+            vec![],
+        );
+
+        let iter = CONSENSUS_MAX_ITER - 1;
+        iter_ctx.generate_iteration_committees(
+            iter,
+            &provisioners,
+            round_update.seed(),
+        );
+
+        let inbound = AsyncQueue::bounded(16, "test-inbound");
+        let outbound = AsyncQueue::bounded(16, "test-outbound");
+        let future_msgs = Arc::new(Mutex::new(MsgRegistry::default()));
+        let client = Arc::new(DummyOps::default());
+
+        let mut ctx = ExecutionCtx::new(
+            &mut iter_ctx,
+            inbound.clone(),
+            outbound.clone(),
+            future_msgs,
+            &provisioners,
+            round_update.clone(),
+            iter,
+            StepName::Ratification,
+            client,
+            att_registry,
+        );
+
+        let step_handler = Arc::new(Mutex::new(NoopHandler));
+        let mut event_loop = Box::pin(ctx.event_loop(step_handler, None));
+
+        let driver = async {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+
+            let fail_quorum = build_quorum_message(
+                &round_update,
+                iter,
+                RatificationResult::Fail(Vote::NoCandidate),
+            );
+            inbound.try_send(fail_quorum);
+
+            let fail_forwarded = tokio::time::timeout(
+                Duration::from_millis(60),
+                outbound.recv(),
+            )
+            .await;
+            assert!(
+                fail_forwarded.is_err(),
+                "fail quorum should not be rebroadcast in open consensus"
+            );
+
+            let success_quorum = build_quorum_message(
+                &round_update,
+                iter,
+                RatificationResult::Success(Vote::Valid([9u8; 32])),
+            );
+            inbound.try_send(success_quorum);
+
+            let forwarded = tokio::time::timeout(
+                Duration::from_millis(200),
+                outbound.recv(),
+            )
+            .await
+            .expect("expected success quorum")
+            .expect("outbound message");
+
+            match forwarded.payload {
+                Payload::Quorum(q) => match q.att.result {
+                    RatificationResult::Success(_) => {}
+                    other => panic!("unexpected quorum result: {other:?}"),
+                },
+                _ => panic!("expected quorum payload"),
+            }
+        };
+
+        tokio::select! {
+            _ = &mut event_loop => {
+                panic!("open consensus loop should not exit early");
+            }
+            _ = driver => {}
+        }
+    }
+
+    #[tokio::test]
+    // Validation quorum with invalid aggregated votes must be rejected.
+    async fn invalid_validation_quorum_is_rejected() {
+        let db = Arc::new(Mutex::new(DummyDb::default()));
+        let (mut iter_ctx, att_registry, validation_handler) =
+            build_iter_ctx(db.clone());
+
+        let mut provisioners = Provisioners::empty();
+        let mut rng = StdRng::seed_from_u64(12);
+        let mut keys = Vec::new();
+        for _ in 0..3 {
+            let sk = BlsSecretKey::random(&mut rng);
+            let pk = node_data::bls::PublicKey::new(BlsPublicKey::from(&sk));
+            provisioners.add_provisioner_with_value(pk.clone(), 1000 * DUSK);
+            keys.push((pk, sk));
+        }
+
+        let mut tip = Header::default();
+        tip.height = 0;
+        tip.seed = node_data::ledger::Seed::from([7u8; 48]);
+        tip.hash = [3u8; 32];
+        let (pk1, sk1) = &keys[0];
+        let round_update = RoundUpdate::new(
+            pk1.clone(),
+            sk1.clone(),
+            &tip,
+            HashMap::new(),
+            vec![],
+        );
+
+        let msg_iter = crate::config::EMERGENCY_MODE_ITERATION_THRESHOLD;
+        let current_iter = msg_iter + 1;
+        iter_ctx.generate_iteration_committees(
+            msg_iter,
+            &provisioners,
+            round_update.seed(),
+        );
+        iter_ctx.generate_iteration_committees(
+            current_iter,
+            &provisioners,
+            round_update.seed(),
+        );
+
+        let inbound = AsyncQueue::bounded(16, "test-inbound");
+        let outbound = AsyncQueue::bounded(16, "test-outbound");
+        let future_msgs = Arc::new(Mutex::new(MsgRegistry::default()));
+        let client = Arc::new(DummyOps::default());
+
+        let mut ctx = ExecutionCtx::new(
+            &mut iter_ctx,
+            inbound,
+            outbound.clone(),
+            future_msgs,
+            &provisioners,
+            round_update,
+            current_iter,
+            StepName::Validation,
+            client,
+            att_registry,
+        );
+
+        let header = ConsensusHeader {
+            prev_block_hash: tip.hash,
+            round: tip.height + 1,
+            iteration: msg_iter,
+        };
+        let bad_votes = StepVotes::new([0u8; 48], 1);
+        let validation = ValidationResult::new(
+            bad_votes,
+            Vote::Valid([1u8; 32]),
+            QuorumType::Valid,
+        );
+        let vq = ValidationQuorum {
+            header,
+            result: validation,
+        };
+        let msg: Message = vq.into();
+
+        let _ = ctx.process_inbound_msg(validation_handler, msg).await;
+
+        let stored = db.lock().await.validation_results.lock().await.len();
+        assert_eq!(stored, 0, "invalid validation quorum should be rejected");
+
+        let forwarded =
+            tokio::time::timeout(Duration::from_millis(100), outbound.recv())
+                .await;
+        assert!(
+            forwarded.is_err(),
+            "invalid validation quorum should not be rebroadcast"
+        );
+    }
+}
+
 #[inline(always)]
 fn log_msg(event: &str, src: &str, msg: &Message) {
     debug!(

--- a/consensus/src/iteration_ctx.rs
+++ b/consensus/src/iteration_ctx.rs
@@ -120,7 +120,7 @@ impl<DB: Database> IterationCtx<DB> {
         self.join_set.abort_all();
     }
 
-    /// Handles an event of a Step timeout
+    /// Handles an event of a Phase timeout
     pub(crate) fn on_timeout_event(&mut self, step_name: StepName) {
         let curr_step_timeout =
             self.timeouts.get_mut(&step_name).expect("valid timeout");
@@ -316,5 +316,103 @@ impl<DB: Database> IterationCtx<DB> {
 impl<DB: Database> Drop for IterationCtx<DB> {
     fn drop(&mut self) {
         self.on_close();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    use crate::config::{MIN_STEP_TIMEOUT, TIMEOUT_INCREASE};
+    use crate::step_votes_reg::AttInfoRegistry;
+
+    #[derive(Default)]
+    struct DummyDb;
+
+    // Minimal in-memory DB stub used to isolate timeout logic tests.
+    #[async_trait]
+    impl Database for DummyDb {
+        async fn store_candidate_block(
+            &mut self,
+            _b: node_data::ledger::Block,
+        ) {
+        }
+        async fn store_validation_result(
+            &mut self,
+            _ch: &node_data::message::ConsensusHeader,
+            _vr: &node_data::message::payload::ValidationResult,
+        ) {
+        }
+        async fn get_last_iter(&self) -> (node_data::ledger::Hash, u8) {
+            ([0u8; 32], 0)
+        }
+        async fn store_last_iter(
+            &mut self,
+            _data: (node_data::ledger::Hash, u8),
+        ) {
+        }
+    }
+
+    // Build an IterationCtx with default handlers and baseline timeouts.
+    fn build_ctx() -> IterationCtx<DummyDb> {
+        let db = Arc::new(Mutex::new(DummyDb::default()));
+        let att_registry = Arc::new(Mutex::new(AttInfoRegistry::new()));
+        let validation =
+            Arc::new(Mutex::new(validation::handler::ValidationHandler::new(
+                att_registry.clone(),
+                db.clone(),
+            )));
+        let ratification = Arc::new(Mutex::new(
+            ratification::handler::RatificationHandler::new(att_registry),
+        ));
+        let proposal =
+            Arc::new(Mutex::new(proposal::handler::ProposalHandler::new(db)));
+
+        let mut timeouts: TimeoutSet = HashMap::new();
+        timeouts.insert(StepName::Proposal, MIN_STEP_TIMEOUT);
+        timeouts
+            .insert(StepName::Validation, MIN_STEP_TIMEOUT + TIMEOUT_INCREASE);
+        timeouts.insert(
+            StepName::Ratification,
+            MIN_STEP_TIMEOUT + TIMEOUT_INCREASE + TIMEOUT_INCREASE,
+        );
+
+        IterationCtx::new(1, 0, validation, ratification, proposal, timeouts)
+    }
+
+    #[test]
+    // Step timeouts should only grow on repeated timeouts and stop at max cap.
+    fn timeout_increases_and_caps_at_max() {
+        let mut ctx = build_ctx();
+        let mut current = ctx.get_timeout(StepName::Proposal);
+
+        for _ in 0..20 {
+            ctx.on_timeout_event(StepName::Proposal);
+            let next = ctx.get_timeout(StepName::Proposal);
+            assert!(next >= current, "timeout should be non-decreasing");
+            current = next;
+        }
+
+        assert_eq!(ctx.get_timeout(StepName::Proposal), MAX_STEP_TIMEOUT);
+    }
+
+    #[test]
+    // Missing timeout configuration is a bug and should panic on timeout events.
+    fn timeout_event_panics_for_unconfigured_step() {
+        let mut ctx = build_ctx();
+        ctx.timeouts.remove(&StepName::Proposal);
+
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                ctx.on_timeout_event(StepName::Proposal);
+            }));
+        assert!(
+            result.is_err(),
+            "unconfigured step timeout must panic to surface invalid setup"
+        );
     }
 }

--- a/consensus/src/msg_handler.rs
+++ b/consensus/src/msg_handler.rs
@@ -187,3 +187,485 @@ pub trait MsgHandler {
         curr_iteration: u8,
     ) -> Option<Message>;
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use dusk_core::signatures::bls::{
+        PublicKey as BlsPublicKey, SecretKey as BlsSecretKey,
+    };
+    use node_data::StepName;
+    use node_data::ledger::{Block, Header, Seed, StepVotes};
+    use node_data::message::payload::{
+        Candidate, QuorumType, ValidationResult, Vote,
+    };
+    use node_data::message::{Message, SignedStepMessage};
+    use rand::SeedableRng;
+    use tokio::sync::Mutex;
+
+    use crate::commons::{Database, RoundUpdate};
+    use crate::errors::ConsensusError;
+    use crate::iteration_ctx::RoundCommittees;
+    use crate::merkle::merkle_root;
+    use crate::msg_handler::MsgHandler;
+    use crate::proposal::handler::ProposalHandler;
+    use crate::ratification::handler::RatificationHandler;
+    use crate::step_votes_reg::AttInfoRegistry;
+    use crate::user::committee::Committee;
+    use crate::user::provisioners::{DUSK, Provisioners};
+    use crate::user::sortition::Config;
+    use crate::validation::handler::ValidationHandler;
+
+    #[derive(Clone, Copy)]
+    enum ExpectedOutcome {
+        Ok,
+        InvalidPrevHash,
+        InvalidSignature,
+        NotCommitteeMember,
+        FutureEvent,
+    }
+
+    struct MutationCase {
+        name: &'static str,
+        msg: Message,
+        expected: ExpectedOutcome,
+    }
+
+    // Assert that message validation produced the expected error class.
+    fn assert_expected(
+        result: Result<(), ConsensusError>,
+        expected: ExpectedOutcome,
+        name: &str,
+    ) {
+        match expected {
+            ExpectedOutcome::Ok => {
+                assert!(result.is_ok(), "{name}: expected Ok, got {result:?}");
+            }
+            ExpectedOutcome::InvalidPrevHash => {
+                assert!(
+                    matches!(
+                        result,
+                        Err(ConsensusError::InvalidPrevBlockHash(_))
+                    ),
+                    "{name}: expected InvalidPrevBlockHash, got {result:?}"
+                );
+            }
+            ExpectedOutcome::InvalidSignature => {
+                assert!(
+                    matches!(result, Err(ConsensusError::InvalidSignature(_))),
+                    "{name}: expected InvalidSignature, got {result:?}"
+                );
+            }
+            ExpectedOutcome::NotCommitteeMember => {
+                assert!(
+                    matches!(result, Err(ConsensusError::NotCommitteeMember)),
+                    "{name}: expected NotCommitteeMember, got {result:?}"
+                );
+            }
+            ExpectedOutcome::FutureEvent => {
+                assert!(
+                    matches!(result, Err(ConsensusError::FutureEvent)),
+                    "{name}: expected FutureEvent, got {result:?}"
+                );
+            }
+        }
+    }
+
+    // Run a compact table-driven mutation test suite for one validator.
+    fn run_mutation_matrix<F>(cases: Vec<MutationCase>, validate: F)
+    where
+        F: Fn(&Message) -> Result<(), ConsensusError>,
+    {
+        for case in cases {
+            let result = validate(&case.msg);
+            assert_expected(result, case.expected, case.name);
+        }
+    }
+
+    #[derive(Default)]
+    struct DummyDb;
+
+    // Minimal DB stub needed by handlers under test.
+    #[async_trait::async_trait]
+    impl Database for DummyDb {
+        async fn store_candidate_block(&mut self, _b: Block) {}
+        async fn store_validation_result(
+            &mut self,
+            _ch: &node_data::message::ConsensusHeader,
+            _vr: &ValidationResult,
+        ) {
+        }
+        async fn get_last_iter(&self) -> (node_data::ledger::Hash, u8) {
+            ([0u8; 32], 0)
+        }
+        async fn store_last_iter(
+            &mut self,
+            _data: (node_data::ledger::Hash, u8),
+        ) {
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestKey {
+        sk: BlsSecretKey,
+        pk: node_data::bls::PublicKey,
+    }
+
+    // Build a deterministic test keypair from a fixed seed.
+    fn key(seed: u64) -> TestKey {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let sk = BlsSecretKey::random(&mut rng);
+        let pk = node_data::bls::PublicKey::new(BlsPublicKey::from(&sk));
+        TestKey { sk, pk }
+    }
+
+    // Build a deterministic tip header shared by mutation scenarios.
+    fn tip_header() -> Header {
+        let mut header = Header::default();
+        header.height = 0;
+        header.timestamp = 1;
+        header.seed = Seed::from([7u8; 48]);
+        header.hash = [1u8; 32];
+        header.state_hash = [2u8; 32];
+        header
+    }
+
+    // Build proposal/validation/ratification committees for one iteration.
+    fn build_round_committees(
+        provisioners: &Provisioners,
+        seed: Seed,
+        round: u64,
+        iter: u8,
+    ) -> RoundCommittees {
+        let mut rc = RoundCommittees::default();
+        for step in [
+            StepName::Proposal,
+            StepName::Validation,
+            StepName::Ratification,
+        ] {
+            let cfg = Config::new(seed, round, iter, step, vec![]);
+            let committee = Committee::new(provisioners, &cfg);
+            rc.insert(step.to_step(iter), committee);
+        }
+        rc
+    }
+
+    // Build a signed candidate message with caller-controlled mutations.
+    fn build_candidate(
+        ru: &RoundUpdate,
+        generator: &TestKey,
+        prev_hash: [u8; 32],
+        iter: u8,
+    ) -> Message {
+        let mut header = Header::default();
+        header.height = ru.round;
+        header.iteration = iter;
+        header.prev_block_hash = prev_hash;
+        header.generator_bls_pubkey = *generator.pk.bytes();
+        header.txroot = merkle_root::<[u8; 32]>(&[]);
+        header.faultroot = merkle_root::<[u8; 32]>(&[]);
+
+        let block = Block::new(header, vec![], vec![]).expect("valid block");
+        let mut candidate = Candidate { candidate: block };
+        candidate.sign(&generator.sk, generator.pk.inner());
+        candidate.into()
+    }
+
+    // Flip one signature byte to produce an invalid signature variant.
+    fn corrupt_signature(mut msg: Message) -> Message {
+        match &mut msg.payload {
+            node_data::message::Payload::Candidate(c) => {
+                let mut sig = *c.candidate.header().signature.inner();
+                sig[0] ^= 0x01;
+                c.candidate.set_signature(sig.into());
+            }
+            node_data::message::Payload::Validation(v) => {
+                let mut sig = *v.sign_info.signature.inner();
+                sig[0] ^= 0x01;
+                v.sign_info.signature = sig.into();
+            }
+            node_data::message::Payload::Ratification(r) => {
+                let mut sig = *r.sign_info.signature.inner();
+                sig[0] ^= 0x01;
+                r.sign_info.signature = sig.into();
+            }
+            _ => {}
+        }
+        msg
+    }
+
+    #[test]
+    // Proposal handler should reject malformed/mutated candidates.
+    fn proposal_mutations_rejected() {
+        let key_a = key(1);
+        let key_b = key(2);
+
+        let mut provisioners = Provisioners::empty();
+        provisioners.add_provisioner_with_value(key_a.pk.clone(), 1000 * DUSK);
+
+        let tip = tip_header();
+        let ru = RoundUpdate::new(
+            key_a.pk.clone(),
+            key_a.sk.clone(),
+            &tip,
+            HashMap::new(),
+            vec![],
+        );
+
+        let rc = build_round_committees(&provisioners, tip.seed, ru.round, 0);
+        let proposal_step = StepName::Proposal.to_step(0);
+        let proposal_committee =
+            rc.get_committee(proposal_step).expect("committee");
+
+        let db = Arc::new(Mutex::new(DummyDb::default()));
+        let handler = ProposalHandler::new(db);
+
+        let generator = proposal_committee.iter().next().expect("generator");
+        let generator_key = if generator.bytes() == key_a.pk.bytes() {
+            &key_a
+        } else {
+            &key_b
+        };
+        let valid = build_candidate(&ru, generator_key, ru.hash(), 0);
+        let wrong_prev = build_candidate(&ru, generator_key, [9u8; 32], 0);
+        let wrong_signer = build_candidate(&ru, &key_b, ru.hash(), 0);
+        let future_iter = build_candidate(&ru, generator_key, ru.hash(), 1);
+        let bad_sig = corrupt_signature(valid.clone());
+
+        run_mutation_matrix(
+            vec![
+                MutationCase {
+                    name: "valid",
+                    msg: valid,
+                    expected: ExpectedOutcome::Ok,
+                },
+                MutationCase {
+                    name: "wrong prev hash",
+                    msg: wrong_prev,
+                    expected: ExpectedOutcome::InvalidPrevHash,
+                },
+                MutationCase {
+                    name: "invalid signature",
+                    msg: bad_sig,
+                    expected: ExpectedOutcome::InvalidSignature,
+                },
+                MutationCase {
+                    name: "wrong signer",
+                    msg: wrong_signer,
+                    expected: ExpectedOutcome::NotCommitteeMember,
+                },
+                MutationCase {
+                    name: "future iteration",
+                    msg: future_iter,
+                    expected: ExpectedOutcome::FutureEvent,
+                },
+            ],
+            |msg| {
+                handler.is_valid(
+                    msg,
+                    &ru,
+                    0,
+                    StepName::Proposal,
+                    proposal_committee,
+                    &rc,
+                )
+            },
+        );
+    }
+
+    #[test]
+    // Validation handler should reject malformed votes and future events.
+    fn validation_mutations_rejected_or_queued() {
+        let key_a = key(3);
+        let key_b = key(4);
+
+        let mut provisioners = Provisioners::empty();
+        provisioners.add_provisioner_with_value(key_a.pk.clone(), 1000 * DUSK);
+
+        let tip = tip_header();
+        let ru = RoundUpdate::new(
+            key_a.pk.clone(),
+            key_a.sk.clone(),
+            &tip,
+            HashMap::new(),
+            vec![],
+        );
+        let ru_bad = RoundUpdate::new(
+            key_b.pk.clone(),
+            key_b.sk.clone(),
+            &tip,
+            HashMap::new(),
+            vec![],
+        );
+
+        let rc = build_round_committees(&provisioners, tip.seed, ru.round, 0);
+        let validation_step = StepName::Validation.to_step(0);
+        let validation_committee =
+            rc.get_committee(validation_step).expect("committee");
+
+        let att_registry = Arc::new(Mutex::new(AttInfoRegistry::new()));
+        let db = Arc::new(Mutex::new(DummyDb::default()));
+        let handler = ValidationHandler::new(att_registry, db);
+
+        let valid = crate::build_validation_payload(Vote::NoCandidate, &ru, 0);
+        let valid_msg: Message = valid.into();
+
+        let mut wrong_prev = valid_msg.clone();
+        wrong_prev.header.prev_block_hash = [9u8; 32];
+        if let node_data::message::Payload::Validation(v) =
+            &mut wrong_prev.payload
+        {
+            v.header.prev_block_hash = [9u8; 32];
+        }
+
+        let wrong_signer =
+            crate::build_validation_payload(Vote::NoCandidate, &ru_bad, 0);
+        let wrong_msg: Message = wrong_signer.into();
+
+        let future = crate::build_validation_payload(Vote::NoCandidate, &ru, 1);
+        let future_msg: Message = future.into();
+        let bad_sig = corrupt_signature(valid_msg.clone());
+
+        run_mutation_matrix(
+            vec![
+                MutationCase {
+                    name: "valid",
+                    msg: valid_msg,
+                    expected: ExpectedOutcome::Ok,
+                },
+                MutationCase {
+                    name: "wrong prev hash",
+                    msg: wrong_prev,
+                    expected: ExpectedOutcome::InvalidPrevHash,
+                },
+                MutationCase {
+                    name: "invalid signature",
+                    msg: bad_sig,
+                    expected: ExpectedOutcome::InvalidSignature,
+                },
+                MutationCase {
+                    name: "wrong signer",
+                    msg: wrong_msg,
+                    expected: ExpectedOutcome::NotCommitteeMember,
+                },
+                MutationCase {
+                    name: "future iteration",
+                    msg: future_msg,
+                    expected: ExpectedOutcome::FutureEvent,
+                },
+            ],
+            |msg| {
+                handler.is_valid(
+                    msg,
+                    &ru,
+                    0,
+                    StepName::Validation,
+                    validation_committee,
+                    &rc,
+                )
+            },
+        );
+    }
+
+    #[test]
+    // Ratification handler should reject malformed votes and future events.
+    fn ratification_mutations_rejected_or_queued() {
+        let key_a = key(5);
+        let key_b = key(6);
+
+        let mut provisioners = Provisioners::empty();
+        provisioners.add_provisioner_with_value(key_a.pk.clone(), 1000 * DUSK);
+
+        let tip = tip_header();
+        let ru = RoundUpdate::new(
+            key_a.pk.clone(),
+            key_a.sk.clone(),
+            &tip,
+            HashMap::new(),
+            vec![],
+        );
+        let ru_bad = RoundUpdate::new(
+            key_b.pk.clone(),
+            key_b.sk.clone(),
+            &tip,
+            HashMap::new(),
+            vec![],
+        );
+
+        let rc = build_round_committees(&provisioners, tip.seed, ru.round, 0);
+        let ratification_step = StepName::Ratification.to_step(0);
+        let ratification_committee =
+            rc.get_committee(ratification_step).expect("committee");
+
+        let att_registry = Arc::new(Mutex::new(AttInfoRegistry::new()));
+        let handler = RatificationHandler::new(att_registry);
+
+        let validation_result = ValidationResult::new(
+            StepVotes::default(),
+            Vote::NoQuorum,
+            QuorumType::NoQuorum,
+        );
+        let ratification =
+            crate::build_ratification_payload(&ru, 0, &validation_result);
+        let ratification_msg: Message = ratification.into();
+
+        let mut wrong_prev = ratification_msg.clone();
+        wrong_prev.header.prev_block_hash = [9u8; 32];
+        if let node_data::message::Payload::Ratification(r) =
+            &mut wrong_prev.payload
+        {
+            r.header.prev_block_hash = [9u8; 32];
+        }
+
+        let wrong_signer =
+            crate::build_ratification_payload(&ru_bad, 0, &validation_result);
+        let wrong_msg: Message = wrong_signer.into();
+
+        let future =
+            crate::build_ratification_payload(&ru, 1, &validation_result);
+        let future_msg: Message = future.into();
+        let bad_sig = corrupt_signature(ratification_msg.clone());
+
+        run_mutation_matrix(
+            vec![
+                MutationCase {
+                    name: "valid",
+                    msg: ratification_msg,
+                    expected: ExpectedOutcome::Ok,
+                },
+                MutationCase {
+                    name: "wrong prev hash",
+                    msg: wrong_prev,
+                    expected: ExpectedOutcome::InvalidPrevHash,
+                },
+                MutationCase {
+                    name: "invalid signature",
+                    msg: bad_sig,
+                    expected: ExpectedOutcome::InvalidSignature,
+                },
+                MutationCase {
+                    name: "wrong signer",
+                    msg: wrong_msg,
+                    expected: ExpectedOutcome::NotCommitteeMember,
+                },
+                MutationCase {
+                    name: "future iteration",
+                    msg: future_msg,
+                    expected: ExpectedOutcome::FutureEvent,
+                },
+            ],
+            |msg| {
+                handler.is_valid(
+                    msg,
+                    &ru,
+                    0,
+                    StepName::Ratification,
+                    ratification_committee,
+                    &rc,
+                )
+            },
+        );
+    }
+}

--- a/consensus/src/proposal/handler.rs
+++ b/consensus/src/proposal/handler.rs
@@ -224,3 +224,436 @@ pub fn verify_stateless(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::sync::Arc;
+
+    use super::{ProposalHandler, verify_candidate_msg};
+    use dusk_core::signatures::bls::{
+        PublicKey as BlsPublicKey, SecretKey as BlsSecretKey,
+    };
+    use dusk_core::transfer::Transaction as ProtocolTransaction;
+    use node_data::Serializable;
+    use node_data::ledger::Hash;
+    use node_data::ledger::{
+        Block, Fault, Header, Transaction as LedgerTransaction,
+    };
+    use node_data::message::payload::Candidate;
+    use node_data::message::{
+        ConsensusHeader, Message, SignInfo, SignedStepMessage,
+    };
+    use rand::RngCore;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+    use tokio::sync::Mutex;
+
+    use crate::commons::Database;
+    use crate::config::{
+        MAX_BLOCK_SIZE, MAX_NUMBER_OF_FAULTS, MAX_NUMBER_OF_TRANSACTIONS,
+    };
+    use crate::merkle::merkle_root;
+    use crate::msg_handler::{MsgHandler, StepOutcome};
+    use crate::user::committee::Committee;
+
+    // Keep one unique deterministic seed per test so RNG streams are
+    // reproducible and isolated across test cases.
+    const SEED_ACCEPT_EXPECTED_GENERATOR: u64 = 1;
+    const SEED_ACCEPT_NON_EMPTY_PAYLOAD: u64 = 2;
+    const SEED_ACCEPT_PAST_CANDIDATE_COLLECTION: u64 = 3;
+    const SEED_REJECT_WRONG_GENERATOR: u64 = 4;
+    const SEED_REJECT_INVALID_SIGNATURE: u64 = 5;
+    const SEED_REJECT_TXROOT_MISMATCH: u64 = 6;
+    const SEED_REJECT_FAULTROOT_MISMATCH: u64 = 7;
+    const SEED_REJECT_TOO_MANY_TRANSACTIONS: u64 = 8;
+    const SEED_REJECT_TOO_MANY_FAULTS: u64 = 9;
+    const SEED_REJECT_OVERSIZED_BLOCK: u64 = 10;
+    const SEED_REJECT_PAYLOAD_MUTATION_AFTER_SIGNATURE: u64 = 11;
+
+    #[derive(Default)]
+    struct DummyDb {
+        stored_candidates: usize,
+    }
+
+    // Minimal DB stub that records candidate-store side effects.
+    #[async_trait::async_trait]
+    impl Database for DummyDb {
+        async fn store_candidate_block(&mut self, _b: Block) {
+            self.stored_candidates += 1;
+        }
+
+        async fn store_validation_result(
+            &mut self,
+            _ch: &ConsensusHeader,
+            _vr: &node_data::message::payload::ValidationResult,
+        ) {
+        }
+
+        async fn get_last_iter(&self) -> (Hash, u8) {
+            ([0u8; 32], 0)
+        }
+
+        async fn store_last_iter(&mut self, _data: (Hash, u8)) {}
+    }
+
+    // Build and sign a candidate with explicit roots and payload.
+    fn build_signed_candidate(
+        sk: &BlsSecretKey,
+        pk: &node_data::bls::PublicKey,
+        txroot: [u8; 32],
+        faultroot: [u8; 32],
+        txs: Vec<LedgerTransaction>,
+        faults: Vec<Fault>,
+    ) -> Candidate {
+        let mut header = Header::default();
+        header.height = 1;
+        header.iteration = 0;
+        header.prev_block_hash = [7u8; 32];
+        header.generator_bls_pubkey = *pk.bytes();
+        header.txroot = txroot;
+        header.faultroot = faultroot;
+
+        let block = Block::new(header, txs, faults).expect("valid block");
+        let mut candidate = Candidate { candidate: block };
+        candidate.sign(sk, pk.inner());
+        candidate
+    }
+
+    // Build a minimally valid signed candidate block
+    fn build_candidate(
+        sk: &BlsSecretKey,
+        pk: &node_data::bls::PublicKey,
+        txroot: [u8; 32],
+        faultroot: [u8; 32],
+    ) -> Candidate {
+        build_signed_candidate(sk, pk, txroot, faultroot, vec![], vec![])
+    }
+
+    // Build a signed candidate with txroot/faultroot derived from its payload.
+    fn build_candidate_with_payload(
+        sk: &BlsSecretKey,
+        pk: &node_data::bls::PublicKey,
+        txs: Vec<LedgerTransaction>,
+        faults: Vec<Fault>,
+    ) -> Candidate {
+        let tx_digests: Vec<_> = txs.iter().map(|tx| tx.digest()).collect();
+        let fault_digests: Vec<_> =
+            faults.iter().map(|fault| fault.digest()).collect();
+
+        build_signed_candidate(
+            sk,
+            pk,
+            merkle_root(&tx_digests[..]),
+            merkle_root(&fault_digests[..]),
+            txs,
+            faults,
+        )
+    }
+
+    // Build a compact moonlight transaction suitable for count/size tests.
+    fn build_small_transaction(
+        sk: &BlsSecretKey,
+        nonce: u64,
+    ) -> LedgerTransaction {
+        let tx = ProtocolTransaction::moonlight(
+            sk,
+            None,
+            0,
+            0,
+            1,
+            1,
+            nonce,
+            0xFA,
+            Option::<Vec<u8>>::None,
+        )
+        .expect("valid transaction");
+        LedgerTransaction::from(tx)
+    }
+
+    // Build a minimal decodable fault for fault-count/root verification tests.
+    fn build_fault_template(signer: &node_data::bls::PublicKey) -> Fault {
+        let mut encoded = vec![0u8];
+        let sign_info = SignInfo {
+            signer: signer.clone(),
+            signature: [9u8; 48].into(),
+        };
+
+        for hash_byte in [1u8, 2u8] {
+            let header = ConsensusHeader {
+                prev_block_hash: [hash_byte; 32],
+                round: 1,
+                iteration: 0,
+            };
+            header
+                .write(&mut encoded)
+                .expect("consensus header should serialize");
+            sign_info
+                .write(&mut encoded)
+                .expect("sign info should serialize");
+            encoded.extend_from_slice(&[hash_byte; 32]);
+        }
+
+        let mut cursor = Cursor::new(encoded);
+        Fault::read(&mut cursor).expect("fault bytes should deserialize")
+    }
+
+    // Build a deterministic keypair from the test RNG stream.
+    fn generate_random_keypair(
+        rng: &mut StdRng,
+    ) -> (BlsSecretKey, node_data::bls::PublicKey) {
+        let sk = BlsSecretKey::random(rng);
+        let pk = node_data::bls::PublicKey::new(BlsPublicKey::from(&sk));
+        (sk, pk)
+    }
+
+    #[test]
+    // Candidate from the expected generator should pass stateless checks.
+    fn accept_candidate_from_expected_generator() {
+        let mut rng = StdRng::seed_from_u64(SEED_ACCEPT_EXPECTED_GENERATOR);
+        let (sk, pk) = generate_random_keypair(&mut rng);
+        let empty_root = merkle_root::<[u8; 32]>(&[]);
+
+        let candidate = build_candidate(&sk, &pk, empty_root, empty_root);
+        verify_candidate_msg(&candidate, pk.bytes())
+            .expect("candidate from expected generator should be valid");
+    }
+
+    #[test]
+    // Candidate with consistent non-empty tx/fault payload should be accepted.
+    fn accept_candidate_with_non_empty_payload() {
+        let mut rng = StdRng::seed_from_u64(SEED_ACCEPT_NON_EMPTY_PAYLOAD);
+        let (sk, pk) = generate_random_keypair(&mut rng);
+        let tx_nonce = rng.next_u64();
+        let tx = build_small_transaction(&sk, tx_nonce);
+        let fault = build_fault_template(&pk);
+        let candidate =
+            build_candidate_with_payload(&sk, &pk, vec![tx], vec![fault]);
+
+        let candidate_size = candidate
+            .candidate
+            .size()
+            .expect("candidate size should be known");
+        // Ensure the test won't fail due to the block size.
+        assert!(candidate_size <= MAX_BLOCK_SIZE);
+
+        verify_candidate_msg(&candidate, pk.bytes())
+            .expect("candidate with non-empty payload should be valid");
+    }
+
+    #[tokio::test]
+    // Past candidate messages should be collected and persisted.
+    async fn collect_from_past_stores_candidate_and_returns_ready() {
+        let mut rng =
+            StdRng::seed_from_u64(SEED_ACCEPT_PAST_CANDIDATE_COLLECTION);
+        let (sk, pk) = generate_random_keypair(&mut rng);
+        let empty_root = merkle_root::<[u8; 32]>(&[]);
+        let candidate = build_candidate(&sk, &pk, empty_root, empty_root);
+        let msg: Message = candidate.into();
+
+        let db = Arc::new(Mutex::new(DummyDb::default()));
+        let mut handler = ProposalHandler::new(db.clone());
+        let committee = Committee::default();
+
+        let outcome = handler
+            .collect_from_past(msg, &committee, None)
+            .await
+            .expect("past candidate should be accepted");
+        assert!(matches!(outcome, StepOutcome::Ready(_)));
+
+        let stored = db.lock().await.stored_candidates;
+        assert_eq!(stored, 1, "candidate should be stored once");
+    }
+
+    #[tokio::test]
+    // Past messages with non-candidate payload must be rejected.
+    async fn collect_from_past_rejects_invalid_payload() {
+        let db = Arc::new(Mutex::new(DummyDb::default()));
+        let mut handler = ProposalHandler::new(db);
+        let committee = Committee::default();
+
+        let err = match handler
+            .collect_from_past(Message::default(), &committee, None)
+            .await
+        {
+            Ok(_) => panic!("expected invalid payload rejection"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, crate::errors::ConsensusError::InvalidMsgType));
+    }
+
+    #[test]
+    // Candidate generator must match the one extracted by deterministic
+    // sortition.
+    fn reject_candidate_from_wrong_generator() {
+        let mut rng = StdRng::seed_from_u64(SEED_REJECT_WRONG_GENERATOR);
+        let (_expected_sk, expected_pk) = generate_random_keypair(&mut rng);
+        let (wrong_sk, wrong_pk) = generate_random_keypair(&mut rng);
+        let empty_root = merkle_root::<[u8; 32]>(&[]);
+
+        let candidate =
+            build_candidate(&wrong_sk, &wrong_pk, empty_root, empty_root);
+
+        let err = verify_candidate_msg(&candidate, expected_pk.bytes())
+            .expect_err("expected wrong generator to be rejected");
+
+        assert!(matches!(
+            err,
+            crate::errors::ConsensusError::NotCommitteeMember
+        ));
+    }
+
+    #[test]
+    // Candidate signature must always verify against signed header payload.
+    fn reject_candidate_with_invalid_signature() {
+        let mut rng = StdRng::seed_from_u64(SEED_REJECT_INVALID_SIGNATURE);
+        let (sk, pk) = generate_random_keypair(&mut rng);
+        let empty_root = merkle_root::<[u8; 32]>(&[]);
+        let mut candidate = build_candidate(&sk, &pk, empty_root, empty_root);
+
+        let mut sig = *candidate.candidate.header().signature.inner();
+        sig[0] ^= 0x01;
+        candidate.candidate.set_signature(sig.into());
+
+        let err = verify_candidate_msg(&candidate, pk.bytes())
+            .expect_err("expected invalid signature to be rejected");
+        assert!(matches!(
+            err,
+            crate::errors::ConsensusError::InvalidSignature(_)
+        ));
+    }
+
+    #[test]
+    // txroot in the header must match the transactions included in the block.
+    fn reject_candidate_with_mismatched_txroot() {
+        let mut rng = StdRng::seed_from_u64(SEED_REJECT_TXROOT_MISMATCH);
+        let (sk, pk) = generate_random_keypair(&mut rng);
+
+        let candidate =
+            build_candidate(&sk, &pk, [1u8; 32], merkle_root::<[u8; 32]>(&[]));
+        let err = verify_candidate_msg(&candidate, pk.bytes())
+            .expect_err("expected invalid txroot to be rejected");
+
+        assert!(matches!(err, crate::errors::ConsensusError::InvalidBlock));
+    }
+
+    #[test]
+    // faultroot in the header must match the faults included in the block.
+    fn reject_candidate_with_mismatched_faultroot() {
+        let mut rng = StdRng::seed_from_u64(SEED_REJECT_FAULTROOT_MISMATCH);
+        let (sk, pk) = generate_random_keypair(&mut rng);
+
+        let candidate =
+            build_candidate(&sk, &pk, merkle_root::<[u8; 32]>(&[]), [2u8; 32]);
+        let err = verify_candidate_msg(&candidate, pk.bytes())
+            .expect_err("expected invalid faultroot to be rejected");
+
+        assert!(matches!(err, crate::errors::ConsensusError::InvalidBlock));
+    }
+
+    #[test]
+    // Candidate with more transactions than the configured maximum is invalid.
+    fn reject_candidate_with_too_many_transactions() {
+        let mut rng = StdRng::seed_from_u64(SEED_REJECT_TOO_MANY_TRANSACTIONS);
+        let (sk, pk) = generate_random_keypair(&mut rng);
+        let tx_nonce = rng.next_u64();
+        let tx = build_small_transaction(&sk, tx_nonce);
+        let txs = vec![tx; MAX_NUMBER_OF_TRANSACTIONS + 1];
+
+        let candidate = build_candidate_with_payload(&sk, &pk, txs, vec![]);
+        let candidate_size = candidate
+            .candidate
+            .size()
+            .expect("candidate size should be known");
+        // Ensure the test won't fail due to the block size.
+        assert!(candidate_size <= MAX_BLOCK_SIZE);
+
+        let err = verify_candidate_msg(&candidate, pk.bytes())
+            .expect_err("expected too many transactions to be rejected");
+
+        assert!(matches!(
+            err,
+            crate::errors::ConsensusError::TooManyTransactions(count)
+                if count == MAX_NUMBER_OF_TRANSACTIONS + 1
+        ));
+    }
+
+    #[test]
+    // Candidate with more faults than the configured maximum is invalid.
+    fn reject_candidate_with_too_many_faults() {
+        let mut rng = StdRng::seed_from_u64(SEED_REJECT_TOO_MANY_FAULTS);
+        let (sk, pk) = generate_random_keypair(&mut rng);
+        let fault = build_fault_template(&pk);
+        let faults = vec![fault; MAX_NUMBER_OF_FAULTS + 1];
+
+        let candidate = build_candidate_with_payload(&sk, &pk, vec![], faults);
+        let candidate_size = candidate
+            .candidate
+            .size()
+            .expect("candidate size should be known");
+        // Ensure the test won't fail due to the block size.
+        assert!(candidate_size <= MAX_BLOCK_SIZE);
+
+        let err = verify_candidate_msg(&candidate, pk.bytes())
+            .expect_err("expected too many faults to be rejected");
+
+        assert!(matches!(
+            err,
+            crate::errors::ConsensusError::TooManyFaults(count)
+                if count == MAX_NUMBER_OF_FAULTS + 1
+        ));
+    }
+
+    #[test]
+    // Candidate serialized size must stay within the configured block limit.
+    fn reject_oversized_candidate_block() {
+        let mut rng = StdRng::seed_from_u64(SEED_REJECT_OVERSIZED_BLOCK);
+        let (sk, pk) = generate_random_keypair(&mut rng);
+        let tx_nonce = rng.next_u64();
+        let tx = build_small_transaction(&sk, tx_nonce);
+        let tx_count = MAX_BLOCK_SIZE / tx.size() + 1;
+        let txs = vec![tx; tx_count];
+
+        let candidate = build_candidate_with_payload(&sk, &pk, txs, vec![]);
+        let candidate_size = candidate
+            .candidate
+            .size()
+            .expect("candidate size should be known");
+        assert!(candidate_size > MAX_BLOCK_SIZE);
+
+        let err = verify_candidate_msg(&candidate, pk.bytes())
+            .expect_err("expected oversized block to be rejected");
+        assert!(matches!(
+            err,
+            crate::errors::ConsensusError::InvalidBlockSize(size)
+                if size > MAX_BLOCK_SIZE
+        ));
+    }
+
+    #[test]
+    // Candidate payload must not be mutable after signature and root commit.
+    fn reject_payload_mutation_after_signature() {
+        let mut rng =
+            StdRng::seed_from_u64(SEED_REJECT_PAYLOAD_MUTATION_AFTER_SIGNATURE);
+        let (sk, pk) = generate_random_keypair(&mut rng);
+        let tx_nonce = rng.next_u64();
+        let tx = build_small_transaction(&sk, tx_nonce);
+        let different_tx =
+            build_small_transaction(&sk, tx_nonce.wrapping_add(1));
+        let mut candidate =
+            build_candidate_with_payload(&sk, &pk, vec![tx], vec![]);
+
+        let mut tampered_txs = candidate.candidate.txs().clone();
+        tampered_txs.push(different_tx);
+        let tampered_header = candidate.candidate.header().clone();
+        let tampered_faults = candidate.candidate.faults().clone();
+        candidate.candidate =
+            Block::new(tampered_header, tampered_txs, tampered_faults)
+                .expect("tampered candidate block should still serialize");
+
+        let err = verify_candidate_msg(&candidate, pk.bytes()).expect_err(
+            "expected post-signature payload mutation to be rejected",
+        );
+        assert!(matches!(err, crate::errors::ConsensusError::InvalidBlock));
+    }
+}

--- a/consensus/tests/consensus_property.rs
+++ b/consensus/tests/consensus_property.rs
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::io::Cursor;
+
+use node_data::Serializable;
+use node_data::message::Message;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+#[test]
+#[ignore = "fuzz-like deserialization; run manually"]
+// Randomized deserialization should never panic, even on malformed input.
+fn fuzz_message_deserialization_does_not_panic() {
+    let mut rng = StdRng::seed_from_u64(4242);
+
+    for _ in 0..1000 {
+        let len = rng.gen_range(0..512);
+        let mut bytes = vec![0u8; len];
+        rng.fill(&mut bytes[..]);
+
+        let result = std::panic::catch_unwind(|| {
+            let mut cursor = Cursor::new(bytes);
+            let _ = Message::read(&mut cursor);
+        });
+
+        assert!(result.is_ok(), "deserialization panicked");
+    }
+}


### PR DESCRIPTION
Adds unit and invariant coverage for consensus internals (handlers, execution/iteration context, queue, and vote/attestation rules).\n\nThis PR focuses on unit-level behavior and edge-case validation paths.\n\nRelated broader effort: #4023.