### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,11 +182,11 @@ overflow-checks = true
 [patch.crates-io]
 # Pin AEGIS cryptography/runtime dependencies to private mirrors carrying the
 # merged remediation set.
-dusk-plonk = { git = "https://github.com/dusk-network/plonk-private.git", rev = "55083f925935b67b116c089e186ee1b261e0fdf0" }
-bls12_381-bls = { git = "https://github.com/dusk-network/bls12_381-bls-private.git", rev = "2bbf457d31d83df92f3afeca8e9fc72c3d33545b" }
-dusk-jubjub = { git = "https://github.com/dusk-network/jubjub-private.git", rev = "6e2b63f59edac8afa4f81a28b12d88529af37cdb" }
-jubjub-elgamal = { git = "https://github.com/dusk-network/jubjub-elgamal-private.git", rev = "1f0d481fb29282c69fdc0063a0404cb89a53bd10" }
-piecrust = { git = "https://github.com/dusk-network/piecrust-private.git", rev = "66ddb31693ffb0fd5a4faac3c80930e6228e0836" }
-piecrust-uplink = { git = "https://github.com/dusk-network/piecrust-private.git", rev = "66ddb31693ffb0fd5a4faac3c80930e6228e0836" }
-phoenix-core = { git = "https://github.com/dusk-network/phoenix-private.git", rev = "3d5b9838d7e824b441c93de9aaa38737263b97bd" }
-phoenix-circuits = { git = "https://github.com/dusk-network/phoenix-private.git", rev = "3d5b9838d7e824b441c93de9aaa38737263b97bd" }
+dusk-plonk = { git = "https://github.com/dusk-network/plonk.git", rev = "55083f925935b67b116c089e186ee1b261e0fdf0" }
+bls12_381-bls = { git = "https://github.com/dusk-network/bls12_381-bls.git", rev = "2bbf457d31d83df92f3afeca8e9fc72c3d33545b" }
+dusk-jubjub = { git = "https://github.com/dusk-network/jubjub.git", rev = "6e2b63f59edac8afa4f81a28b12d88529af37cdb" }
+jubjub-elgamal = { git = "https://github.com/dusk-network/jubjub-elgamal.git", rev = "1f0d481fb29282c69fdc0063a0404cb89a53bd10" }
+piecrust = { git = "https://github.com/dusk-network/piecrust.git", rev = "66ddb31693ffb0fd5a4faac3c80930e6228e0836" }
+piecrust-uplink = { git = "https://github.com/dusk-network/piecrust.git", rev = "66ddb31693ffb0fd5a4faac3c80930e6228e0836" }
+phoenix-core = { git = "https://github.com/dusk-network/phoenix.git", rev = "3d5b9838d7e824b441c93de9aaa38737263b97bd" }
+phoenix-circuits = { git = "https://github.com/dusk-network/phoenix.git", rev = "3d5b9838d7e824b441c93de9aaa38737263b97bd" }


### PR DESCRIPTION
Updating 404 path.crates.io https links

When compiling master.zip or using git clone build will fail with github username/password prompt as the links refer to name-private.git which does not exist.