### PR TITLE
docs(vm): document ephemeral host-query policy (#4064)

### DIFF
--- a/vm/CHANGELOG.md
+++ b/vm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Document that [`VM::ephemeral`](https://docs.rs/dusk-vm/latest/dusk_vm/struct.VM.html#method.ephemeral) leaves host-query policy at the thread-local default (`HardFork::PreFork`) and how downstream contract tests should call [`set_host_query_policy`](https://docs.rs/dusk-vm/latest/dusk_vm/host_queries/fn.set_host_query_policy.html) for post-fork BLS verification (`#4064`).
+
 ## [1.7.0] - 2026-06-10
 
 ### Added

--- a/vm/src/host_queries/cache.rs
+++ b/vm/src/host_queries/cache.rs
@@ -140,6 +140,11 @@ pub fn host_query_policy() -> HostQueryPolicy {
 /// Sets the current thread's host-query policy.
 ///
 /// The previous policy is restored when the returned guard is dropped.
+///
+/// Ephemeral contract tests should call this before executing contracts that
+/// invoke `verify_bls` / `verify_bls_multisig` if signatures were produced with
+/// the post-fork `sign()` / `sign_multisig()` APIs. Without an explicit policy,
+/// verification follows [`HardFork::PreFork`] (pre-fork BLS semantics only).
 pub fn set_host_query_policy(policy: HostQueryPolicy) -> HostQueryPolicyGuard {
     let prev = HOST_QUERY_POLICY.with(|m| {
         let prev = m.get();

--- a/vm/src/host_queries/mod.rs
+++ b/vm/src/host_queries/mod.rs
@@ -4,7 +4,16 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-//! The host-queries registered on the Dusk VM
+//! Host queries registered on the Dusk VM.
+//!
+//! Several queries (`verify_bls`, `verify_bls_multisig`, PLONK verification,
+//! memoization keys) depend on a **thread-local** [`HostQueryPolicy`] (PLONK
+//! version + [`HardFork`]). The default is [`HardFork::PreFork`] with PLONK V2.
+//!
+//! A running Rusk node sets policy before block execution via the same public
+//! [`set_host_query_policy`] API. Contract tests that use [`VM::ephemeral`](crate::VM::ephemeral)
+//! must set policy explicitly when they need post-fork BLS semantics — see
+//! `vm/tests/vm.rs` (`bls_signature`, `bls_multisig_signature`).
 
 use alloc::vec::Vec;
 use std::sync::LazyLock;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -117,6 +117,21 @@ impl VM {
     /// This method initializes a VM that operates in memory without persisting
     /// state. It is useful for testing or temporary computations.
     ///
+    /// **Host-query policy:** this does not change the thread-local
+    /// [`host_queries::HostQueryPolicy`](crate::host_queries::HostQueryPolicy).
+    /// BLS verification inside contract calls therefore defaults to
+    /// [`HardFork::PreFork`](crate::host_queries::HardFork::PreFork) until
+    /// [`set_host_query_policy`](crate::host_queries::set_host_query_policy)
+    /// is called on the same thread. That matches production safety defaults but
+    /// means `sign()`-produced signatures need an explicit policy such as
+    /// [`HardFork::Aegis`](crate::host_queries::HardFork::Aegis) or
+    /// [`HardFork::Boreas`](crate::host_queries::HardFork::Boreas). See
+    /// `vm/tests/vm.rs` (`bls_signature`).
+    ///
+    /// `session` / `genesis_session` `block_height` gates per-query activation
+    /// via [`with_hq_activation`](Self::with_hq_activation); it does **not** derive
+    /// hardfork policy from height.
+    ///
     /// # Returns
     /// A new ephemeral `VM` instance.
     ///
@@ -124,10 +139,20 @@ impl VM {
     /// If creating a temporary directory fails.
     ///
     /// # Examples
-    /// ```rust
-    /// use dusk_vm::VM;
+    /// ```rust,no_run
+    /// use dusk_vm::{
+    ///     host_queries::{
+    ///         HardFork, HostQueryPolicy, plonk_version, set_host_query_policy,
+    ///     },
+    ///     VM,
+    /// };
     ///
-    /// let vm = VM::ephemeral();
+    /// let vm = VM::ephemeral()?;
+    /// let _policy = set_host_query_policy(
+    ///     HostQueryPolicy::from_versions(plonk_version(), HardFork::Aegis),
+    /// );
+    /// let session = vm.genesis_session(0xCA);
+    /// # Ok::<(), dusk_vm::Error>(())
     /// ```
     pub fn ephemeral() -> Result<VM, Error> {
         let mut vm: Self = PiecrustVM::ephemeral()?.into();
@@ -188,7 +213,10 @@ impl VM {
     ///   session begins.
     /// * `chain_id` - The identifier of the network.
     /// * `block_height` - The current block height at which the session is
-    ///   created.
+    ///   created. This height is stored in session metadata and drives
+    ///   [`with_hq_activation`](Self::with_hq_activation) exclusions only; it does
+    ///   not set [`host_queries::HostQueryPolicy`](crate::host_queries::HostQueryPolicy)
+    ///   or BLS hardfork semantics.
     ///
     /// # Returns
     /// A `Result` containing a `Session` instance for executing transactions,


### PR DESCRIPTION
## Summary

#4064 reported that hardfork host-query policy is unreachable from `VM::ephemeral()` contract tests. On review, the policy API is already public: `set_host_query_policy` / `HostQueryPolicy` / `HardFork` on `dusk_vm::host_queries` in 1.7+ (re-exported from the internal `cache` module), and `set_hard_fork` / `HardFork` on 1.6. The issue reproduction used 1.7 symbol names against 1.6 tags, which explains the compile errors — not a private-module bug.

What remains is documentation: `VM::ephemeral()` does not change thread-local host-query policy. The default stays `HardFork::PreFork`, so `verify_bls` / `verify_bls_multisig` follow pre-fork BLS semantics until the test thread calls `set_host_query_policy` explicitly. `session` / `genesis_session` `block_height` gates per-query activation via `with_hq_activation` only; it does not derive hardfork policy from height.

This PR documents that for ephemeral contract testers and points to the existing `vm/tests/vm.rs` pattern (`bls_signature`, `bls_multisig_signature`). No runtime behavior change.

Closes #4064

## Test plan

| Check | What it verifies |
|-------|------------------|
| `cargo check -p dusk-vm` | Doc comment edits compile |
| `vm/tests/vm.rs` (`bls_signature`, `bls_multisig_signature`) | In-tree examples cited in docs already use `set_host_query_policy` + `VM::ephemeral` |

**Run:**

```bash
cargo check -p dusk-vm
```