### PR TITLE
fix(vm): store genesis BLOCK_HEIGHT metadata as u64

### DIFF
--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -268,7 +268,7 @@ impl VM {
                 SessionData::builder()
                     .insert(Metadata::CHAIN_ID, chain_id)
                     .expect("Inserting chain ID in metadata should succeed")
-                    .insert(Metadata::BLOCK_HEIGHT, 0)
+                    .insert(Metadata::BLOCK_HEIGHT, 0u64)
                     .expect(
                         "Inserting block height in metadata should succeed",
                     ),


### PR DESCRIPTION
## Summary

`genesis_session` inserted `BLOCK_HEIGHT` with literal `0` (rkyv `i32`). Contracts read `block_height()` as `u64`. On genesis sessions with contract WASM built under workspace `overflow-checks`, `archived_root::<u64>` panics on a 4-byte metadata buffer.

## Fix

`.insert(Metadata::BLOCK_HEIGHT, 0u64)` in `VM::genesis_session`.

`VM::session(..., block_height: u64)` already used the correct type.

## Test plan

- [x] `cargo test -p dusk-vm` (lib)
- [ ] CI

Fixes #4066
