### PR TITLE
rusk: label legacy GraphQL schema responses

### DIFF
--- a/rusk/CHANGELOG.md
+++ b/rusk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Return schema SDL from the legacy `/on/graphql/query` endpoint with a
+  `text/plain; charset=utf-8` media type and document both successful response
+  formats in the generated OpenAPI contract.
+
 ## [1.7.0] - 2026-06-10
 
 ### Added

--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -1934,15 +1934,26 @@ mod tests {
             .await;
 
         let client = reqwest::Client::new();
-        let response = client
-            .post(format!("http://{local_addr}/on/graphql/query"))
-            .send()
-            .await
-            .expect("Requesting should succeed");
+        for request_body in ["", " \n"] {
+            let response = client
+                .post(format!("http://{local_addr}/on/graphql/query"))
+                .body(request_body)
+                .send()
+                .await
+                .expect("Requesting should succeed");
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response.text().await.expect("Response should have body");
-        assert_eq!(body, "schema");
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(
+                response
+                    .headers()
+                    .get(CONTENT_TYPE)
+                    .and_then(|value| value.to_str().ok()),
+                Some("text/plain; charset=utf-8")
+            );
+            let body =
+                response.text().await.expect("Response should have body");
+            assert_eq!(body, "schema");
+        }
     }
 
     #[tokio::test]

--- a/rusk/src/lib/http.rs
+++ b/rusk/src/lib/http.rs
@@ -1934,13 +1934,19 @@ mod tests {
             .await;
 
         let client = reqwest::Client::new();
-        for request_body in ["", " \n"] {
-            let response = client
+        for (request_body, content_type) in [
+            (Vec::new(), None),
+            (b" \n".to_vec(), None),
+            (vec![0xff], Some("application/octet-stream")),
+        ] {
+            let mut request = client
                 .post(format!("http://{local_addr}/on/graphql/query"))
-                .body(request_body)
-                .send()
-                .await
-                .expect("Requesting should succeed");
+                .body(request_body);
+            if let Some(content_type) = content_type {
+                request = request.header(CONTENT_TYPE, content_type);
+            }
+            let response =
+                request.send().await.expect("Requesting should succeed");
 
             assert_eq!(response.status(), StatusCode::OK);
             assert_eq!(

--- a/rusk/src/lib/http/openapi.rs
+++ b/rusk/src/lib/http/openapi.rs
@@ -411,6 +411,16 @@ mod tests {
             graphql_legacy_request_types.contains("text/plain"),
             "The legacy GraphQL route should document raw text requests"
         );
+        let graphql_legacy_response_types =
+            response_content_types(graphql_legacy, "200");
+        assert!(
+            graphql_legacy_response_types.contains("application/json"),
+            "Legacy GraphQL query responses should be documented as JSON"
+        );
+        assert!(
+            graphql_legacy_response_types.contains("text/plain"),
+            "Legacy GraphQL schema responses should be documented as text"
+        );
 
         let contracts_post =
             operation(&spec, "/on/contracts:{entity}/{topic}", "post");

--- a/rusk/src/lib/http/routes/on/graphql.rs
+++ b/rusk/src/lib/http/routes/on/graphql.rs
@@ -37,8 +37,8 @@ pub(crate) fn legacy_graphql_routes(
             status = 200,
             description = "Legacy GraphQL response body or schema SDL",
             content(
-                ("application/json" = crate::http::openapi::GraphqlHttpResponse),
-                ("text/plain" = String)
+                (crate::http::openapi::GraphqlHttpResponse = "application/json"),
+                (String = "text/plain")
             )
         ),
         (status = 400, description = "Invalid legacy GraphQL request or version headers", body = crate::http::openapi::RuesErrorResponse),
@@ -54,7 +54,9 @@ async fn legacy_rues_graphql_post_route(
     body: Bytes,
 ) -> Result<Response<Body>, ApiError> {
     let returns_schema = std::str::from_utf8(&body)
-        .is_ok_and(|request_body| request_body.trim().is_empty());
+        .unwrap_or_default()
+        .trim()
+        .is_empty();
     let request =
         rues::ParsedRuesRequest::component("graphql", "query", headers, body)?;
     let result = match state.services.chain_handler() {

--- a/rusk/src/lib/http/routes/on/graphql.rs
+++ b/rusk/src/lib/http/routes/on/graphql.rs
@@ -36,8 +36,10 @@ pub(crate) fn legacy_graphql_routes(
         (
             status = 200,
             description = "Legacy GraphQL response body or schema SDL",
-            body = crate::http::openapi::GraphqlHttpResponse,
-            content_type = "application/json"
+            content(
+                ("application/json" = crate::http::openapi::GraphqlHttpResponse),
+                ("text/plain" = String)
+            )
         ),
         (status = 400, description = "Invalid legacy GraphQL request or version headers", body = crate::http::openapi::RuesErrorResponse),
         (status = 413, description = "Request body exceeds the default RUES size limit"),
@@ -51,11 +53,20 @@ async fn legacy_rues_graphql_post_route(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response<Body>, ApiError> {
+    let returns_schema = std::str::from_utf8(&body)
+        .is_ok_and(|request_body| request_body.trim().is_empty());
     let request =
         rues::ParsedRuesRequest::component("graphql", "query", headers, body)?;
     let result = match state.services.chain_handler() {
         Some(chain) => chain.graphql_query(request.event()).await,
         None => Err(HttpError::Unsupported),
     };
+    let result = result.map(|response| {
+        if returns_schema {
+            response.with_header("content-type", "text/plain; charset=utf-8")
+        } else {
+            response
+        }
+    });
     request.into_response(result)
 }


### PR DESCRIPTION
## Summary

Addresses audit finding **AR-18**.

The legacy `POST /on/graphql/query` endpoint returns the GraphQL schema SDL when the effective request body is empty. This PR:

- labels empty, whitespace-only, and empty-equivalent binary schema responses as `text/plain; charset=utf-8`
- retains `application/json` for normal GraphQL query responses
- documents both successful response media types with valid Utoipa syntax
- adds regression assertions for response headers, whitespace bodies, and invalid UTF-8 binary input
- records the fix in the changelog

## Root cause and impact

The schema body was returned successfully but without a declared media type, forcing clients and retrieval agents to infer how to parse it. The response branch now advertises its actual representation.

The media-type decision is aligned with the existing request handler: invalid UTF-8 is accepted only for binary requests, where the legacy handler treats it as an empty query and returns the schema.

## Validation

- `cargo fmt --all -- --check`: passed
- targeted regression compilation attempted: `cargo test -p dusk-rusk legacy_graphql_empty_body_returns_schema --no-run`
- the corrected Utoipa response syntax matches existing repository patterns
- local Windows compilation remains blocked before the changed tests can link by two environment/upstream issues:
  - pinned `piecrust 0.31.0` imports unavailable `crumbles::LocateFile` and `crumbles::Mmap` symbols on Windows
  - `utoipa-swagger-ui` cannot download its build asset through this Windows credential context

This PR therefore remains **CI-dependent** and should not merge until the repository's standard CI compiles and runs the new tests.

## Security and remaining risk

The change does not alter routing, permissions, request-size limits, query execution, storage, or secrets. Invalid non-binary UTF-8 requests remain rejected by the existing parser; the new regression case explicitly uses `application/octet-stream`.

## Deployment and rollback

No storage or API-route migration is required. JSON query behavior is unchanged. Roll back by reverting this PR.

## Post-deployment check

Send an empty POST to `/on/graphql/query` and confirm status 200, schema SDL body, and `Content-Type: text/plain; charset=utf-8`; then send a normal GraphQL query and confirm JSON behavior remains unchanged.